### PR TITLE
Fixed locking issue in Reflection

### DIFF
--- a/LiteDB/Serializer/Mapper/Reflection.cs
+++ b/LiteDB/Serializer/Mapper/Reflection.cs
@@ -150,21 +150,21 @@ namespace LiteDB
         /// </summary>
         public static object CreateInstance(Type type)
         {
-            try
-            {
-                CreateObject c;
-                if (_cacheCtor.TryGetValue(type, out c))
-                {
-                    return c();
-                }
-            }
-            catch
-            {
-                throw LiteException.InvalidCtor(type);
-            }
-
             lock (_cacheCtor)
             {
+                try
+                {
+                    CreateObject c;
+                    if (_cacheCtor.TryGetValue(type, out c))
+                    {
+                        return c();
+                    }
+                }
+                catch
+                {
+                    throw LiteException.InvalidCtor(type);
+                }
+
                 try
                 {
                     CreateObject c = null;


### PR DESCRIPTION
Fixed an issue where multi-threaded calls to Reflection.CreateInstance for the same Type would cause an exception as the same item would be added to the _cacheCtor dictionary more than once. To see this in action simply run the ThreadedMappingShouldNotCauseConstructorException against the original Reflection.cs class. To fix the issue I simply moved the lock up so it wraps around all accesses to _cacheCtor.

It might also be a good idea to include the original Exception as an InnerException in the thrown exception. I found it a bit confusing getting an exception telling me my classes required a Parameter-less constructor when they already had one. If you want I can also add this?