### PR TITLE
Various small fixes after merge

### DIFF
--- a/LiteDB.NetCore.Tests/LiteDB.NetCore.Tests.csproj
+++ b/LiteDB.NetCore.Tests/LiteDB.NetCore.Tests.csproj
@@ -68,12 +68,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\LiteDB.NetCore\LiteDB.NetCore.csproj">
-      <Project>{28c0558c-13b2-4f3d-b956-5d6081625f61}</Project>
-      <Name>LiteDB.NetCore</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
@@ -134,12 +128,21 @@
     <Compile Include="..\LiteDB.Tests\ShellTest.cs">
       <Link>ShellTest.cs</Link>
     </Compile>
+    <Compile Include="..\LiteDB.Tests\StreamDb_Test.cs">
+      <Link>StreamDb_Test.cs</Link>
+    </Compile>
     <Compile Include="..\LiteDB.Tests\Utils\DB.cs">
       <Link>Utils\DB.cs</Link>
     </Compile>
     <Compile Include="..\LiteDB.Tests\Utils\Initialize.cs">
       <Link>Utils\Initialize.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB.NetCore\LiteDB.NetCore.csproj">
+      <Project>{28c0558c-13b2-4f3d-b956-5d6081625f61}</Project>
+      <Name>LiteDB.NetCore</Name>
+    </ProjectReference>
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/LiteDB.NetCore/LiteDB.NetCore.csproj
+++ b/LiteDB.NetCore/LiteDB.NetCore.csproj
@@ -445,6 +445,9 @@
     <Compile Include="..\LiteDB\Utils\StringScanner.cs">
       <Link>Utils\StringScanner.cs</Link>
     </Compile>
+    <Compile Include="..\LiteDB\Utils\TransactionCancelledException.cs">
+      <Link>Utils\TransactionCancelledException.cs</Link>
+    </Compile>
     <Compile Include="..\LiteDB\Utils\TypeExtensions.cs">
       <Link>Utils\TypeExtensions.cs</Link>
     </Compile>

--- a/LiteDB.PCL.Tests/LiteDB.PCL.Tests.csproj
+++ b/LiteDB.PCL.Tests/LiteDB.PCL.Tests.csproj
@@ -126,6 +126,9 @@
     <Compile Include="..\LiteDB.Tests\ShellTest.cs">
       <Link>ShellTest.cs</Link>
     </Compile>
+    <Compile Include="..\LiteDB.Tests\StreamDb_Test.cs">
+      <Link>StreamDb_Test.cs</Link>
+    </Compile>
     <Compile Include="..\LiteDB.Tests\Utils\DB.cs">
       <Link>Utils\DB.cs</Link>
     </Compile>

--- a/LiteDB.PCL/LiteDB.PCL.csproj
+++ b/LiteDB.PCL/LiteDB.PCL.csproj
@@ -449,6 +449,9 @@
     <Compile Include="..\LiteDB\Utils\StringScanner.cs">
       <Link>Utils\StringScanner.cs</Link>
     </Compile>
+    <Compile Include="..\LiteDB\Utils\TransactionCancelledException.cs">
+      <Link>Utils\TransactionCancelledException.cs</Link>
+    </Compile>
     <Compile Include="..\LiteDB\Utils\TypeExtensions.cs">
       <Link>Utils\TypeExtensions.cs</Link>
     </Compile>

--- a/LiteDB.Portable.sln
+++ b/LiteDB.Portable.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB", "LiteDB\LiteDB.csproj", "{E808051A-83B7-4FA9-B004-D064EA162B60}"
 EndProject

--- a/LiteDB.Tests/LiteDB.Tests.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="LinqTest.cs" />
     <Compile Include="IncludeTest.cs" />
     <Compile Include="ShellTest.cs" />
+    <Compile Include="StreamDb_Test.cs" />
     <Compile Include="Utils\Initialize.cs" />
     <Compile Include="Utils\DB.cs" />
     <Compile Include="IndexOrderTest.cs" />

