### PR TITLE
Optimize locking

### DIFF
--- a/LiteDB/Core/Database/OnModelCreating.cs
+++ b/LiteDB/Core/Database/OnModelCreating.cs
@@ -12,13 +12,19 @@ namespace LiteDB
 
         private void InitializeMapper()
         {
-            lock (_mapperCache)
+            var type = this.GetType();
+
+            if (!_mapperCache.TryGetValue(type, out _mapper))
             {
-                if (!_mapperCache.TryGetValue(this.GetType(), out _mapper))
+                lock (_mapperCache)
                 {
-                    _mapper = new BsonMapper();
-                    _mapperCache.Add(this.GetType(), _mapper);
-                    this.OnModelCreating(_mapper);
+                    if (!_mapperCache.TryGetValue(type, out _mapper))
+                    {
+                        _mapper = new BsonMapper();
+                        this.OnModelCreating(_mapper);
+
+                        _mapperCache.Add(type, _mapper);
+                    }
                 }
             }
         }

--- a/LiteDB/Serializer/Mapper/BsonMapper.cs
+++ b/LiteDB/Serializer/Mapper/BsonMapper.cs
@@ -140,17 +140,18 @@ namespace LiteDB
         {
             Dictionary<string, PropertyMapper> props;
 
-            lock (_mapper)
+            if (!_mapper.TryGetValue(type, out props))
             {
-                if (_mapper.TryGetValue(type, out props))
+                lock (_mapper)
                 {
-                    return props;
+                    if (!_mapper.TryGetValue(type, out props))
+                    {
+                        return _mapper[type] = Reflection.GetProperties(type, this.ResolvePropertyName);
+                    }
                 }
-
-                _mapper[type] = Reflection.GetProperties(type, this.ResolvePropertyName);
-
-                return _mapper[type];
             }
+
+            return props;
         }
 
         /// <summary>

--- a/LiteDB/Serializer/Mapper/Reflection.cs
+++ b/LiteDB/Serializer/Mapper/Reflection.cs
@@ -135,6 +135,19 @@ namespace LiteDB
         /// </summary>
         public static object CreateInstance(Type type)
         {
+            try
+            {
+                CreateObject c;
+                if (_cacheCtor.TryGetValue(type, out c))
+                {
+                    return c();
+                }
+            }
+            catch
+            {
+                throw LiteException.InvalidCtor(type);
+            }
+
             lock(_cacheCtor)
             {
                 try


### PR DESCRIPTION
Using of double checked locking instead of simple lock for the `BsonMapper` cache,  `PropertyMapper` cache and reflection constructor's cache.