### PR TITLE
[Shell] Unescape unicode characters before output

### DIFF
--- a/LiteDB.Shell/Shell/Display.cs
+++ b/LiteDB.Shell/Shell/Display.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace LiteDB.Shell
 {
@@ -112,7 +113,7 @@ namespace LiteDB.Shell
 
             foreach (var writer in this.TextWriters)
             {
-                writer.Write(text);
+                writer.Write(Regex.Unescape(text));
             }
         }
 


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/946095/24912656/6fdd51c8-1ed7-11e7-9d44-399ffe4aedbb.png)

After:
![after](https://cloud.githubusercontent.com/assets/946095/24912655/6fd9b27a-1ed7-11e7-9b06-645bd3090d64.png)