--- a/LiteDB.Tests/LoopTest.cs
+++ b/LiteDB.Tests/LoopTest.cs
@@ -1,5 +1,4 @@
-﻿#if !PCL
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -13,9 +12,17 @@ namespace LiteDB.Tests
         [TestMethod]
         public void Loop_Test()
         {
+#if NETFULL
             var f = DB.RandomFile();
+#else
+            var ms = new MemoryStream();
+#endif
 
+#if NETFULL
             using (var db = new LiteDatabase(f))
+#else
+            using (var db = new LiteDatabase(ms))
+#endif
             {
                 var col = db.GetCollection("b");
 
@@ -25,7 +32,11 @@ namespace LiteDB.Tests
                 col.Insert(new BsonDocument().Add("Number", 4));
             }
 
+#if NETFULL
             using (var db = new LiteDatabase(f))
+#else
+            using (var db = new LiteDatabase(ms))
+#endif
             {
                 var col = db.GetCollection("b");
 
@@ -43,4 +54,3 @@ namespace LiteDB.Tests
         }
     }
 }
-#endif

--- a/LiteDB.Tests/ShellTest.cs
+++ b/LiteDB.Tests/ShellTest.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿#if NETFULL
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 
 namespace LiteDB.Tests
@@ -32,3 +33,4 @@ namespace LiteDB.Tests
         }
     }
 }
+#endif

--- a/LiteDB.Tests/StreamDb_Test.cs
+++ b/LiteDB.Tests/StreamDb_Test.cs
@@ -1,0 +1,109 @@
+﻿using LiteDB.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace LiteDB.Tests
+{
+    public class StreamTestsClass
+    {
+        public int Id { get; set; }
+        public String Value { get; set; }
+    }
+
+    [TestClass]
+    public class StreamDb_Test
+    {
+        [TestMethod]
+        public void FindBeforeInsertClosesTransaction()
+        {
+            MemoryStream ms = new MemoryStream();
+
+            using (var db = new LiteDatabase(ms))
+            {
+                var coll = db.GetCollection<StreamTestsClass>("StreamTestsClass");
+                // Do a find on a non-existant record
+                var val = coll.FindById(new BsonValue(1));
+
+                Assert.IsNull(val, "Empty database should not have record");
+                val = new StreamTestsClass() { Id = 1, Value = "Hello" };
+                coll.Insert(val);
+            }
+
+            using (var db = new LiteDatabase(ms))
+            {
+                var coll = db.GetCollection<StreamTestsClass>("StreamTestsClass");
+                var val = coll.FindById(new BsonValue(1));
+
+                Assert.IsNotNull(val, "Database should contain value from previous session");
+            }
+        }
+
+        [TestMethod]
+        public void FindOneClosesTransaction()
+        {
+            MemoryStream ms = new MemoryStream();
+
+            using (var db = new LiteDatabase(ms))
+            {
+                var coll = db.GetCollection<StreamTestsClass>("StreamTestsClass");
+                coll.Insert(new StreamTestsClass() { Id = 1, Value = "Record 1" });
+                coll.Insert(new StreamTestsClass() { Id = 2, Value = "Record 1" });
+                coll.Insert(new StreamTestsClass() { Id = 3, Value = "Record 1" });
+
+                System.Diagnostics.Debug.WriteLine("Size:" + ms.Length);
+
+                //                coll.FindOne(Query.)
+                var rec = coll.FindOne(Query.EQ("Value", "Record 1"));
+
+                coll.Insert(new StreamTestsClass() { Id = 4, Value = "Record 1" });
+
+                System.Diagnostics.Debug.WriteLine("Size:" + ms.Length);
+            }
+
+            using (var db = new LiteDatabase(ms))
+            {
+                var coll = db.GetCollection<StreamTestsClass>("StreamTestsClass");
+                var val = coll.FindAll();
+
+                Assert.AreEqual(4, val.Count());
+            }
+        }
+
+        [ExpectedException(typeof(TransactionCancelledException))]
+        [TestMethod]
+        public void TransactionAbortCancelsOtherTransactions()
+        {
+            MemoryStream ms = new MemoryStream();
+
+            using (var db = new LiteDatabase(ms))
+            {
+                var trans1 = db.BeginTrans();
+                var trans2 = db.BeginTrans();
+
+                trans1.Abort();
+                trans2.Complete();
+            }
+        }
+
+        [TestMethod]
+        public void CreateIndexOnBsonDocument()
+        {
+            MemoryStream ms = new MemoryStream();
+
+            using (var db = new LiteDatabase(ms))
+            {
+                var tc = new StreamTestsClass() { Id = 1, Value = "2" };
+                var typedColl = db.GetCollection<StreamTestsClass>("StreamTestsClass");
+                typedColl.Insert(tc);
+
+                var coll = db.GetCollection("StreamTestsClass");
+                var seasonCollResult = coll.FindOne(Query.EQ("Id", new BsonValue(1)));
+            }
+        }
+    }
+}
+

