### PR TITLE
Connection string builder

### DIFF
--- a/LiteDB/Database/LiteDatabase.cs
+++ b/LiteDB/Database/LiteDatabase.cs
@@ -36,12 +36,13 @@ namespace LiteDB
 
         #region Ctor
 
-        /// <summary>
-        /// Starts LiteDB database using a connection string for file system database
-        /// </summary>
-        public LiteDatabase(string connectionString, BsonMapper mapper = null)
+        public LiteDatabase(ConnectionString connectionString, BsonMapper mapper = null)
         {
-            _connectionString = new ConnectionString(connectionString);
+            if (connectionString == null)
+            {
+                throw new ArgumentNullException("connectionString");
+            }
+            _connectionString = connectionString;
             _log.Level = _connectionString.Log;
 
             if (_connectionString.Upgrade)
@@ -60,6 +61,13 @@ namespace LiteDB
             };
 
             _engine = new LazyLoad<LiteEngine>(() => new LiteEngine(new FileDiskService(_connectionString.Filename, options), _connectionString.Password, _connectionString.Timeout, _connectionString.CacheSize, _log));
+        }
+
+        /// <summary>
+        /// Starts LiteDB database using a connection string for file system database
+        /// </summary>
+        public LiteDatabase(string connectionString, BsonMapper mapper = null) : this(new ConnectionString(connectionString), mapper)
+        {
         }
 
         /// <summary>
@@ -89,7 +97,7 @@ namespace LiteDB
 
             _mapper = mapper ?? BsonMapper.Global;
 
-            _engine = new LazyLoad<LiteEngine>(() => new LiteEngine(diskService, password: password, timeout: timeout, cacheSize: cacheSize, log: _log ));
+            _engine = new LazyLoad<LiteEngine>(() => new LiteEngine(diskService, password: password, timeout: timeout, cacheSize: cacheSize, log: _log));
         }
 
         #endregion

