### PR TITLE
BsonDocument copies its properties by reference  to KV array

### DIFF
--- a/LiteDB.Tests/Document/DocumentTest.cs
+++ b/LiteDB.Tests/Document/DocumentTest.cs
@@ -33,5 +33,36 @@ namespace LiteDB.Tests
 
             Assert.AreEqual("{\"int\":123,\"arr\":[3.0,2,1,\"zero\",false],\"doc\":{\"a\":\"a\",\"b\":[0]}}", json);
         }
+
+        [TestMethod]
+        public void Document_copies_properties_to_KeyValue_array()
+        {
+            // ARRANGE
+            // create a Bson document with all possible value types
+
+            var document = new BsonDocument();
+            document.Add("string", new BsonValue("string"));
+            document.Add("bool", new BsonValue(true));
+            document.Add("objectId", new BsonValue(ObjectId.NewObjectId()));
+            document.Add("DateTime", new BsonValue(DateTime.Now));
+            document.Add("decimal", new BsonValue((decimal)1));
+            document.Add("double", new BsonValue((double)1.0));
+            document.Add("guid", new BsonValue(Guid.NewGuid()));
+            document.Add("int", new BsonValue((int)1));
+            document.Add("long", new BsonValue((long)1));
+            document.Add("bytes", new BsonValue(new byte[] { (byte)1 }));
+            document.Add("bsonDocument", new BsonDocument());
+
+            // ACT
+            // copy all properties to destination array
+
+            var result = new KeyValuePair<string, BsonValue>[document.Count()];
+            document.CopyTo(result, 0);
+
+            // ASSERT
+            // all BsonValue instances have been added to the array by reference
+
+            Assert.IsTrue(result.All(kv => object.ReferenceEquals(document.Get(kv.Key), kv.Value)));
+        }
     }
 }

--- a/LiteDB/Document/BsonDocument.cs
+++ b/LiteDB/Document/BsonDocument.cs
@@ -334,7 +334,7 @@ namespace LiteDB
 
         public void CopyTo(KeyValuePair<string, BsonValue>[] array, int arrayIndex)
         {
-            throw new NotImplementedException();
+            ((ICollection<KeyValuePair<string, BsonValue>>)this.RawValue).CopyTo(array, arrayIndex);
         }
 
         public bool Remove(KeyValuePair<string, BsonValue> item)


### PR DESCRIPTION
Finally found some time to add code to copy a BsonDocument to an array.
This fixes #557 

I've also added a test because I'm a TDD guy. Please feel free to throw it away if you think this is over the top... i'm used to it :-)

