### PR TITLE
Check value before executing Contains - fixes #75

### DIFF
--- a/LiteDB/Query/Impl/QueryContains.cs
+++ b/LiteDB/Query/Impl/QueryContains.cs
@@ -23,7 +23,9 @@ namespace LiteDB
         {
             var v = _value.Normalize(index.Options);
 
-            return indexer.FindAll(index, Query.Ascending).Where(x => x.Key.AsString.Contains(v));
+            return indexer
+                .FindAll(index, Query.Ascending)
+                .Where(x => x.Key.IsString && x.Key.AsString.Contains(v));
         }
     }
 }


### PR DESCRIPTION
To prevent #75, we need to check if the value is actually a string, otherwise we might get a `NullReferenceException`.