### PR TITLE
Spelling and grammar improvements for method documentation.

### DIFF
--- a/LiteDB.Shell/Commands/Console/Help.cs
+++ b/LiteDB.Shell/Commands/Console/Help.cs
@@ -50,7 +50,7 @@ namespace LiteDB.Shell.Commands
                 d.WriteHelp("> dump > <filename.dmp>", "Export all documents to an external file script");
                 d.WriteHelp("> dump < <filename.dmp>", "Import all documents inside a script dump file");
                 d.WriteHelp("> timer", "Show timer before prompt");
-                d.WriteHelp("> ed", "Open nodepad with last command to edit and execute");
+                d.WriteHelp("> ed", "Open notepad with last command to edit and execute");
                 d.WriteHelp("> spool on|off", "Spool all output in a spool file");
                 d.WriteHelp("> -- comment", "Do nothing, its just a comment");
                 d.WriteHelp("> /<command>/", "Support for multi line command");

--- a/LiteDB.Shell/Commands/Console/Run.cs
+++ b/LiteDB.Shell/Commands/Console/Run.cs
@@ -14,7 +14,7 @@ namespace LiteDB.Shell.Commands
 
         public void Execute(LiteEngine engine, StringScanner s, Display display, InputCommand input, Env env)
         {
-            if (engine == null) throw ShellExpcetion.NoDatabase();
+            if (engine == null) throw ShellException.NoDatabase();
 
             var filename = s.Scan(@".+").Trim();
 

--- a/LiteDB.Shell/Commands/Console/Spool.cs
+++ b/LiteDB.Shell/Commands/Console/Spool.cs
@@ -26,7 +26,7 @@ namespace LiteDB.Shell.Commands
             }
             else if (_writer == null)
             {
-                if (engine == null) throw ShellExpcetion.NoDatabase();
+                if (engine == null) throw ShellException.NoDatabase();
 
                 var path = Path.GetFullPath(string.Format("LiteDB-spool-{0:yyyy-MM-dd-HH-mm}.txt", DateTime.Now));
 

--- a/LiteDB.Shell/Commands/Console/Upgrade.cs
+++ b/LiteDB.Shell/Commands/Console/Upgrade.cs
@@ -26,7 +26,7 @@ namespace LiteDB.Shell.Commands
             }
             else
             {
-                throw new ShellExpcetion("File format do not support upgrade (" + connectionString.Filename + ")");
+                throw new ShellException("File format do not support upgrade (" + connectionString.Filename + ")");
             }
         }
     }

--- a/LiteDB.Shell/Program.cs
+++ b/LiteDB.Shell/Program.cs
@@ -13,7 +13,7 @@ namespace LiteDB.Shell
         /// Parameters:
         /// --exec "command"   : Execute an shell command (can be multiples --exec)
         /// --run script.txt   : Run script commands file 
-        /// --pretty           : Show JSON in multiline + idented
+        /// --pretty           : Show JSON in multiline + indented
         /// --exit             : Exit after last command
         /// </summary>
         private static void Main(string[] args)

--- a/LiteDB.Shell/Shell/Env.cs
+++ b/LiteDB.Shell/Shell/Env.cs
@@ -23,7 +23,7 @@ namespace LiteDB.Shell
 
         public LiteEngine CreateEngine(DataAccess access)
         {
-            if (this.Filename == null) throw new ShellExpcetion("No database");
+            if (this.Filename == null) throw new ShellException("No database");
 
             var disk = new FileDiskService(this.Filename,
                 new FileOptions

--- a/LiteDB.Shell/Shell/InputCommand.cs
+++ b/LiteDB.Shell/Shell/InputCommand.cs
@@ -36,7 +36,7 @@ namespace LiteDB.Shell
 
             var cmd = this.ReadLine();
 
-            // suport for multiline command
+            // support for multiline command
             if (cmd.StartsWith("/"))
             {
                 cmd = cmd.Substring(1);

--- a/LiteDB.Shell/Shell/ShellException.cs
+++ b/LiteDB.Shell/Shell/ShellException.cs
@@ -2,16 +2,16 @@
 
 namespace LiteDB.Shell
 {
-    internal class ShellExpcetion : Exception
+    internal class ShellException : Exception
     {
-        public ShellExpcetion(string message)
+        public ShellException(string message)
             : base(message)
         {
         }
 
-        public static ShellExpcetion NoDatabase()
+        public static ShellException NoDatabase()
         {
-            return new ShellExpcetion("No open database");
+            return new ShellException("No open database");
         }
     }
 }

--- a/LiteDB.Shell/Shell/ShellProgram.cs
+++ b/LiteDB.Shell/Shell/ShellProgram.cs
@@ -52,7 +52,7 @@ namespace LiteDB.Shell
                         break;
                     }
 
-                    if (!found) throw new ShellExpcetion("Command not found");
+                    if (!found) throw new ShellException("Command not found");
                 }
                 catch (Exception ex)
                 {

--- a/LiteDB.Tests/Concurrency/ProcessTest.cs
+++ b/LiteDB.Tests/Concurrency/ProcessTest.cs
@@ -71,7 +71,7 @@ namespace LiteDB.Tests
                         }
                     });
 