--- a/LiteDB/Core/Collections/Find.cs
+++ b/LiteDB/Core/Collections/Find.cs
@@ -16,49 +16,58 @@ namespace LiteDB
         {
             if (query == null) throw new ArgumentNullException("query");
 
-            IEnumerator<BsonDocument> enumerator;
+            IEnumerator<BsonDocument> enumerator = null;
             var more = true;
 
-            // keep trying execute query to auto-create indexes when not found
-            // must try get first doc inside try/catch to get index not found (yield returns are not supported inside try/catch)
-            while (true)
+            try
             {
-                try
+                // keep trying execute query to auto-create indexes when not found
+                // must try get first doc inside try/catch to get index not found (yield returns are not supported inside try/catch)
+                while (true)
                 {
-                    var docs = _engine.Find(_name, query, skip, limit);
+                    try
+                    {
+                        var docs = _engine.Find(_name, query, skip, limit);
 
-                    enumerator = (IEnumerator<BsonDocument>)docs.GetEnumerator();
+                        enumerator = (IEnumerator<BsonDocument>)docs.GetEnumerator();
 
-                    more = enumerator.MoveNext();
+                        more = enumerator.MoveNext();
 
-                    break;
+                        break;
+                    }
+                    catch (IndexNotFoundException ex)
+                    {
+                        // if query returns this exception, let's auto create using mapper (or using default options)
+                        var options = _mapper.GetIndexFromMapper<T>(ex.Field) ?? new IndexOptions();
+
+                        _engine.EnsureIndex(ex.Collection, ex.Field, options);
+                    }
                 }
-                catch (IndexNotFoundException ex)
-                {
-                    // if query returns this exception, let's auto create using mapper (or using default options)
-                    var options = _mapper.GetIndexFromMapper<T>(ex.Field) ?? new IndexOptions();
 
-                    _engine.EnsureIndex(ex.Collection, ex.Field, options);
+                if (more == false) yield break;
+
+                // do...while
+                do
+                {
+                    // executing all includes in BsonDocument
+                    foreach (var action in _includes)
+                    {
+                        action(enumerator.Current);
+                    }
+
+                    // get object from BsonDocument
+                    var obj = _mapper.ToObject<T>(enumerator.Current);
+
+                    yield return obj;
+                }
+                while (more = enumerator.MoveNext());
+            } finally
+            {
+                if (enumerator != null)
+                {
+                    enumerator.Dispose();
                 }
             }
-
-            if (more == false) yield break;
-
-            // do...while
-            do
-            {
-                // executing all includes in BsonDocument
-                foreach (var action in _includes)
-                {
-                    action(enumerator.Current);
-                }
-
-                // get object from BsonDocument
-                var obj = _mapper.ToObject<T>(enumerator.Current);
-
-                yield return obj;
-            }
-            while (more = enumerator.MoveNext());
         }
 
         /// <summary>

--- a/LiteDB/Core/Collections/Find.cs
+++ b/LiteDB/Core/Collections/Find.cs
@@ -16,58 +16,49 @@ namespace LiteDB
         {
             if (query == null) throw new ArgumentNullException("query");
 
-            IEnumerator<BsonDocument> enumerator = null;
+            IEnumerator<BsonDocument> enumerator;
             var more = true;
 
-            try
+            // keep trying execute query to auto-create indexes when not found
+            // must try get first doc inside try/catch to get index not found (yield returns are not supported inside try/catch)
+            while (true)
             {
-                // keep trying execute query to auto-create indexes when not found
-                // must try get first doc inside try/catch to get index not found (yield returns are not supported inside try/catch)
-                while (true)
+                try
                 {
-                    try
-                    {
-                        var docs = _engine.Find(_name, query, skip, limit);
+                    var docs = _engine.Find(_name, query, skip, limit);
 
-                        enumerator = (IEnumerator<BsonDocument>)docs.GetEnumerator();
+                    enumerator = (IEnumerator<BsonDocument>)docs.GetEnumerator();
 
-                        more = enumerator.MoveNext();
+                    more = enumerator.MoveNext();
 
-                        break;
-                    }
-                    catch (IndexNotFoundException ex)
-                    {
-                        // if query returns this exception, let's auto create using mapper (or using default options)
-                        var options = _mapper.GetIndexFromMapper<T>(ex.Field) ?? new IndexOptions();
-
-                        _engine.EnsureIndex(ex.Collection, ex.Field, options);
-                    }
+                    break;
                 }
-
-                if (more == false) yield break;
-
-                // do...while
-                do
+                catch (IndexNotFoundException ex)
                 {
-                    // executing all includes in BsonDocument
-                    foreach (var action in _includes)
-                    {
-                        action(enumerator.Current);
-                    }
+                    // if query returns this exception, let's auto create using mapper (or using default options)
+                    var options = _mapper.GetIndexFromMapper<T>(ex.Field) ?? new IndexOptions();
 
-                    // get object from BsonDocument
-                    var obj = _mapper.ToObject<T>(enumerator.Current);
-
-                    yield return obj;
-                }
-                while (more = enumerator.MoveNext());
-            } finally
-            {
-                if (enumerator != null)
-                {
-                    enumerator.Dispose();
+                    _engine.EnsureIndex(ex.Collection, ex.Field, options);
                 }
             }
+
+            if (more == false) yield break;
+
+            // do...while
+            do
+            {
+                // executing all includes in BsonDocument
+                foreach (var action in _includes)
+                {
+                    action(enumerator.Current);
+                }
+
+                // get object from BsonDocument
+                var obj = _mapper.ToObject<T>(enumerator.Current);
+
+                yield return obj;
+            }
+            while (more = enumerator.MoveNext());
         }
 
         /// <summary>

--- a/LiteDB/Core/Collections/Find.cs
+++ b/LiteDB/Core/Collections/Find.cs
@@ -16,49 +16,56 @@ namespace LiteDB
         {
             if (query == null) throw new ArgumentNullException("query");
 
-            IEnumerator<BsonDocument> enumerator;
+            IEnumerator<BsonDocument> enumerator = null;
             var more = true;
 
-            // keep trying execute query to auto-create indexes when not found
-            // must try get first doc inside try/catch to get index not found (yield returns are not supported inside try/catch)
-            while (true)
+            try
             {
-                try
+
+                // keep trying execute query to auto-create indexes when not found
+                // must try get first doc inside try/catch to get index not found (yield returns are not supported inside try/catch)
+                while (true)
                 {
-                    var docs = _engine.Find(_name, query, skip, limit);
+                    try
+                    {
+                        var docs = _engine.Find(_name, query, skip, limit);
 
-                    enumerator = (IEnumerator<BsonDocument>)docs.GetEnumerator();
+                        enumerator = (IEnumerator<BsonDocument>)docs.GetEnumerator();
 
-                    more = enumerator.MoveNext();
+                        more = enumerator.MoveNext();
 
-                    break;
+                        break;
+                    }
+                    catch (IndexNotFoundException ex)
+                    {
+                        // if query returns this exception, let's auto create using mapper (or using default options)
+                        var options = _mapper.GetIndexFromMapper<T>(ex.Field) ?? new IndexOptions();
+
+                        _engine.EnsureIndex(ex.Collection, ex.Field, options);
+                    }
                 }
-                catch (IndexNotFoundException ex)
+
+                if (more == false) yield break;
+
+                // do...while
+                do
                 {
-                    // if query returns this exception, let's auto create using mapper (or using default options)
-                    var options = _mapper.GetIndexFromMapper<T>(ex.Field) ?? new IndexOptions();
+                    // executing all includes in BsonDocument
+                    foreach (var action in _includes)
+                    {
+                        action(enumerator.Current);
+                    }
 
-                    _engine.EnsureIndex(ex.Collection, ex.Field, options);
+                    // get object from BsonDocument
+                    var obj = _mapper.ToObject<T>(enumerator.Current);
+
+                    yield return obj;
                 }
-            }
-
-            if (more == false) yield break;
-
-            // do...while
-            do
+                while (more = enumerator.MoveNext());
+            } finally
             {
-                // executing all includes in BsonDocument
-                foreach (var action in _includes)
-                {
-                    action(enumerator.Current);
-                }
-
-                // get object from BsonDocument
-                var obj = _mapper.ToObject<T>(enumerator.Current);
-
-                yield return obj;
+                if (enumerator != null) enumerator.Dispose();
             }
-            while (more = enumerator.MoveNext());
         }
 
         /// <summary>

