### PR TITLE
Fixed timespan parsing in ConnectionString

### DIFF
--- a/LiteDB.Tests/LiteDB.Tests.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.csproj
@@ -58,6 +58,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Tests\ConcurrentThreadTest.cs" />
+    <Compile Include="Tests\ConnectionStringTest.cs" />
     <Compile Include="Tests\DatabasePerformanceTest.cs" />
     <Compile Include="Tests\DataTableTest.cs" />
     <Compile Include="Tests\Datafilev1Test.cs" />

--- a/LiteDB.Tests/Tests/ConnectionStringTest.cs
+++ b/LiteDB.Tests/Tests/ConnectionStringTest.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace LiteDB.Tests
+{
+    [TestClass]
+    public class ConnectionStringTest
+    {
+        [TestMethod]
+        public void ConnectionString_Test()
+        {
+            var cs = new ConnectionString("string=A; double=33.0; bool=true; timespan=00:00:42");
+
+            Assert.AreEqual("A", cs.GetValue("string",""));
+            Assert.AreEqual(33.0, cs.GetValue("double", 0.0));
+            Assert.AreEqual(true, cs.GetValue("bool", false));
+            Assert.AreEqual(TimeSpan.Parse("00:00:42"), cs.GetValue("timespan", new TimeSpan()));
+        }
+    }
+}

--- a/LiteDB/Utils/ConnectionString.cs
+++ b/LiteDB/Utils/ConnectionString.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -41,7 +42,8 @@ namespace LiteDB
             try
             {
                 return _values.ContainsKey(key) ?
-                    (T)Convert.ChangeType(_values[key], typeof(T)) :
+                    (T)TypeDescriptor.GetConverter(typeof(T))
+                        .ConvertFromString(_values[key]) :
                     defaultValue;
             }
             catch (Exception)


### PR DESCRIPTION
Hi, I've been toying around LiteDB. Looks great! I've tried using the `timeout` connection string parameter, and it failed at type conversion. Here's a fix based on the [SO answer](http://stackoverflow.com/a/11967393/847349) by @mgravell.

Tested it on .Net 4 only. Hope it works on all platforms.
