### PR TITLE
[1.0.4] Fix invalid start position in RecoveryService

### DIFF
--- a/LiteDB/Storage/Services/RecoveryService.cs
+++ b/LiteDB/Storage/Services/RecoveryService.cs
@@ -71,7 +71,7 @@ namespace LiteDB
         private BasePage ReadPageJournal(BinaryReader reader)
         {
             var stream = reader.BaseStream;
-            var posStart = stream.Position * BasePage.PAGE_SIZE;
+            var posStart = stream.Position;
             var posEnd = posStart + BasePage.PAGE_SIZE;
 
             // Create page instance and read from disk (read page header + content page)


### PR DESCRIPTION
Start position was multiplied by page size even though it already scaled. This caused the target page position to be calculated wrongly, leading to a) database corruption or b) an exception due to int overflow.

Note that this change refers to the version tagged 1.0.4, *not* the current master. A quick glance at the current version suggested that this file was completely rewritten, so I'm unsure if it can still be applied. (Sadly, github did not let me create a pull request against the tag, only against a current branch.)

fix mbdavid/litedb/#193