--- a/LiteDB/Core/Database/Transaction.cs
+++ b/LiteDB/Core/Database/Transaction.cs
@@ -7,26 +7,9 @@ namespace LiteDB
         /// <summary>
         /// Begin a exclusive read/write transaction
         /// </summary>
-        public void BeginTrans()
+        public Transaction BeginTrans()
         {
-            _engine.Value.BeginTrans();
-        }
-
-        /// <summary>
-        /// Persist all changes on disk. Always use this method to finish your changes on database
-        /// </summary>
-        public void Commit()
-        {
-            _engine.Value.Commit();
-        }
-
-        /// <summary>
-        /// Cancel all write operations and keep datafile as is before BeginTrans() called.
-        /// Rollback are implicit on a database operation error, so you do not need call for database errors (only on business rules).
-        /// </summary>
-        public void Rollback()
-        {
-            _engine.Value.Rollback();
+            return _engine.Value.BeginTrans();
         }
     }
 }

--- a/LiteDB/DbEngine/DbEngine/Collection.cs
+++ b/LiteDB/DbEngine/DbEngine/Collection.cs
@@ -11,23 +11,24 @@ namespace LiteDB
         /// </summary>
         public IEnumerable<string> GetCollectionNames()
         {
-            try
+            // initalize read only transaction
+            using (var trans = _transaction.Begin(true))
             {
-                // initalize read only transaction
-                _transaction.Begin(true);
+                try
+                {
+                    var header = _pager.GetPage<HeaderPage>(0);
 
-                var header = _pager.GetPage<HeaderPage>(0);
+                    // complete transaction, release datafile
+                    trans.Complete();
 
-                // complete transaction, release datafile
-                _transaction.Complete();
-
-                return header.CollectionPages.Keys.AsEnumerable();
-            }
-            catch (Exception ex)
-            {
-                _log.Write(Logger.ERROR, ex.Message);
-                _transaction.Abort();
-                throw;
+                    return header.CollectionPages.Keys.AsEnumerable();
+                }
+                catch (Exception ex)
+                {
+                    _log.Write(Logger.ERROR, ex.Message);
+                    trans.Abort();
+                    throw;
+                }
             }
         }
 

