### PR TITLE
add Travis CI build files, targetting dotnet 1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+
+language: csharp
+solution: LiteDB.NetStandard.sln
+install:
+  - sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893
+  - sudo apt-get update
+  - sudo apt-get install dotnet-dev-1.0.1
+
+matrix:
+  include:
+    - os: linux
+      dotnet: none
+      mono: none
+      dist: trusty
+
+script:
+  - dotnet restore ./LiteDB/LiteDB.dotnet.csproj
+  - dotnet build ./LiteDB/LiteDB.dotnet.csproj
+  - dotnet restore ./LiteDB.Tests/LiteDB.Tests.dotnet.csproj
+  - dotnet build ./LiteDB.Tests/LiteDB.Tests.dotnet.csproj
+  - dotnet test ./LiteDB.Tests/LiteDB.Tests.dotnet.csproj
+

--- a/LiteDB.Tests/Concurrency/PerformanceTest.cs
+++ b/LiteDB.Tests/Concurrency/PerformanceTest.cs
@@ -51,10 +51,10 @@ namespace LiteDB.Tests
                 db.Commit();
                 td.Stop();
 
-                Debug.Print("Insert time: " + ti.ElapsedMilliseconds);
-                Debug.Print("EnsureIndex time: " + tx.ElapsedMilliseconds);
-                Debug.Print("Update time: " + tu.ElapsedMilliseconds);
-                Debug.Print("Delete time: " + td.ElapsedMilliseconds);
+                Debug.WriteLine("Insert time: " + ti.ElapsedMilliseconds);
+                Debug.WriteLine("EnsureIndex time: " + tx.ElapsedMilliseconds);
+                Debug.WriteLine("Update time: " + tu.ElapsedMilliseconds);
+                Debug.WriteLine("Delete time: " + td.ElapsedMilliseconds);
             }
         }
 

--- a/LiteDB.Tests/LiteDB.Tests.dotnet.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.dotnet.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
+    <PackageReference Include="CoreCompat.System.Drawing" Version="1.0.0-beta006" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../LiteDB/LiteDB.dotnet.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>
+

--- a/LiteDB/LiteDB.dotnet.csproj
+++ b/LiteDB/LiteDB.dotnet.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+    <AssemblyName>LiteDB</AssemblyName>
+    <PackageId>LiteDB</PackageId>
+    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LiteDB - A .NET NoSQL Document Store in a single data file
 
-[![Join the chat at https://gitter.im/mbdavid/LiteDB](https://badges.gitter.im/mbdavid/LiteDB.svg)](https://gitter.im/mbdavid/LiteDB?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build status](https://ci.appveyor.com/api/projects/status/sfe8he0vik18m033?svg=true)](https://ci.appveyor.com/project/mbdavid/litedb)
+[![Join the chat at https://gitter.im/mbdavid/LiteDB](https://badges.gitter.im/mbdavid/LiteDB.svg)](https://gitter.im/mbdavid/LiteDB?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build status](https://ci.appveyor.com/api/projects/status/sfe8he0vik18m033?svg=true)](https://ci.appveyor.com/project/mbdavid/litedb) [![Build Status](https://travis-ci.org/xied75/LiteDB.svg?branch=master)](https://travis-ci.org/xied75/LiteDB)
 
 LiteDB is a small, fast and lightweight NoSQL embedded database. 
 


### PR DESCRIPTION
These changes would be enough for now to test netstandard code on Travis, only missing an solution file to enable opening solution on VS 2017, will PR that later if needed.

There are two tests failing: https://travis-ci.org/xied75/LiteDB/builds/209813288

Once you merge, you can login to Travis with your GitHub account then switch on Travis build for your main stream and update the README.md to change my travis to yours.