### PR TITLE
Reduce locked file wait interval

### DIFF
--- a/LiteDB/DbEngine/Disks/FileDiskService.cs
+++ b/LiteDB/DbEngine/Disks/FileDiskService.cs
@@ -387,11 +387,11 @@ namespace LiteDB
                 }
                 catch (UnauthorizedAccessException)
                 {
-                        LitePlatform.Platform.WaitFor (10);
+                    LitePlatform.Platform.WaitFor (10);
                 }
                 catch (IOException ex)
                 {
-                        ex.WaitIfLocked (10);
+                    ex.WaitIfLocked (10);
                 }
             }
 

--- a/LiteDB/DbEngine/Disks/FileDiskService.cs
+++ b/LiteDB/DbEngine/Disks/FileDiskService.cs
@@ -387,11 +387,11 @@ namespace LiteDB
                 }
                 catch (UnauthorizedAccessException)
                 {
-                    LitePlatform.Platform.WaitFor(250);
+                        LitePlatform.Platform.WaitFor (10);
                 }
                 catch (IOException ex)
                 {
-                    ex.WaitIfLocked(250);
+                        ex.WaitIfLocked (10);
                 }
             }
 


### PR DESCRIPTION
Reduce locked file wait interval.

This helps a lot in cases with concurrent access. It enormously improved throughput and latency in my tests, and also helped getting a _lot_ fewer timeouts.

Maybe this also helps with #322.