--- a/LiteDB/DbEngine/DbEngine/Find.cs
+++ b/LiteDB/DbEngine/DbEngine/Find.cs
@@ -11,61 +11,61 @@ namespace LiteDB
         /// </summary>
         public IEnumerable<BsonDocument> Find(string colName, Query query, int skip = 0, int limit = int.MaxValue)
         {
-            _transaction.Begin(true);
-
-            // get my collection page
-            var col = this.GetCollectionPage(colName, false);
-
-            // no collection, no documents
-            if (col == null) yield break;
-
-            // get nodes from query executor to get all IndexNodes
-            IEnumerable<IndexNode> nodes;
-
-            try
+            // transaction will be closed as soon as the IEnumerable goes out of scope
+            using (var trans = _transaction.Begin(true))
             {
-                nodes = query.Run(col, _indexer);
-            }
-            catch (Exception ex)
-            {
-                _log.Write(Logger.ERROR, ex.Message);
-                _transaction.Abort();
-                throw;
-            }
+                // get my collection page
+                var col = this.GetCollectionPage(colName, false);
 
-            // skip first N nodes
-            if (skip > 0) nodes = nodes.Skip(skip);
+                // no collection, no documents
+                if (col == null) yield break;
 
-            // limit in M nodes
-            if (limit != int.MaxValue) nodes = nodes.Take(limit);
+                // get nodes from query executor to get all IndexNodes
+                IEnumerable<IndexNode> nodes;
 
-            // for each document, read data and deserialize as document
-            foreach (var node in nodes)
-            {
-                _log.Write(Logger.QUERY, "read document on '{0}' :: _id = {1}", colName, node.Key);
-
-                byte[] buffer;
-                BsonDocument doc;
-
-                // encapsulate read operation inside a try/catch (yeild do not support try/catch)
                 try
                 {
-                    buffer = _data.Read(node.DataBlock);
-                    doc = BsonSerializer.Deserialize(buffer).AsDocument;
+                    nodes = query.Run(col, _indexer);
                 }
                 catch (Exception ex)
                 {
                     _log.Write(Logger.ERROR, ex.Message);
-                    _transaction.Abort();
+                    trans.Abort();
                     throw;
                 }
 
-                yield return doc;
+                // skip first N nodes
+                if (skip > 0) nodes = nodes.Skip(skip);
 
-                _cache.CheckPoint();
+                // limit in M nodes
+                if (limit != int.MaxValue) nodes = nodes.Take(limit);
+
+                // for each document, read data and deserialize as document
+                foreach (var node in nodes)
+                {
+                    _log.Write(Logger.QUERY, "read document on '{0}' :: _id = {1}", colName, node.Key);
+
+                    byte[] buffer;
+                    BsonDocument doc;
+
+                    // encapsulate read operation inside a try/catch (yeild do not support try/catch)
+                    try
+                    {
+                        buffer = _data.Read(node.DataBlock);
+                        doc = BsonSerializer.Deserialize(buffer).AsDocument;
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Write(Logger.ERROR, ex.Message);
+                        trans.Abort();
+                        throw;
+                    }
+
+                    yield return doc;
+
+                    _cache.CheckPoint();
+                }
             }
-
-            _transaction.Complete();
         }
     }
 }