-                    // keep quering until found 1000 docs
+                    // keep querying until found 1000 docs
                     var tb = Task.Factory.StartNew(() =>
                     {
                         var count = 0L;

--- a/LiteDB.Tests/Storage/StorageStreamTest.cs
+++ b/LiteDB.Tests/Storage/StorageStreamTest.cs
@@ -32,7 +32,7 @@ namespace LiteDB.Tests
                     }
                 }
 
-                // test if was updated Length in _files collectin
+                // test if was updated Length in _files collection
                 var doc = db.Find("_files", Query.EQ("_id", "f1")).Single();
 
                 Assert.AreEqual(HELLO1.Length, doc["length"].AsInt32);

--- a/LiteDB/Database/Collections/Aggregate.cs
+++ b/LiteDB/Database/Collections/Aggregate.cs
@@ -17,7 +17,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Count documnets with a query. This method does not deserialize any document. Needs indexes on query expression
+        /// Count documents matching a query. This method does not deserialize any document. Needs indexes on query expression
         /// </summary>
         public int Count(Query query)
         {
@@ -38,7 +38,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Count documnets with a query. This method does not deserialize any document. Needs indexes on query expression
+        /// Count documents matching a query. This method does not deserialize any documents. Needs indexes on query expression
         /// </summary>
         public int Count(Expression<Func<T, bool>> predicate)
         {
@@ -61,7 +61,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Count documnets with a query. This method does not deserialize any document. Needs indexes on query expression
+        /// Count documents matching a query. This method does not deserialize any documents. Needs indexes on query expression
         /// </summary>
         public long LongCount(Query query)
         {
@@ -82,7 +82,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Count documnets with a query. This method does not deserialize any document. Needs indexes on query expression
+        /// Count documents matching a query. This method does not deserialize any documents. Needs indexes on query expression
         /// </summary>
         public long LongCount(Expression<Func<T, bool>> predicate)
         {

--- a/LiteDB/Database/Collections/Include.cs
+++ b/LiteDB/Database/Collections/Include.cs
@@ -38,7 +38,7 @@ namespace LiteDB
                 }
                 else
                 {
-                    // for BsonDocument, get property value e update with full object refence
+                    // for BsonDocument, get property value update with full object reference
                     var doc = value.AsDocument;
                     var col = new LiteCollection<BsonDocument>(doc["$ref"], _engine, _mapper, _log);
                     var obj = col.FindById(doc["$id"]);

--- a/LiteDB/Database/LiteDatabase.cs
+++ b/LiteDB/Database/LiteDatabase.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace LiteDB
 {
     /// <summary>
-    /// The LiteDB database. Used for create a LiteDB instance and use all storage resoures. It's the database connection
+    /// The LiteDB database. Used for create a LiteDB instance and use all storage resources. It's the database connection
     /// </summary>
     public partial class LiteDatabase : IDisposable
     {
@@ -37,7 +37,7 @@ namespace LiteDB
         #region Ctor
 
         /// <summary>
-        /// Starts LiteDB database using a connection string for filesystem database
+        /// Starts LiteDB database using a connection string for file system database
         /// </summary>
         public LiteDatabase(string connectionString, BsonMapper mapper = null)
         {
@@ -72,14 +72,13 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Starts LiteDB database using a custom IDiskService with all parameters avaiable
+        /// Starts LiteDB database using a custom IDiskService with all parameters available
         /// </summary>
         /// <param name="diskService">Custom implementation of persist data layer</param>
         /// <param name="mapper">Instance of BsonMapper that map poco classes to document</param>
         /// <param name="password">Password to encrypt you datafile</param>
         /// <param name="timeout">Locker timeout for concurrent access</param>
-        /// <param name="autocommit">If auto commit after any write operation</param>
-        /// <param name="cacheSize">Max memory pages used before flush data in Journal file (when avaiable)</param>
+        /// <param name="cacheSize">Max memory pages used before flush data in Journal file (when available)</param>
         /// <param name="log">Custom log implementation</param>
         public LiteDatabase(IDiskService diskService, BsonMapper mapper = null, string password = null, TimeSpan? timeout = null, int cacheSize = 5000, Logger log = null)
         {
@@ -155,7 +154,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Checks if a collection exists on database. Collection name is case unsensitive
+        /// Checks if a collection exists on database. Collection name is case insensitive
         /// </summary>
         public bool CollectionExists(string name)
         {
@@ -198,14 +197,14 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Reduce disk size re-arranging unused spaces. Can change password. If temporary disk was not provided, use MemoryStream temp disk
+        /// Reduce disk size re-arranging unused space. Can change password. If a temporary disk was not provided, use MemoryStream temp disk
         /// </summary>
         public long Shrink(string password)
         {
             // if has connection string, use same path
             if (_connectionString != null)
             {
-                // get temp file ("-temp" sufix)
+                // get temp file ("-temp" suffix)
                 var tempFile = FileHelper.GetTempFile(_connectionString.Filename);
 
                 // get temp disk based on temp file

--- a/LiteDB/Document/BsonArray.cs
+++ b/LiteDB/Document/BsonArray.cs
@@ -144,7 +144,7 @@ namespace LiteDB
 
         public override int CompareTo(BsonValue other)
         {
-            // if types are diferent, returns sort type order
+            // if types are different, returns sort type order
             if (other.Type != BsonType.Document) return this.Type.CompareTo(other.Type);
 
             var otherArray = other.AsArray;

--- a/LiteDB/Document/BsonDocument.cs
+++ b/LiteDB/Document/BsonDocument.cs
@@ -229,7 +229,7 @@ namespace LiteDB
 
         public override int CompareTo(BsonValue other)
         {
-            // if types are diferent, returns sort type order
+            // if types are different, returns sort type order
             if (other.Type != BsonType.Document) return this.Type.CompareTo(other.Type);
 
             var thisKeys = this.Keys.ToArray();
@@ -246,10 +246,10 @@ namespace LiteDB
             for (; 0 == result && i < stop; i++)
                 result = this[thisKeys[i]].CompareTo(otherDoc[thisKeys[i]]);
 
-            // are diferents
+            // are different
             if (result != 0) return result;
 
-            // test keys length to check wich is bigger
+            // test keys length to check which is bigger
             if (i == thisLength) return i == otherLength ? 0 : -1;
             return 1;
         }

--- a/LiteDB/Document/BsonValue.cs
+++ b/LiteDB/Document/BsonValue.cs
@@ -152,7 +152,7 @@ namespace LiteDB
                 var enumerable = value as System.Collections.IEnumerable;
                 var dictionary = value as System.Collections.IDictionary;
 
-                // test first for dictionary (becasue IDictionary implement IEnumerable)
+                // test first for dictionary (because IDictionary implements IEnumerable)
                 if (dictionary != null)
                 {
                     var dict = new Dictionary<string, BsonValue>();
@@ -517,7 +517,7 @@ namespace LiteDB
 
         public virtual int CompareTo(BsonValue other)
         {
-            // first, test if types are diferentes
+            // first, test if types are different
             if (this.Type != other.Type)
             {
                 // if both values are number, convert them to Decimal (128 bits) to compare
@@ -533,7 +533,7 @@ namespace LiteDB
                 }
             }
 
-            // for both values with same datatype just compare
+            // for both values with same data type just compare
             switch (this.Type)
             {
                 case BsonType.Null:

--- a/LiteDB/Document/Json/JsonTokenizer.cs
+++ b/LiteDB/Document/Json/JsonTokenizer.cs
@@ -144,7 +144,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Eat all whitespaces - used before a valid token
+        /// Eat all whitespace - used before a valid token
         /// </summary>
         private void EatWhitespace()
         {
@@ -247,15 +247,15 @@ namespace LiteDB
             return p1 + p2 + p3 + p4;
         }
 
-        private uint ParseSingleChar(char c1, uint multipliyer)
+        private uint ParseSingleChar(char c1, uint multiplier)
         {
             uint p1 = 0;
             if (c1 >= '0' && c1 <= '9')
-                p1 = (uint)(c1 - '0') * multipliyer;
+                p1 = (uint)(c1 - '0') * multiplier;
             else if (c1 >= 'A' && c1 <= 'F')
-                p1 = (uint)((c1 - 'A') + 10) * multipliyer;
+                p1 = (uint)((c1 - 'A') + 10) * multiplier;
             else if (c1 >= 'a' && c1 <= 'f')
-                p1 = (uint)((c1 - 'a') + 10) * multipliyer;
+                p1 = (uint)((c1 - 'a') + 10) * multiplier;
             return p1;
         }
     }

--- a/LiteDB/Document/ObjectId.cs
+++ b/LiteDB/Document/ObjectId.cs
@@ -128,7 +128,9 @@ namespace LiteDB
         #region Equals/CompareTo/ToString
 
         /// <summary>
-        /// Equalses the specified other.
+        /// Checks if this ObjectId is equal to the given object. Returns true
+        /// if the given object is equal to the value of this instance. 
+        /// Returns false otherwise.
         /// </summary>
         public bool Equals(ObjectId other)
         {

--- a/LiteDB/Engine/Disks/FileDiskService.cs
+++ b/LiteDB/Engine/Disks/FileDiskService.cs
@@ -60,10 +60,10 @@ namespace LiteDB
             // get log instance to disk
             _log = log;
 
-            // if is readonly, journal must be disabled
+            // if is read only, journal must be disabled
             if (_options.FileMode == FileMode.ReadOnly) _options.Journal = false;
 
-            // open/create file using readonly/exclusive options
+            // open/create file using read only/exclusive options
             _stream = new FileStream(_filename,
                 _options.FileMode == FileMode.ReadOnly ? System.IO.FileMode.Open : System.IO.FileMode.OpenOrCreate,
                 _options.FileMode == FileMode.ReadOnly ? FileAccess.Read : FileAccess.ReadWrite,
@@ -231,7 +231,7 @@ namespace LiteDB
         /// </summary>
         public IEnumerable<byte[]> ReadJournal()
         {
-            // check if exists journal file (if opended)
+            // check if exists journal file (if opened)
             if (_journal == null)
             {
                 try
@@ -274,7 +274,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Clear jounal file (set size to 0 length)
+        /// Clear journal file (set size to 0 length)
         /// </summary>
         public void ClearJournal()
         {

--- a/LiteDB/Engine/Disks/IDiskService.cs
+++ b/LiteDB/Engine/Disks/IDiskService.cs
@@ -52,12 +52,12 @@ namespace LiteDB
         void WriteJournal(ICollection<byte[]> pages);
 
         /// <summary>
-        /// Clear jounal file
+        /// Clear journal file
         /// </summary>
         void ClearJournal();
 
         /// <summary>
-        /// Lock datafile returing lock position
+        /// Lock datafile returning lock position
         /// </summary>
         void Lock(LockState state);
 

--- a/LiteDB/Engine/Engine/Find.cs
+++ b/LiteDB/Engine/Engine/Find.cs
@@ -37,7 +37,7 @@ namespace LiteDB
                     byte[] buffer;
                     BsonDocument doc;
 
-                    // encapsulate read operation inside a try/catch (yeild do not support try/catch)
+                    // encapsulate read operation inside a try/catch (yield do not support try/catch)
                     buffer = _data.Read(node.DataBlock);
                     doc = BsonSerializer.Deserialize(buffer).AsDocument;
 

--- a/LiteDB/Engine/Engine/Index.cs
+++ b/LiteDB/Engine/Engine/Index.cs
@@ -6,7 +6,7 @@ namespace LiteDB
     public partial class LiteEngine
     {
         /// <summary>
-        /// Create a new index (or do nothing if already exisits) to a collection/field
+        /// Create a new index (or do nothing if already exists) to a collection/field
         /// </summary>
         public bool EnsureIndex(string colName, string field, bool unique = false)
         {

--- a/LiteDB/Engine/LiteEngine.cs
+++ b/LiteDB/Engine/LiteEngine.cs
@@ -147,7 +147,7 @@ namespace LiteDB
         #endregion
 
         /// <summary>
-        /// Get the collection page only when nedded. Gets from pager always to garantee that wil be the last (in case of clear cache will get a new one - pageID never changes)
+        /// Get the collection page only when needed. Gets from pager always to grantee that wil be the last (in case of clear cache will get a new one - pageID never changes)
         /// </summary>
         private CollectionPage GetCollectionPage(string name, bool addIfNotExits)
         {

--- a/LiteDB/Engine/Pages/BasePage.cs
+++ b/LiteDB/Engine/Pages/BasePage.cs
@@ -19,7 +19,7 @@ namespace LiteDB
         public const int PAGE_HEADER_SIZE = 25;
 
         /// <summary>
-        /// Bytes avaiable to store data removing page header size - 4071 bytes
+        /// Bytes available to store data removing page header size - 4071 bytes
         /// </summary>
         public const int PAGE_AVAILABLE_BYTES = PAGE_SIZE - PAGE_HEADER_SIZE;
 
@@ -46,7 +46,7 @@ namespace LiteDB
         public uint NextPageID { get; set; }
 
         /// <summary>
-        /// Used for all pages to count itens inside this page(bytes, nodes, blocks, ...) [2 bytes]
+        /// Used for all pages to count items inside this page(bytes, nodes, blocks, ...) [2 bytes]
         /// Its Int32 but writes in UInt16
         /// </summary>
         public int ItemCount { get; set; }
@@ -59,7 +59,7 @@ namespace LiteDB
         public int FreeBytes { get; set; }
 
         /// <summary>
-        /// Indicate that this page is dirty (was modified) and must persist when commited [not-persistable]
+        /// Indicate that this page is dirty (was modified) and must persist when committed [not-persistable]
         /// </summary>
         public bool IsDirty { get; set; }
 
@@ -79,7 +79,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Every page must imeplement this ItemCount + FreeBytes
+        /// Every page must implement this ItemCount + FreeBytes
         /// Must be called after Items are updates (insert/deletes) to keep variables ItemCount and FreeBytes synced
         /// </summary>
         public abstract void UpdateItemCount();

--- a/LiteDB/Engine/Pages/CollectionPage.cs
+++ b/LiteDB/Engine/Pages/CollectionPage.cs
@@ -11,7 +11,7 @@ namespace LiteDB
     internal class CollectionPage : BasePage
     {
         /// <summary>
-        /// Represent maximun bytes that all collections names can be used in header
+        /// Represent maximum bytes that all collections names can be used in header
         /// </summary>
         public const ushort MAX_COLLECTIONS_SIZE = 3000;
 

--- a/LiteDB/Engine/Pages/HeaderPage.cs
+++ b/LiteDB/Engine/Pages/HeaderPage.cs
@@ -26,7 +26,7 @@ namespace LiteDB
         public ushort ChangeID { get; set; }
 
         /// <summary>
-        /// Get/Set the pageID that start sequenece with a complete empty pages (can be used as a new page)
+        /// Get/Set the pageID that start sequence with a complete empty pages (can be used as a new page)
         /// Must be a field to be used as "ref"
         /// </summary>
         public uint FreeEmptyPageID;

--- a/LiteDB/Engine/Query/QueryStartsWith.cs
+++ b/LiteDB/Engine/Query/QueryStartsWith.cs
@@ -34,7 +34,7 @@ namespace LiteDB
                 }
                 else
                 {
-                    break; // if not more startswith, stop scanning
+                    break; // if no more starts with, stop scanning
                 }
 
                 node = indexer.GetNode(node.Next[0]);

--- a/LiteDB/Engine/Services/DataService.cs
+++ b/LiteDB/Engine/Services/DataService.cs
@@ -15,14 +15,14 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Insert data inside a datapage. Returns dataPageID that idicates the first page
+        /// Insert data inside a datapage. Returns dataPageID that indicates the first page
         /// </summary>
         public DataBlock Insert(CollectionPage col, byte[] data)
         {
             // need to extend (data is bigger than 1 page)
             var extend = (data.Length + DataBlock.DATA_BLOCK_FIXED_SIZE) > BasePage.PAGE_AVAILABLE_BYTES;
 
-            // if extend, just search for a page with BLOCK_SIZE avaiable
+            // if extend, just search for a page with BLOCK_SIZE available
             var dataPage = _pager.GetFreePage<DataPage>(col.FreeDataPageID, extend ? DataBlock.DATA_BLOCK_FIXED_SIZE : data.Length + DataBlock.DATA_BLOCK_FIXED_SIZE);
 
             // create a new block with first empty index on DataPage
@@ -62,7 +62,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Update data inside a datapage. If new data can be used in same datapage, just update. Otherside, copy content to a new ExtendedPage
+        /// Update data inside a datapage. If new data can be used in same datapage, just update. Otherwise, copy content to a new ExtendedPage
         /// </summary>
         public DataBlock Update(CollectionPage col, PageAddress blockAddress, byte[] data)
         {

--- a/LiteDB/Engine/Services/IndexService.cs
+++ b/LiteDB/Engine/Services/IndexService.cs
@@ -139,9 +139,9 @@ namespace LiteDB
 
                 if (i <= (level - 1)) // level == length
                 {
-                    // cur = current (imediatte before - prev)
+                    // cur = current (immediately before - prev)
                     // node = new inserted node
-                    // next = next node (where cur is poiting)
+                    // next = next node (where cur is pointing)
                     _pager.SetDirty(cur.Page);
 
                     node.Next[i] = cur.Next[i];
@@ -190,17 +190,17 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Get all node list from any index node (go fordward and backward)
+        /// Gets all node list from any index node (go forward and backward)
         /// </summary>
         public IEnumerable<IndexNode> GetNodeList(IndexNode node, bool includeInitial)
         {
             var next = node.NextNode;
             var prev = node.PrevNode;
 
-            // returns some inital node
+            // returns some initial node
             if (includeInitial) yield return node;
 
-            // go fordward
+            // go forward
             while (next.IsEmpty == false)
             {
                 var n = this.GetNode(next);
@@ -218,7 +218,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Delete indexNode from a Index  ajust Next/Prev nodes
+        /// Deletes an indexNode from a Index and adjust Next/Prev nodes
         /// </summary>
         public void Delete(CollectionIndex index, PageAddress nodeAddress)
         {
@@ -230,7 +230,7 @@ namespace LiteDB
 
             for (int i = node.Prev.Length - 1; i >= 0; i--)
             {
-                // get previus and next nodes (between my deleted node)
+                // get previous and next nodes (between my deleted node)
                 var prev = this.GetNode(node.Prev[i]);
                 var next = this.GetNode(node.Next[i]);
 
@@ -394,7 +394,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Go first/last occurence of this index value
+        /// Goto the first/last occurrence of this index value
         /// </summary>
         private IndexNode FindBoundary(CollectionIndex index, IndexNode cur, BsonValue value, int order, int level)
         {

--- a/LiteDB/Engine/Services/PageService.cs
+++ b/LiteDB/Engine/Services/PageService.cs
@@ -156,7 +156,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Returns a page that contains space enouth to data to insert new object - if not exits, create a new Page
+        /// Returns a page that contains space enough to data to insert new object - if one does not exit, creates a new page.
         /// </summary>
         public T GetFreePage<T>(uint startPageID, int size)
             where T : BasePage
@@ -200,7 +200,7 @@ namespace LiteDB
                 }
                 else
                 {
-                    // othersie this page is already in this list, lets move do put in free size desc order
+                    // otherwise this page is already in this list, lets move do put in free size desc order
                     this.MoveToFreeList(page, startPage, ref fieldPageID);
                 }
             }
@@ -302,7 +302,7 @@ namespace LiteDB
                 this.SetDirty(prevPage);
             }
 
-            // if my page is not the last on sequence, ajust the last page (set as dirty)
+            // if my page is not the last on sequence, adjust the last page (set as dirty)
             if (page.NextPageID != uint.MaxValue)
             {
                 var nextPage = this.GetPage<BasePage>(page.NextPageID);
@@ -317,7 +317,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// When a page is already on a list it's more efficient just move comparing with sinblings
+        /// When a page is already on a list it's more efficient just move comparing with siblings
         /// </summary>
         private void MoveToFreeList(BasePage page, BasePage startPage, ref uint fieldPageID)
         {

--- a/LiteDB/Engine/Services/TransactionService.cs
+++ b/LiteDB/Engine/Services/TransactionService.cs
@@ -5,7 +5,7 @@ using System.Linq;
 namespace LiteDB
 {
     /// <summary>
-    /// Manage all transaction and garantee concurrency and recovery
+    /// Manages all transactions and grantees concurrency and recovery
     /// </summary>
     internal class TransactionService
     {
@@ -102,7 +102,7 @@ namespace LiteDB
         /// </summary>
         public void AvoidDirtyRead()
         {
-            // if disk are exclusive dont need check dirty read
+            // if disk are exclusive don't need check dirty read
             if (_disk.IsExclusive) return;
 
             _log.Write(Logger.CACHE, "checking disk to avoid dirty read");

--- a/LiteDB/Engine/Structures/PageAddress.cs
+++ b/LiteDB/Engine/Structures/PageAddress.cs
@@ -3,7 +3,7 @@
 namespace LiteDB
 {
     /// <summary>
-    /// Represents a page adress inside a page structure - index could be byte offset position OR index in a list (6 bytes)
+    /// Represents a page address inside a page structure - index could be byte offset position OR index in a list (6 bytes)
     /// </summary>
     internal struct PageAddress
     {

--- a/LiteDB/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Mapper/BsonMapper.Deserialize.cs
@@ -151,7 +151,7 @@ namespace LiteDB
                     if (type == null) throw LiteException.InvalidTypedName(typeField.AsString);
                 }
 
-                var o = _typeInstanciator(type);
+                var o = _typeInstantiator(type);
 
                 if (o is IDictionary && type.GetTypeInfo().IsGenericType)
                 {

--- a/LiteDB/Mapper/BsonMapper.cs
+++ b/LiteDB/Mapper/BsonMapper.cs
@@ -38,9 +38,9 @@ namespace LiteDB
         private Dictionary<Type, Func<BsonValue, object>> _customDeserializer = new Dictionary<Type, Func<BsonValue, object>>();
 
         /// <summary>
-        /// Get type initializator to support IoC
+        /// Type instantiator function to support IoC
         /// </summary>
-        private readonly Func<Type, object> _typeInstanciator;
+        private readonly Func<Type, object> _typeInstantiator;
 
         /// <summary>
         /// Map for autoId type based functions
@@ -91,7 +91,7 @@ namespace LiteDB
 
         #endregion
 
-        public BsonMapper(Func<Type, object> customTypeInstanciator = null)
+        public BsonMapper(Func<Type, object> customTypeInstantiator = null)
         {
             this.SerializeNullValues = false;
             this.TrimWhitespace = true;
@@ -102,7 +102,7 @@ namespace LiteDB
             this.IncludeFields = false;
 #endif
 
-            _typeInstanciator = customTypeInstanciator ?? Reflection.CreateInstance;
+            _typeInstantiator = customTypeInstantiator ?? Reflection.CreateInstance;
 
             #region Register CustomTypes
 
@@ -241,7 +241,7 @@ namespace LiteDB
         private Regex _lowerCaseDelimiter = new Regex("(?!(^[A-Z]))([A-Z])");
 
         /// <summary>
-        /// Use lower camel case with delemiter resolution for convert property names to field names
+        /// Uses lower camel case with delimiter to convert property names to field names
         /// </summary>
         public BsonMapper UseLowerCaseDelimiter(char delimiter = '_')
         {
@@ -277,7 +277,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Use this method to override how your class can be, by defalut, mapped from entity to Bson document.
+        /// Use this method to override how your class can be, by default, mapped from entity to Bson document.
         /// Returns an EntityMapper from each requested Type
         /// </summary>
         protected virtual EntityMapper BuildEntityMapper(Type type)
@@ -327,7 +327,7 @@ namespace LiteDB
                 // check if property has [BsonId] to get with was setted AutoId = true
                 var autoId = (BsonIdAttribute)memberInfo.GetCustomAttributes(idAttr, false).FirstOrDefault();
 
-                // checks if this proerty has [BsonIndex]
+                // checks if this property has [BsonIndex]
                 var index = (BsonIndexAttribute)memberInfo.GetCustomAttributes(indexAttr, false).FirstOrDefault();
 
                 // get data type
@@ -422,7 +422,7 @@ namespace LiteDB
         #region Register DbRef
 
         /// <summary>
-        /// Register a property mapper as DbRef to serialize/deserialize only document refenece _id
+        /// Register a property mapper as DbRef to serialize/deserialize only document reference _id
         /// </summary>
         public static void RegisterDbRef(BsonMapper mapper, MemberMapper member, string collectionName)
         {

--- a/LiteDB/Mapper/Linq/QueryVisitor.cs
+++ b/LiteDB/Mapper/Linq/QueryVisitor.cs
@@ -308,7 +308,7 @@ namespace LiteDB
 
                 if (prop == null) throw LiteException.PropertyNotMapped(property);
 
-                // if property is a IEnumerable, gets underlayer type (otherwise, gets PropertyType)
+                // if property is an IEnumerable, gets underlying type (otherwise, gets PropertyType)
                 type = prop.UnderlyingType;
 
                 fields[i] = prop.FieldName;

--- a/LiteDB/Storage/LiteFileInfo.cs
+++ b/LiteDB/Storage/LiteFileInfo.cs
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 namespace LiteDB
 {
     /// <summary>
-    /// Represets a file inside storage collection
+    /// Represents a file inside storage collection
     /// </summary>
     public class LiteFileInfo
     {

--- a/LiteDB/Storage/LiteStorage.cs
+++ b/LiteDB/Storage/LiteStorage.cs
@@ -74,7 +74,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Upload a file based on filesystem data
+        /// Upload a file based on file system data
         /// </summary>
         public LiteFileInfo Upload(string id, string filename)
         {
@@ -85,7 +85,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Update metada on a file. File must exisits
+        /// Update metadata on a file. File must exist.
         /// </summary>
         public bool SetMetadata(string id, BsonDocument metadata)
         {

--- a/LiteDB/Upgrade/V6/Pages/BasePage.cs
+++ b/LiteDB/Upgrade/V6/Pages/BasePage.cs
@@ -19,7 +19,7 @@ namespace LiteDB_V6
         public const int PAGE_HEADER_SIZE = 25;
 
         /// <summary>
-        /// Bytes avaiable to store data removing page header size - 4071 bytes
+        /// Bytes available to store data removing page header size - 4071 bytes
         /// </summary>
         public const int PAGE_AVAILABLE_BYTES = PAGE_SIZE - PAGE_HEADER_SIZE;
 
@@ -46,7 +46,7 @@ namespace LiteDB_V6
         public uint NextPageID { get; set; }
 
         /// <summary>
-        /// Used for all pages to count itens inside this page(bytes, nodes, blocks, ...) [2 bytes]
+        /// Used for all pages to count items inside this page(bytes, nodes, blocks, ...) [2 bytes]
         /// Its Int32 but writes in UInt16
         /// </summary>
         public int ItemCount { get; set; }

--- a/LiteDB/Upgrade/V6/Pages/HeaderPage.cs
+++ b/LiteDB/Upgrade/V6/Pages/HeaderPage.cs
@@ -21,12 +21,12 @@ namespace LiteDB_V6
         private const byte FILE_VERSION = 6;
 
         /// <summary>
-        /// Get/Set the changeID of data. When a client read pages, all pages are in the same version. But when OpenTransaction, we need validade that current changeID is the sabe that we have in cache
+        /// Get/Set the changeID of data. When a client read pages, all pages are in the same version. But when OpenTransaction, we need validate that current changeID is the same that we have in cache
         /// </summary>
         public ushort ChangeID { get; set; }
 
         /// <summary>
-        /// Get/Set the pageID that start sequenece with a complete empty pages (can be used as a new page)
+        /// Get/Set the pageID that start sequence with a complete empty pages (can be used as a new page)
         /// </summary>
         public uint FreeEmptyPageID;
 

--- a/LiteDB/Upgrade/V6/Services/FileDiskService.cs
+++ b/LiteDB/Upgrade/V6/Services/FileDiskService.cs
@@ -54,7 +54,7 @@ namespace LiteDB_V6
             // read bytes from data file
             _stream.Read(buffer, 0, BasePage.PAGE_SIZE);
 
-            // when read header, checks passoword
+            // when reading the header, check the password
             if (pageID == 0 && _crypto != null)
             {
                 // I know, header page will be double read (it's the price for isolated concerns)

--- a/LiteDB/Upgrade/V6/Services/IndexService.cs
+++ b/LiteDB/Upgrade/V6/Services/IndexService.cs
@@ -10,7 +10,7 @@ namespace LiteDB_V6
     internal class IndexService
     {
         /// <summary>
-        /// Max size of a index entry - usde for string, binary, array and documents
+        /// Max size of a index entry - used for string, binary, array and documents
         /// </summary>
         public const int MAX_INDEX_LENGTH = 512;
 

--- a/LiteDB/Utils/AesEncryption.cs
+++ b/LiteDB/Utils/AesEncryption.cs
@@ -86,7 +86,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Generate an Salt key that will storaged inside first page database
+        /// Generate a salt key that will be stored inside first page database
         /// </summary>
         /// <returns></returns>
         public static byte[] Salt(int maxLength = 16)

--- a/LiteDB/Utils/ConnectionString.cs
+++ b/LiteDB/Utils/ConnectionString.cs
@@ -27,12 +27,12 @@ namespace LiteDB
         public bool Journal { get; private set; }
 
         /// <summary>
-        /// "password": Encrypt (using AES) your datafile with a password (defult: null - no encryption)
+        /// "password": Encrypt (using AES) your datafile with a password (default: null - no encryption)
         /// </summary>
         public string Password { get; private set; }
 
         /// <summary>
-        /// "cache size": Max number of pages in cache. After this size, flush data to disk to avoid too memory usage (defult: 5000)
+        /// "cache size": Max number of pages in cache. After this size, flush data to disk to avoid too memory usage (default: 5000)
         /// </summary>
         public int CacheSize { get; private set; }
 
@@ -47,17 +47,17 @@ namespace LiteDB
         public FileMode Mode { get; private set; }
 
         /// <summary>
-        /// "initial size": If database is new, initialize with allocated space - support KB, MB, GB (defult: null)
+        /// "initial size": If database is new, initialize with allocated space - support KB, MB, GB (default: null)
         /// </summary>
         public long InitialSize { get; private set; }
 
         /// <summary>
-        /// "limit size": Max limit of datafile - support KB, MB, GB (defult: null)
+        /// "limit size": Max limit of datafile - support KB, MB, GB (default: null)
         /// </summary>
         public long LimitSize { get; private set; }
 
         /// <summary>
-        /// "log": Debug messages from database - use `LiteDatabase.Log` (defult: Logger.NONE)
+        /// "log": Debug messages from database - use `LiteDatabase.Log` (default: Logger.NONE)
         /// </summary>
         public byte Log { get; private set; }
 

--- a/LiteDB/Utils/FileHelper.cs
+++ b/LiteDB/Utils/FileHelper.cs
@@ -14,17 +14,17 @@ namespace LiteDB
         /// <summary>
         /// Create a temp filename based on original filename - checks if file exists (if exists, append counter number)
         /// </summary>
-        public static string GetTempFile(string filename, string sufix = "-temp", bool checkIfExists = true)
+        public static string GetTempFile(string filename, string suffix = "-temp", bool checkIfExists = true)
         {
             var count = 0;
             var temp = Path.Combine(Path.GetDirectoryName(filename), 
-                Path.GetFileNameWithoutExtension(filename) + sufix + 
+                Path.GetFileNameWithoutExtension(filename) + suffix + 
                 Path.GetExtension(filename));
 
             while(checkIfExists && File.Exists(temp))
             {
                 temp = Path.Combine(Path.GetDirectoryName(filename),
-                    Path.GetFileNameWithoutExtension(filename) + sufix +
+                    Path.GetFileNameWithoutExtension(filename) + suffix +
                     "-" + (++count) +
                     Path.GetExtension(filename));
             }

--- a/LiteDB/Utils/IndexNotFoundException.cs
+++ b/LiteDB/Utils/IndexNotFoundException.cs
@@ -3,7 +3,7 @@
 namespace LiteDB
 {
     /// <summary>
-    /// A specific exception when a query didnt found an index
+    /// A specific exception when a query didn't found an index
     /// </summary>
     internal class IndexNotFoundException : LiteException
     {

--- a/LiteDB/Utils/LockControl.cs
+++ b/LiteDB/Utils/LockControl.cs
@@ -4,7 +4,7 @@ using System.Threading;
 namespace LiteDB
 {
     /// <summary>
-    /// A class to control dispose locking. Can be a "new lock" - when a lock are not comming form other lock state
+    /// A class to control locking disposal. Can be a "new lock" - when a lock is not not coming from other lock state
     /// </summary>
     public class LockControl : IDisposable
     {


### PR DESCRIPTION
This set of changes fixes up the most obvious spelling and grammar issues with the internal code documentation. Further improvement on the spelling/grammar on some of the method/class XML documentation still needs to be done.