--- a/LiteDB/Database/LiteDatabase.cs
+++ b/LiteDB/Database/LiteDatabase.cs
@@ -42,6 +42,7 @@ namespace LiteDB
         public LiteDatabase(string connectionString, BsonMapper mapper = null)
         {
             _connectionString = new ConnectionString(connectionString);
+            _log.Level = _connectionString.Log;
 
             if (_connectionString.Upgrade)
             {

--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Engine\Structures\DataBlock.cs" />
     <Compile Include="Engine\Structures\IndexNode.cs" />
     <Compile Include="Engine\Structures\IndexInfo.cs" />
+    <Compile Include="Utils\ConnectionStringBuilder.cs" />
     <Compile Include="Utils\LockControl.cs" />
     <Compile Include="Utils\LockState.cs" />
     <Compile Include="Mapper\Attributes\BsonRefAttribute.cs" />

--- a/LiteDB/Utils/ConnectionStringBuilder.cs
+++ b/LiteDB/Utils/ConnectionStringBuilder.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Text;
+
+namespace LiteDB
+{
+    public class ConnectionStringBuilder
+    {
+        internal const int DefaultCacheSize = 5000;
+        internal static readonly TimeSpan DefaultTimeOut = TimeSpan.FromMinutes(1);
+#if NET35
+        internal const FileMode DefaultFileMode = FileMode.Shared;
+#else
+        internal const FileMode DefaultFileMode = FileMode.Exclusive;
+#endif
+        internal const long DefaultInitialSize = BasePage.PAGE_SIZE * 2;
+        internal const long DefaultLimitSize = long.MaxValue;
+        internal const byte DefaultLogLevel = Logger.NONE;
+        internal const bool DefaultJournal = true;
+        internal const bool DefaultUpgrade = false;
+
+        public ConnectionStringBuilder()
+        {
+            Filename = string.Empty;
+            Journal = DefaultJournal;
+            Password = null;
+            CacheSize = DefaultCacheSize;
+            Timeout = DefaultTimeOut;
+            Mode = DefaultFileMode;
+            InitialSize = DefaultInitialSize;
+            LimitSize = DefaultLimitSize;
+            Log = DefaultLogLevel;
+            Upgrade = DefaultUpgrade;
+        }
+
+        /// <summary>
+        /// "filename": Full path or relative path from DLL directory
+        /// </summary>
+        public string Filename { get; set; }
+
+        /// <summary>
+        /// "journal": Enabled or disable double write check to ensure durability (default: true)
+        /// </summary>
+        public bool Journal { get; set; }
+
+        /// <summary>
+        /// "password": Encrypt (using AES) your datafile with a password (default: null - no encryption)
+        /// </summary>
+        public string Password { get; set; }
+
+        /// <summary>
+        /// "cache size": Max number of pages in cache. After this size, flush data to disk to avoid too memory usage (default: 5000)
+        /// </summary>
+        public int CacheSize { get; set; }
+
+        /// <summary>
+        /// "timeout": Timeout for waiting unlock operations (default: 1 minute)
+        /// </summary>
+        public TimeSpan Timeout { get; set; }
+
+        /// <summary>
+        /// "mode": Define if datafile will be shared, exclusive or read only access (default: Shared)
+        /// </summary>
+        public FileMode Mode { get; set; }
+
+        /// <summary>
+        /// "initial size": If database is new, initialize with allocated space - support KB, MB, GB (default: null)
+        /// </summary>
+        public long InitialSize { get; set; }
+
+        /// <summary>
+        /// "limit size": Max limit of datafile - support KB, MB, GB (default: null)
+        /// </summary>
+        public long LimitSize { get; set; }
+
+        /// <summary>
+        /// "log": Debug messages from database - use `LiteDatabase.Log` (default: Logger.NONE)
+        /// </summary>
+        public byte Log { get; set; }
+
+        /// <summary>
+        /// "upgrade": Test if database is in old version and update if needed (default: false)
+        /// </summary>
+        public bool Upgrade { get; set; }
+
+        public ConnectionString ToConnectionString()
+        {
+            return new ConnectionString(this);
+        }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            if (!string.IsNullOrEmpty(Filename))
+            {
+                sb.AppendFormat("filename=\"{0}\";", Filename);
+            }
+            if (Journal != DefaultJournal)
+            {
+                sb.AppendFormat("journal={0};", DefaultJournal);
+            }
+            if (!string.IsNullOrEmpty(Password))
+            {
+                sb.AppendFormat("password=\"{0}\";", Password);
+            }
+            if (CacheSize != DefaultCacheSize)
+            {
+                sb.AppendFormat("cache size={0};", CacheSize);
+            }
+            if (Timeout != DefaultTimeOut)
+            {
+                sb.AppendFormat("timeout={0};", Timeout);
+            }
+            if (Mode != DefaultFileMode)
+            {
+                sb.AppendFormat("mode={0};", Mode);
+            }
+            if (InitialSize != DefaultInitialSize)
+            {
+                sb.AppendFormat("initial size={0};", InitialSize);
+            }
+            if (LimitSize != DefaultLimitSize)
+            {
+                sb.AppendFormat("limit size={0};", LimitSize);
+            }
+            if (Log != DefaultLogLevel)
+            {
+                sb.AppendFormat("log={0};", Log);
+            }
+            if (Upgrade != DefaultUpgrade)
+            {
+                sb.AppendFormat("upgrade={0};", Upgrade);
+            }
+            return sb.ToString();
+        }
+    }
+}


### PR DESCRIPTION
This is useful because it makes it easier to create a correct Connection String for LiteDB (e.g., no worrying about quoting/escaping parameters - in fact, no roundtrip through a string at all if the new LiteDatabase(ConnectionString) ctor is used).

My use case: I have a desktop app where the user uses a File->Open menu and enters a password. Since I have these two pieces of data as separate strings in my application, this is more robust than having to create a string with the correct syntax (and escaping in case the password contains special characters).