--- a/LiteDB/DbEngine/DbEngine/Shrink.cs
+++ b/LiteDB/DbEngine/DbEngine/Shrink.cs
@@ -10,82 +10,83 @@ namespace LiteDB
         /// </summary>
         public long Shrink()
         {
-            try
+            // begin a write exclusive access
+            using (var trans = _transaction.Begin(false))
             {
-                // begin a write exclusive access
-                _transaction.Begin(false);
-
-                // create a temporary disk
-                var tempDisk = _disk.GetTempDisk();
-
-                // get initial disk size
-                var header = _pager.GetPage<HeaderPage>(0);
-                var diff = 0L;
-
-                // create temp engine instance to copy all documents
-                using (var tempEngine = new DbEngine(tempDisk, new Logger()))
+                try
                 {
-                    tempDisk.Open(false);
+                    // create a temporary disk
+                    var tempDisk = _disk.GetTempDisk();
 
-                    // read all collections
-                    foreach (var col in _collections.GetAll())
+                    // get initial disk size
+                    var header = _pager.GetPage<HeaderPage>(0);
+                    var diff = 0L;
+
+                    // create temp engine instance to copy all documents
+                    using (var tempEngine = new DbEngine(tempDisk, new Logger()))
                     {
-                        // first copy all indexes
-                        foreach (var index in col.GetIndexes(false))
+                        tempDisk.Open(false);
+
+                        // read all collections
+                        foreach (var col in _collections.GetAll())
                         {
-                            tempEngine.EnsureIndex(col.CollectionName, index.Field, index.Options);
+                            // first copy all indexes
+                            foreach (var index in col.GetIndexes(false))
+                            {
+                                tempEngine.EnsureIndex(col.CollectionName, index.Field, index.Options);
+                            }
+
+                            // then, read all documents and copy to new engine
+                            var nodes = _indexer.FindAll(col.PK, Query.Ascending);
+
+                            tempEngine.Insert(col.CollectionName,
+                                nodes.Select(node => BsonSerializer.Deserialize(_data.Read(node.DataBlock))));
                         }
 
-                        // then, read all documents and copy to new engine
-                        var nodes = _indexer.FindAll(col.PK, Query.Ascending);
+                        // get final header from temp engine
+                        var tempHeader = tempEngine._pager.GetPage<HeaderPage>(0, true);
 
-                        tempEngine.Insert(col.CollectionName,
-                            nodes.Select(node => BsonSerializer.Deserialize(_data.Read(node.DataBlock))));
+                        // copy info from initial header to final header
+                        tempHeader.ChangeID = header.ChangeID;
+
+                        // lets create journal file before re-write
+                        for (uint pageID = 0; pageID <= header.LastPageID; pageID++)
+                        {
+                            _disk.WriteJournal(pageID, _disk.ReadPage(pageID));
+                        }
+
+                        // commit journal + shrink data file
+                        _disk.SetLength(BasePage.GetSizeOfPages(tempHeader.LastPageID + 1));
+
+                        // lets re-write all pages copying from new database
+                        for (uint pageID = 0; pageID <= tempHeader.LastPageID; pageID++)
+                        {
+                            _disk.WritePage(pageID, tempDisk.ReadPage(pageID));
+                        }
+
+                        // now delete journal
+                        _disk.DeleteJournal();
+
+                        // get diff from initial and final last pageID
+                        diff = BasePage.GetSizeOfPages(header.LastPageID - tempHeader.LastPageID);
+
+                        tempDisk.Close();
                     }
 
-                    // get final header from temp engine
-                    var tempHeader = tempEngine._pager.GetPage<HeaderPage>(0, true);
+                    // unlock disk and clear cache to continue
+                    trans.Complete();
 
-                    // copy info from initial header to final header
-                    tempHeader.ChangeID = header.ChangeID;
+                    // delete temporary disk
+                    _disk.DeleteTempDisk();
 
-                    // lets create journal file before re-write
-                    for (uint pageID = 0; pageID <= header.LastPageID; pageID++)
-                    {
-                        _disk.WriteJournal(pageID, _disk.ReadPage(pageID));
-                    }
-
-                    // commit journal + shrink data file
-                    _disk.SetLength(BasePage.GetSizeOfPages(tempHeader.LastPageID + 1));
-
-                    // lets re-write all pages copying from new database
-                    for (uint pageID = 0; pageID <= tempHeader.LastPageID; pageID++)
-                    {
-                        _disk.WritePage(pageID, tempDisk.ReadPage(pageID));
-                    }
-
-                    // now delete journal
-                    _disk.DeleteJournal();
-
-                    // get diff from initial and final last pageID
-                    diff = BasePage.GetSizeOfPages(header.LastPageID - tempHeader.LastPageID);
-
-                    tempDisk.Close();
+                    return diff;
                 }
-
-                // unlock disk and clear cache to continue
-                _transaction.Complete();
-
-                // delete temporary disk
-                _disk.DeleteTempDisk();
-
-                return diff;
-            }
-            catch (Exception ex)
-            {
-                _log.Write(Logger.ERROR, ex.Message);
-                _transaction.Abort();
-                throw;
+                catch (Exception ex)
+                {
+                    _log.Write(Logger.ERROR, ex.Message);
+                    trans.Abort();
+                    throw;
+                }
             }
         }
     }

