### PR TITLE
Fixed mscorlib exception which arises from journalling not being enabled

### DIFF
--- a/LiteDB/DbEngine/Disks/FileDiskService.cs
+++ b/LiteDB/DbEngine/Disks/FileDiskService.cs
@@ -268,6 +268,7 @@ namespace LiteDB
 
         private void TryRecovery()
         {
+            if (!_journalEnabled)return;
             // if I can open journal file, test FINISH_POSITION. If no journal, do not call action()
             this.OpenExclusiveFile(_journalFilename, (journal) =>
             {


### PR DESCRIPTION
I was a bit frustrated by the constant mscorlib exceptions arising from FileDiskServer::TryRecovery, so I added an if statement to check if the journal function is enabled.

I don't know if you want this fixed, but I find the lack of exceptions from it pleasing.