### PR TITLE
fix bugs on drop and delete commands

### DIFF
--- a/LiteDB/Storage/Services/IndexService.cs
+++ b/LiteDB/Storage/Services/IndexService.cs
@@ -235,7 +235,7 @@ namespace LiteDB
         {
             if (address.IsEmpty) return null;
             var page = _pager.GetPage<IndexPage>(address.PageID);
-            return page.Nodes[address.Index];
+            return page.Nodes.GetOrDefault(address.Index, null);// page.Nodes[address.Index];
         }
 
         /// <summary>
@@ -263,7 +263,7 @@ namespace LiteDB
                 cur = this.GetNode(cur.NextPrev(0, order));
 
                 // stop if node is head/tail
-                if (cur.IsHeadTail(index)) yield break;
+                if (cur == null || cur.IsHeadTail(index)) yield break;
 
                 yield return cur;
             }


### PR DESCRIPTION
Hi guys,

I found some issues when I needed delete some data from the database.
When I use the command delete, the result is the error "The given key was not present in the dictionary".
I also tried use the command drop, but resulted in the same error.

See the printscreen:

![2015-10-07 12_35_43-litedb running - microsoft visual studio](https://cloud.githubusercontent.com/assets/4245961/10342771/1122ffbe-6cf1-11e5-88c9-24ab57654c6f.png)

I forked the repository and fix the issues by adding some validation check in the IndexServices.

I corrected them and now I can execute the delete and drop commands well, and the find command too.

See the printscreen:

![2015-10-07 12_38_14-litedb running - microsoft visual studio](https://cloud.githubusercontent.com/assets/4245961/10342758/015df39a-6cf1-11e5-8076-00bef65e097e.png)
