### PR TITLE
Add dotnet core support for shell

### DIFF
--- a/LiteDB.Shell/Commands/Collections/Bulk.cs
+++ b/LiteDB.Shell/Commands/Collections/Bulk.cs
@@ -18,7 +18,7 @@ namespace LiteDB.Shell.Commands
             var col = this.ReadCollection(engine, s);
             var filename = s.Scan(@".*");
 
-            using (var sr = new StreamReader(filename, Encoding.UTF8))
+            using (var sr = new StreamReader(new FileStream(filename, System.IO.FileMode.Open)))
             {
                 var docs = JsonSerializer.DeserializeArray(sr);
 

--- a/LiteDB.Shell/Commands/Console/ShowCollections.cs
+++ b/LiteDB.Shell/Commands/Console/ShowCollections.cs
@@ -14,6 +14,12 @@ namespace LiteDB.Shell.Commands
 
         public void Execute(LiteEngine engine, StringScanner s, Display display, InputCommand input, Env env)
         {
+            if(engine == null)
+            {
+                display.WriteError("No database file currently open.");
+                return;
+            }
+
             var cols = engine.GetCollectionNames().OrderBy(x => x).ToArray();
 
             if (cols.Length > 0)

--- a/LiteDB.Shell/Shell/Env.cs
+++ b/LiteDB.Shell/Shell/Env.cs
@@ -28,7 +28,7 @@ namespace LiteDB.Shell
             var disk = new FileDiskService(this.Filename,
                 new FileOptions
                 {
-                    FileMode = FileMode.Shared,
+                    FileMode = FileMode.Exclusive,
                     Journal = this.Journal
                 });
 

--- a/LiteDB.Shell/Shell/Env.cs
+++ b/LiteDB.Shell/Shell/Env.cs
@@ -28,7 +28,11 @@ namespace LiteDB.Shell
             var disk = new FileDiskService(this.Filename,
                 new FileOptions
                 {
-                    FileMode = FileMode.Exclusive,
+                    #if NET35
+                        FileMode = FileMode.Shared,
+                    #else
+                        FileMode = FileMode.Exclusive,                    
+                    #endif
                     Journal = this.Journal
                 });
 

--- a/LiteDB.Shell/Shell/ShellProgram.cs
+++ b/LiteDB.Shell/Shell/ShellProgram.cs
@@ -66,7 +66,7 @@ namespace LiteDB.Shell
         public static void RegisterCommands(List<ICommand> commands)
         {
             var type = typeof(ICommand);
-            var types = Assembly.GetEntryAssembly()
+            var types = typeof(ShellProgram).GetTypeInfo().Assembly
                 .GetTypes()
                 .Where(p => type.IsAssignableFrom(p) && p.GetTypeInfo().IsClass);
 

--- a/LiteDB.Shell/Shell/ShellProgram.cs
+++ b/LiteDB.Shell/Shell/ShellProgram.cs
@@ -66,9 +66,9 @@ namespace LiteDB.Shell
         public static void RegisterCommands(List<ICommand> commands)
         {
             var type = typeof(ICommand);
-            var types = Assembly.GetExecutingAssembly()
+            var types = Assembly.GetEntryAssembly()
                 .GetTypes()
-                .Where(p => type.IsAssignableFrom(p) && p.IsClass);
+                .Where(p => type.IsAssignableFrom(p) && p.GetTypeInfo().IsClass);
 
             foreach(var cmd in types)
             {

--- a/LiteDB.Shell/project.json
+++ b/LiteDB.Shell/project.json
@@ -1,0 +1,21 @@
+﻿{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "debugType": "portable",
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "LiteDB": "3.0.0"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.1"
+        }
+      },
+      "imports": "dnxcore50"
+    }
+  }
+}


### PR DESCRIPTION
Some minor tweaks so the shell can be built with dotnet core.

I also fixed a null reference exception when running show collections with no database file opened.

This is only lightly tested with basic CRUD operations. :)