### PR TITLE
bug fix: ignoring QueryAll will cause sort to be ignored

### DIFF
--- a/LiteDB.Tests/Database/IndexSortAndFilterTest.cs
+++ b/LiteDB.Tests/Database/IndexSortAndFilterTest.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LiteDB.Tests.Database
+{
+    [TestClass]
+    public class IndexSortAndFilterTest
+    {
+        private LiteCollection<Item> _collection;
+        private TempFile _tempFile;
+        private LiteDatabase _database;
+
+        [TestInitialize]
+        public void Init()
+        {
+            _tempFile = new TempFile();
+            _database = new LiteDatabase(_tempFile.Filename);
+            _collection = _database.GetCollection<Item>("items");
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _database.Dispose();
+            _tempFile.Dispose();
+        }
+
+        [TestMethod]
+        public void FilterAndSortAscending()
+        {
+            _collection.EnsureIndex(nameof(Item.Value));
+
+            PrepareData(_collection);
+            var result = FilterAndSortById(_collection, Query.Ascending);
+
+            Assert.AreEqual("B", result[0].Id);
+            Assert.AreEqual("C", result[1].Id);
+        }
+
+        [TestMethod]
+        public void FilterAndSortAscendingWithoutIndex()
+        {
+            PrepareData(_collection);
+            var result = FilterAndSortById(_collection, Query.Ascending);
+
+            Assert.AreEqual("B", result[0].Id);
+            Assert.AreEqual("C", result[1].Id);
+        }
+
+        [TestMethod]
+        public void FilterAndSortDescending()
+        {
+            _collection.EnsureIndex(nameof(Item.Value));
+
+            PrepareData(_collection);
+            var result = FilterAndSortById(_collection, Query.Descending);
+
+            Assert.AreEqual("C", result[0].Id);
+            Assert.AreEqual("B", result[1].Id);
+        }
+
+        private void PrepareData(LiteCollection<Item> collection)
+        {
+            collection.Upsert(new Item() { Id = "C", Value = "Value 1" });
+            collection.Upsert(new Item() { Id = "A", Value = "Value 2" });
+            collection.Upsert(new Item() { Id = "B", Value = "Value 1" });
+        }
+
+        private List<Item> FilterAndSortById(LiteCollection<Item> collection, int order)
+        {
+            var filterQuery = Query.EQ(nameof(Item.Value), "Value 1");
+            var sortQuery = Query.All(order);
+            var query = Query.And(sortQuery, filterQuery);
+
+            var result = collection.Find(query).ToList();
+            return result;
+        }
+
+        public class Item
+        {
+            public string Id { get; set; }
+
+            public string Value { get; set; }
+        }
+    }
+}

--- a/LiteDB.Tests/LiteDB.Tests.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Database\NonIdPocoTest.cs" />
     <Compile Include="Database\NullRefTests.cs" />
     <Compile Include="Database\PredicateBuilderTest.cs" />
+    <Compile Include="Database\IndexSortAndFilterTest.cs" />
     <Compile Include="Mapper\MapperNonPublicTest.cs" />
     <Compile Include="Database\MultiKeyMapperTest.cs" />
     <Compile Include="Database\IncludeTest.cs" />

--- a/LiteDB/Engine/Query/QueryAnd.cs
+++ b/LiteDB/Engine/Query/QueryAnd.cs
@@ -29,10 +29,6 @@ namespace LiteDB
 
         internal override IEnumerable<IndexNode> Run(CollectionPage col, IndexService indexer)
         {
-            // ignore QueryAll on AND expression (in both sides)
-            if (_left is QueryAll) return _right.Run(col, indexer);
-            if (_right is QueryAll) return _left.Run(col, indexer);
-
             var left = _left.Run(col, indexer);
             var right = _right.Run(col, indexer);
 


### PR DESCRIPTION
Sort does not work if filter is also used. Following example from Wiki does not work:

`var results = col.Find(Query.And(Query.All("Age", Query.Descending), Query.Between("Age", 20, 30)), limit: 100);
`

This happens because QueryAll is ignored in QueryAnd