--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -186,6 +186,7 @@
     <Compile Include="Utils\Logger.cs" />
     <Compile Include="Utils\SimpleAES.cs" />
     <Compile Include="Utils\StringScanner.cs" />
+    <Compile Include="Utils\TransactionCancelledException.cs" />
     <Compile Include="Utils\TypeExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/LiteDB/Query/Linq/QueryVisitor.cs
+++ b/LiteDB/Query/Linq/QueryVisitor.cs
@@ -140,15 +140,13 @@ namespace LiteDB
             // check if left side is an enum and convert to string before return
             Func<Type, object, BsonValue> convert = (type, value) =>
             {
-#if NETFULL
                 var enumType = (left as UnaryExpression)?.Operand.Type;
 
-                if (enumType != null && enumType.IsEnum)
+                if (enumType != null && enumType.GetTypeInfo().IsEnum)
                 {
                     var str = Enum.GetName(enumType, value);
                     return _mapper.Serialize(typeof(string), str, 0);
                 }
-#endif
                 return _mapper.Serialize(type, value, 0);
             };
 

--- a/LiteDB/Serializer/Mapper/BsonMapper.cs
+++ b/LiteDB/Serializer/Mapper/BsonMapper.cs
@@ -107,13 +107,13 @@ namespace LiteDB
                     return nv;
                 }
             );
