### PR TITLE
Use UtcNow in the FileDiskService.TryExec

### DIFF
--- a/LiteDB/DbEngine/Disks/FileDiskService.cs
+++ b/LiteDB/DbEngine/Disks/FileDiskService.cs
@@ -348,9 +348,9 @@ namespace LiteDB
         /// </summary>
         private void TryExec(Action action)
         {
-            var timer = DateTime.Now.Add(_timeout);
+            var timer = DateTime.UtcNow.Add(_timeout);
 
-            while (DateTime.Now < timer)
+            while (DateTime.UtcNow < timer)
             {
                 try
                 {


### PR DESCRIPTION
Use `DateTime.UtcNow` for timeout checking, because `DateTime.UtcNow` is much more faster than `DateTime.Now`


#### Performance comparison (on my system)
`DateTime.Now`: 1071 ms
```C#
for (int i = 0; i < 1000000; i++)
{
  var timer = DateTime.Now.Add(TimeSpan.FromMinutes(1));
  var tmp = DateTime.Now < timer;
}
```
`DateTime.Now`: 37 ms
```C#
for (int i = 0; i < 1000000; i++)
{
  var timer = DateTime.UtcNow.Add(TimeSpan.FromMinutes(1));
  var tmp = DateTime.UtcNow < timer;
}
```
`DateTime.Now`: 526ms
```C#
var timer = DateTime.Now.Add(TimeSpan.FromMinutes(1));
for (int i = 0; i < 1000000; i++)
{
  var tmp = DateTime.Now < timer;
}
```

`DateTime.UtcNow`: 10ms
```C#
var timer = DateTime.UtcNow.Add(TimeSpan.FromMinutes(1));
for (int i = 0; i < 1000000; i++)
{
  var tmp = DateTime.UtcNow < timer;
}
```
Related [blog post](http://blogs.msdn.com/b/kirillosenkov/archive/2012/01/10/datetime-utcnow-is-generally-preferable-to-datetime-now.aspx)