### PR TITLE
Fix NullReferenceException when using FileDiskService during Shrink

### DIFF
--- a/LiteDB/Engine/Engine/Shrink.cs
+++ b/LiteDB/Engine/Engine/Shrink.cs
@@ -57,10 +57,10 @@ namespace LiteDB
 
                 // initialize all services again (crypto can be changed)
                 this.InitializeServices();
+                
+                // return how many bytes are reduced
+                return originalSize - temp.FileLength;
             }
-
-            // return how many bytes are reduced
-            return originalSize - temp.FileLength;
         }
     }
 }


### PR DESCRIPTION
temp.FileLength will throw NullReferenceException after engine is Disposed, because LiteEngine.Dispose() disposes also DiskService (temp).