### PR TITLE
Fix for NullReferenceException when deserializing a deleted DbRef

### DIFF
--- a/LiteDB.Tests/Database/NullRefTests.cs
+++ b/LiteDB.Tests/Database/NullRefTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LiteDB.Tests.Database
+{
+    public class Pipeline
+    {
+        public int Id { get; set; }
+        public List<Job> Jobs { get; set; } = new List<Job>();
+    }
+
+    public class Job
+    {
+        public int Id { get; set; }
+    }
+
+    [TestClass]
+    public class NullRefTests
+    {
+        [TestMethod]
+        [ExpectedException(typeof(NullReferenceException))]
+        public void DbRef_ToDeleted_ThrowsNullReferenceException()
+        {
+            var mapper = new BsonMapper();
+            mapper.Entity<Pipeline>().DbRef(x => x.Jobs, "jobs");
+
+            using (var db = new LiteDatabase(new MemoryStream(), mapper))
+            {
+                var pipelineCollection = db.GetCollection<Pipeline>("pipelines");
+                var jobCollection = db.GetCollection<Job>("jobs");
+
+                var pipeline = new Pipeline();
+                pipelineCollection.Insert(pipeline);
+
+                var job = new Job();
+                jobCollection.Insert(job);
+
+                pipeline.Jobs.Add(job);
+                pipelineCollection.Update(pipeline);
+
+                jobCollection.Delete(job.Id);
+
+                var thisWillThrow = db.GetCollection<Pipeline>("pipelines").Include(p => p.Jobs).FindAll().ToArray();
+            }
+        }
+    }
+}

--- a/LiteDB.Tests/Database/NullRefTests.cs
+++ b/LiteDB.Tests/Database/NullRefTests.cs
@@ -21,7 +21,6 @@ namespace LiteDB.Tests.Database
     public class NullRefTests
     {
         [TestMethod]
-        [ExpectedException(typeof(NullReferenceException))]
         public void DbRef_ToDeleted_ThrowsNullReferenceException()
         {
             var mapper = new BsonMapper();
@@ -43,7 +42,11 @@ namespace LiteDB.Tests.Database
 
                 jobCollection.Delete(job.Id);
 
-                var thisWillThrow = db.GetCollection<Pipeline>("pipelines").Include(p => p.Jobs).FindAll().ToArray();
+                var pipelines = db.GetCollection<Pipeline>("pipelines").Include(p => p.Jobs).FindAll().ToArray();
+                Assert.AreEqual(1, pipelines.Length);
+
+                pipeline = pipelines.Single();
+                Assert.AreEqual(0, pipeline.Jobs.Count);
             }
         }
     }

--- a/LiteDB.Tests/LiteDB.Tests.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Database\DbRefIndexTest.cs" />
     <Compile Include="Database\DeleteByNameTest.cs" />
     <Compile Include="Database\NonIdPocoTest.cs" />
+    <Compile Include="Database\NullRefTests.cs" />
     <Compile Include="Database\PredicateBuilderTest.cs" />
     <Compile Include="Database\LinqVisitorTest.cs" />
     <Compile Include="Database\MapperNonPublicTest.cs" />

--- a/LiteDB/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Mapper/BsonMapper.Deserialize.cs
@@ -201,7 +201,11 @@ namespace LiteDB
             {
                 foreach (BsonValue item in value)
                 {
-                    list.Add(Deserialize(itemType, item));
+                    var deserializedItem = Deserialize(itemType, item);
+                    if (deserializedItem != null)
+                    {
+                        list.Add(deserializedItem);
+                    }
                 }
             }
             else

--- a/LiteDB/Mapper/BsonMapper.cs
+++ b/LiteDB/Mapper/BsonMapper.cs
@@ -501,7 +501,7 @@ namespace LiteDB
 
                 if (array.Count == 0) return m.Deserialize(member.DataType, array);
 
-                var hasIdRef = array[0].AsDocument["$id"].IsNull;
+                var hasIdRef = array[0].AsDocument == null || array[0].AsDocument["$id"].IsNull;
 
                 if (hasIdRef)
                 {


### PR DESCRIPTION
Hi,

I encountered a NullReferenceException during deserialization. The PR includes a test that reproduces the exact scenario. A quick summary of the steps:
- create and insert an entity that has a list, which is a DbRef
- create an instance of the referenced entity, add it to the first entity and store both
- delete the referenced entity (directly, not by removing it from the list of the first entity)
- load the first entity again => throws

The fix results in ignoring the deleted entity and just returning an empty list.