### PR TITLE
Added support for deserialization of types derived from IEnumerable<>

### DIFF
--- a/LiteDB.Tests/Mapping/MapperTest.cs
+++ b/LiteDB.Tests/Mapping/MapperTest.cs
@@ -1,11 +1,42 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 
 namespace LiteDB.Tests
 {
+    public class CustomStringEnumerable : IEnumerable<string>
+    {
+        private readonly List<string> innerList;
+
+        public CustomStringEnumerable()
+        {
+            innerList = new List<string>();
+        }
+
+        public CustomStringEnumerable(IEnumerable<string> list)
+        {
+            innerList = new List<string>(list);
+        }
+
+        public void Add(string item)
+        {
+            innerList.Add(item);
+        }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            return innerList.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+
     public enum MyEnum { First, Second }
 
     public class MyClass
@@ -53,6 +84,7 @@ namespace LiteDB.Tests
 
         public List<string> MyStringList { get; set; }
         public IEnumerable<string> MyStringEnumerable { get; set; }
+        public CustomStringEnumerable CustomStringEnumerable { get; set; }
         public Dictionary<int, string> MyDict { get; set; }
 
         // interfaces
@@ -108,6 +140,7 @@ namespace LiteDB.Tests
                 MyDict = new Dictionary<int, string>() { { 1, "Row1" }, { 2, "Row2" } },
                 MyStringArray = new string[] { "One", "Two" },
                 MyStringEnumerable = new string[] { "One", "Two" },
+                CustomStringEnumerable = new CustomStringEnumerable(new string[] { "One", "Two" }),
                 MyEnumProp = MyEnum.Second,
                 MyChar = 'Y',
                 MyUri = new Uri("http://www.numeria.com.br"),
@@ -170,6 +203,7 @@ namespace LiteDB.Tests
             Assert.AreEqual(obj.MyStringArray[1], nobj.MyStringArray[1]);
             Assert.AreEqual(obj.MyStringEnumerable.First(), nobj.MyStringEnumerable.First());
             Assert.AreEqual(obj.MyStringEnumerable.Take(1).First(), nobj.MyStringEnumerable.Take(1).First());
+            Assert.AreEqual(true, obj.CustomStringEnumerable.SequenceEqual(nobj.CustomStringEnumerable));
             Assert.AreEqual(obj.MyDict[2], nobj.MyDict[2]);
 
             // interfaces

--- a/LiteDB/Core/Database/Utils.cs
+++ b/LiteDB/Core/Database/Utils.cs
@@ -22,6 +22,14 @@ namespace LiteDB
         }
 
         /// <summary>
+        /// Convert a BsonDocument to a class object using BsonMapper rules
+        /// </summary>
+        public object ToObject(Type type, BsonDocument doc)
+        {
+            return _mapper.ToObject(type, doc);
+        }
+
+        /// <summary>
         /// Convert an entity class instance into a BsonDocument using BsonMapper rules
         /// </summary>
         public BsonDocument ToDocument(object entity)

--- a/LiteDB/Serializer/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Serializer/Mapper/BsonMapper.Deserialize.cs
@@ -14,14 +14,20 @@ namespace LiteDB
         public T ToObject<T>(BsonDocument doc)
             where T : new()
         {
+            return (T)ToObject(typeof(T), doc);
+        }
+
+        /// <summary>
+        /// Deserialize a BsonDocument to entity class
+        /// </summary>
+        public object ToObject(Type type, BsonDocument doc)
+        {
             if (doc == null) throw new ArgumentNullException("doc");
 
-            var type = typeof(T);
-
             // if T is BsonDocument, just return them
-            if (type == typeof(BsonDocument)) return (T)(object)doc;
+            if (type == typeof(BsonDocument)) return doc;
 
-            return (T)this.Deserialize(type, doc);
+            return Deserialize(type, doc);
         }
 
         /// <summary>

--- a/LiteDB/Serializer/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Serializer/Mapper/BsonMapper.Deserialize.cs
@@ -180,7 +180,7 @@ namespace LiteDB
 
         private object DeserializeList(Type type, BsonArray value)
         {
-            var itemType = Reflection.UnderlyingTypeOf(type);
+            var itemType = type.GetGenericArguments().FirstOrDefault() ?? type.GetInterfaces().First(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>)).GetGenericArguments().First();
             var enumerable = (IEnumerable)Reflection.CreateInstance(type);
             var list = enumerable as IList;
 


### PR DESCRIPTION
Fixed issue when type derived from IEnumerable<>, ICollection<>, or IList<>, etc.. is used deserialization fails.

For details please see issue #92