### PR TITLE
Added ability to use GetCollection<T>() without collection name. this…

### DIFF
--- a/LiteDB.Tests/ImplicitCollectionName/BasicTestsOnImplicitCollectionNames.cs
+++ b/LiteDB.Tests/ImplicitCollectionName/BasicTestsOnImplicitCollectionNames.cs
@@ -1,0 +1,62 @@
+﻿using System.IO;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LiteDB.Tests.ImplicitCollectionName
+{
+    [TestClass]
+    public class BasicTestsOnImplicitCollectionNames
+    {
+        public class BasicObject
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        [TestMethod]
+        public void WillAssignCollectionNameIfNotSpecified()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var db = new LiteDatabase(stream))
+                {
+                    var objects = db.GetCollection<BasicObject>();
+                    objects.Insert(new BasicObject());
+                }
+
+                using (var db = new LiteDatabase(stream))
+                {
+                    var actualCollectionNames = db.GetCollectionNames();
+                    var expectedCollectionNames = new[] {"BasicObjectCollection"};
+
+                    actualCollectionNames.ShouldAllBeEquivalentTo(expectedCollectionNames);
+                }
+            }
+            
+        }
+
+        [TestMethod]
+        public void WillGetTheCorrectObjectFromImplicitlyNamedCollection()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var db = new LiteDatabase(stream))
+                {
+                    var objects = db.GetCollection<BasicObject>();
+                    objects.Insert(new BasicObject {Name="BasicObject"});
+                }
+
+                using (var db = new LiteDatabase(stream))
+                {
+                    var expectedObjects = new[] {new BasicObject {Id=1, Name = "BasicObject"}};
+                    var actualObjects = db.GetCollection<BasicObject>().FindAll();
+
+                    actualObjects.ShouldAllBeEquivalentTo(expectedObjects);
+                }
+            }
+
+        }
+
+    }
+
+}

--- a/LiteDB.Tests/LiteDB.Tests.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.csproj
@@ -39,6 +39,14 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FluentAssertions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.1.0\lib\net40\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.1.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.1.0\lib\net40\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.XML" />
@@ -60,6 +68,7 @@
     <Compile Include="Crud\BulkTest.cs" />
     <Compile Include="Bson\BsonTest.cs" />
     <Compile Include="Crud\DbVersionTest.cs" />
+    <Compile Include="ImplicitCollectionName\BasicTestsOnImplicitCollectionNames.cs" />
     <Compile Include="Mapping\AutoIdTest.cs" />
     <Compile Include="Crud\DropCollectionTest.cs" />
     <Compile Include="Crud\FileStorageTest.cs" />
@@ -83,6 +92,9 @@
       <Project>{e808051a-83b7-4fa9-b004-d064ea162b60}</Project>
       <Name>LiteDB</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/LiteDB.Tests/packages.config
+++ b/LiteDB.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FluentAssertions" version="4.1.0" targetFramework="net4" />
+</packages>

--- a/LiteDB/Core/Database/Collection.cs
+++ b/LiteDB/Core/Database/Collection.cs
@@ -20,6 +20,16 @@ namespace LiteDB
 
             return new LiteCollection<T>(name, _engine.Value, _mapper, _log);
         }
+        /// <summary>
+        /// Get a collection with automatic name as e.g for 'Customer' the collection name is set to 'CustomerCollection'
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public LiteCollection<T> GetCollection<T>() where T : new()
+        {
+            var collectionName = typeof (T).Name + "Collection";
+            return GetCollection<T>(collectionName);
+        }
 
         /// <summary>
         /// Get a collection using a generic BsonDocument. If collection does not exits, create a new one.


### PR DESCRIPTION
… assigns collection name automatically. for.e.g for object 'Customer' it will assign collection name to 'CustomerCollection'

Also i have used 'FluentAssertions' library to assert the results easily.