+#endif
 
             this.RegisterType<DateTimeOffset>
             (
                 serialize: (value) => new BsonValue(value.UtcDateTime),
                 deserialize: (bson) => bson.AsDateTime.ToUniversalTime()
             );
-#endif
 
             #endregion Register CustomTypes
 

--- a/LiteDB/Serializer/Mapper/Reflection.cs
+++ b/LiteDB/Serializer/Mapper/Reflection.cs
@@ -99,6 +99,13 @@ namespace LiteDB
                 // if not getter or setter - no mapping
                 if (getter == null) continue;
 
+                if (dict.ContainsKey(prop.Name))
+                {
+                    // If the property is already in the dictionary, it's probably an override
+                    // Keep the first instance added
+                    continue;
+                }
+
                 var name = id != null && id.Equals(prop) ? "_id" : resolvePropertyName(prop.Name);
 
                 // check if property has [BsonField] with a custom field name

--- a/LiteDB/Serializer/Mapper/Reflection.cs
+++ b/LiteDB/Serializer/Mapper/Reflection.cs
@@ -59,7 +59,7 @@ namespace LiteDB
 
         #endregion GetIdProperty
 
-       #region GetProperties
+        #region GetProperties
 
         /// <summary>
         /// Read all properties from a type - store in a static cache - exclude: Id and [BsonIgnore]
@@ -98,13 +98,6 @@ namespace LiteDB
 
                 // if not getter or setter - no mapping
                 if (getter == null) continue;
-
-                if (dict.ContainsKey(prop.Name))
-                {
-                    // When reflecting over types like LiteDBDocument overriden properties can show up more than once
-                    // Like RawValue
-                    continue;
-                }
 
                 var name = id != null && id.Equals(prop) ? "_id" : resolvePropertyName(prop.Name);
 
@@ -145,7 +138,7 @@ namespace LiteDB
             return dict;
         }
 
-        #endregion GetProperties 
+        #endregion GetProperties
 
         #region IL Code
 

--- a/LiteDB/Serializer/Mapper/Reflection.cs
+++ b/LiteDB/Serializer/Mapper/Reflection.cs
@@ -59,7 +59,7 @@ namespace LiteDB
 
         #endregion GetIdProperty
 
-        #region GetProperties
+       #region GetProperties
 
         /// <summary>
         /// Read all properties from a type - store in a static cache - exclude: Id and [BsonIgnore]
@@ -98,6 +98,13 @@ namespace LiteDB
 
                 // if not getter or setter - no mapping
                 if (getter == null) continue;
+
+                if (dict.ContainsKey(prop.Name))
+                {
+                    // When reflecting over types like LiteDBDocument overriden properties can show up more than once
+                    // Like RawValue
+                    continue;
+                }
 
                 var name = id != null && id.Equals(prop) ? "_id" : resolvePropertyName(prop.Name);
 
@@ -138,7 +145,7 @@ namespace LiteDB
             return dict;
         }
 
-        #endregion GetProperties
+        #endregion GetProperties 
 
         #region IL Code
 

--- a/LiteDB/Utils/TransactionCancelledException.cs
+++ b/LiteDB/Utils/TransactionCancelledException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LiteDB.Utils
+{
+    public class TransactionCancelledException : LiteException
+    {
+        public TransactionCancelledException() : base("This transaction is cancelled due to an aborted transaction")
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
After you merged in my changes, I hit some small issues that turned into larger ones. I fixed up some of the failing tests, and got things working with my two test projects again. Here are the results of those fixes.

I hope the transaction changes aren't a problem, it helped me track down some issues converting to objects, and it made sense to leave them that way.

Reworks all transactions to be a disposable object so they can be wrapped in using blocks as well as tracked in transaction service
Updated all internal transactions to use Transaction object
Added try/finally to Find in LiteCollection to close the enumerator and finalize the transaction
Fixed VisitValue (QueryVisitor) to handle enums properly on all platforms
Accounted for issue where an index was added implicitly based on a BsonDocument would not crash (Reflection.cs)

