### PR TITLE
fix for DeserializeList

### DIFF
--- a/LiteDB.Tests/Mapping/MapperTest.cs
+++ b/LiteDB.Tests/Mapping/MapperTest.cs
@@ -99,6 +99,8 @@ namespace LiteDB.Tests
         public object MyObjectInt { get; set; }
         public object MyObjectImpl { get; set; }
         public List<object> MyObjectList { get; set; }
+        public object MyObjectIsList { get; set; }
+        public object MyObjectIsArray { get; set; }
     }
 
     public interface IMyInterface
@@ -155,7 +157,10 @@ namespace LiteDB.Tests
                 MyObjectString = "MyString",
                 MyObjectInt = 123,
                 MyObjectImpl = new MyImpl { Name = "John" },
-                MyObjectList = new List<object>() { 1, "ola", new MyImpl { Name = "John" }, new Uri("http://www.cnn.com") }
+                MyObjectList = new List<object>() { 1, "ola", new MyImpl { Name = "John" }, new Uri("http://www.cnn.com") },
+
+                MyObjectIsList = new List<string> { "One","Two"},
+                MyObjectIsArray = new []{ "One","Two"}
             };
 
             c.MyNameValueCollection["key-1"] = "value-1";
@@ -205,6 +210,9 @@ namespace LiteDB.Tests
             Assert.AreEqual(obj.MyStringEnumerable.Take(1).First(), nobj.MyStringEnumerable.Take(1).First());
             Assert.AreEqual(true, obj.CustomStringEnumerable.SequenceEqual(nobj.CustomStringEnumerable));
             Assert.AreEqual(obj.MyDict[2], nobj.MyDict[2]);
+
+            CollectionAssert.AreEquivalent((ICollection) obj.MyObjectIsList, (ICollection) nobj.MyObjectIsList);
+            CollectionAssert.AreEquivalent((ICollection) obj.MyObjectIsArray, (ICollection) nobj.MyObjectIsArray);
 
             // interfaces
             Assert.AreEqual(obj.MyInterface.Name, nobj.MyInterface.Name);


### PR DESCRIPTION
Happens when Enumerable was provided as an Object property during serialization. On DeserializeList it cannot find any Generic types or Interfaces as `type` is `System.Object`. Also, `type.IsArray` of Object is false even if underlying type is actually an array, which leads to a different can of warms. See the tests and comments.

I updated tests as well, but because it is not possible to detect what was the original underlying type it is hard to Assert expected and actual types. Therefore, `(ICollection)` cast.

Could be a wrong using of the LiteDB altogether. Stumbled upon this one when tried to serialize-deserialize `Dictionary<string,object>` where one of objects was `string[]`.