### PR TITLE
Change transaction syntax to make Commit() implicit

### DIFF
--- a/LiteDB.Tests/Database/TransactionTest.cs
+++ b/LiteDB.Tests/Database/TransactionTest.cs
@@ -1,0 +1,107 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace LiteDB.Tests
+{
+    [TestClass]
+    public class TransactionTest
+    {
+        [TestMethod]
+        public void TransactionCommit_Test()
+        {
+            using (var f = new TempFile())
+            using (var db = new LiteDatabase(f.Filename))
+            {
+                var col = db.GetCollection<Person>("Person");
+
+                col.Insert(new Person { Fullname = "John" });
+                col.Insert(new Person { Fullname = "Doe" });
+                using (var transaction = db.BeginTrans())
+                {
+                    col.Insert(new Person { Fullname = "Joana" });
+                    col.Insert(new Person { Fullname = "Marcus" });
+                }
+
+                Assert.AreEqual(4, col.Count());
+            }
+        }
+
+        [TestMethod]
+        public void TransactionRollback_Test()
+        {
+            using (var f = new TempFile())
+            using (var db = new LiteDatabase(f.Filename))
+            {
+                var col = db.GetCollection<Person>("Person");
+
+                col.Insert(new Person { Fullname = "John" });
+                col.Insert(new Person { Fullname = "Doe" });
+                using (var transaction = db.BeginTrans())
+                {
+                    col.Insert(new Person { Fullname = "Joana" });
+                    col.Insert(new Person { Fullname = "Marcus" });
+                    transaction.Rollback();
+                }
+
+                Assert.AreEqual(2, col.Count());
+            }
+        }
+
+        [TestMethod]
+        public void TransactionException_Test()
+        {
+            using (var f = new TempFile())
+            using (var db = new LiteDatabase(f.Filename))
+            {
+                var col = db.GetCollection<Person>("Person");
+
+                col.Insert(new Person { Fullname = "John" });
+                col.Insert(new Person { Fullname = "Doe" });
+
+                try
+                {
+                    using (var transaction = db.BeginTrans())
+                    {
+                        col.Insert(new Person { Fullname = "Joana" });
+                        col.Insert(new Person { Fullname = "Marcus" });
+                        throw new IOException();
+                    }
+                }
+                catch (IOException) { }
+
+                Assert.AreEqual(2, col.Count());
+            }
+        }
+
+        [TestMethod]
+        public void TransactionNestedException_Test()
+        {
+            using (var f = new TempFile())
+            using (var db = new LiteDatabase(f.Filename))
+            {
+                var col = db.GetCollection<Person>("Person");
+
+                try
+                {
+                    using (var transaction1 = db.BeginTrans())
+                    {
+                        col.Insert(new Person { Id = 1, Fullname = "John" });
+
+                        using (var transaction2 = db.BeginTrans())
+                        {
+                            col.Insert(new Person { Id = 2, Fullname = "Joana" });
+                        }
+
+                        col.Insert(new Person { Id = 1, Fullname = "Foo Bar" }); // throws duplicate key exception
+                    }
+
+                }
+                catch (LiteException) { }
+
+                Assert.AreEqual(0, col.Count());
+            }
+        }
+    }
+}

--- a/LiteDB.Tests/LiteDB.Tests.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Database\ConnectionStringTest.cs" />
     <Compile Include="Database\AttributeMapperTest.cs" />
     <Compile Include="Database\DbRefIndexTest.cs" />
+    <Compile Include="Database\TransactionTest.cs" />
     <Compile Include="Database\DeleteByNameTest.cs" />
     <Compile Include="Database\LinqVisitorTest.cs" />
     <Compile Include="Database\MapperNonPublicTest.cs" />

--- a/LiteDB/Utils/LiteTransaction.cs
+++ b/LiteDB/Utils/LiteTransaction.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace LiteDB
 {
@@ -7,30 +8,26 @@ namespace LiteDB
     {
         private Action _commit;
         private Action _rollback;
-        private bool _dispose;
 
         internal LiteTransaction(Action commit, Action rollback)
         {
             _commit = commit;
             _rollback = rollback;
-            _dispose = true;
-        }
-
-        public void Commit()
-        {
-            _commit();
-            _dispose = false;
         }
 
         public void Rollback()
         {
             _rollback();
-            _dispose = false;
         }
 
         public void Dispose()
         {
-            if(_dispose == true) _rollback();
+            bool exceptionThrown = Marshal.GetExceptionCode() != 0;
+
+            if (exceptionThrown)
+                _rollback();
+            else
+                _commit();
         }
     }
 }


### PR DESCRIPTION
The current transaction syntax is the following:

```C#
using(var transaction = db.BeginTrans())
{
    // (operations)
    transaction.Commit();
}
```

This is unclear and prone to mistakes. Forgetting to commit the transaction will roll it back, or in certain cases (nested transactions) lead to difficult to diagnose bugs. For example, modifying the sample from the wiki:

```C#
using (var transaction1 = db.BeginTrans())
{
    col.Insert(new Person { Id = 1, Fullname = "John" });

    using (var transaction2 = db.BeginTrans())
    {
        col.Insert(new Person { Id = 2, Fullname = "Joana" });
        //transaction2.Commit(); // we don't commit the inner transaction
    }

    col.Insert(new Person { Id = 1, Fullname = "Rick" });
    transaction1.Commit();
}
// what's the result? surprise! only the third person (Rick) gets comitted.
```

I propose a new syntax that makes the `Commit()` statement implicit at the end of the transaction.
```C#
using(var transaction = db.BeginTrans())
{
    // (operations, no need to commit)
}
```

The `IDisposable.Dispose()` implementation uses `Marshal.GetExceptionCode()` to decide whether the transaction should be committed or rolled back. I preserved the behaviour of `Rollback()` only cancelling the operations until the rollback statement, not withing the scope of the entire transaction.

I am not certain what behaviour is intended in some cases so please review the code and decide whether this kind of solution is acceptable.

I am also adding several tests for the transaction system.