### PR TITLE
net461 doesn't require additional dependencies

### DIFF
--- a/LiteDB/LiteDB.dotnet.csproj
+++ b/LiteDB/LiteDB.dotnet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard1.4;net461</TargetFrameworks>
     <AssemblyName>LiteDB</AssemblyName>
     <PackageId>LiteDB</PackageId>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
@@ -16,7 +16,7 @@
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
     <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Adding net461 as target framework creates an additional compilation output containing LiteDb.Dll and System.Reflection.TypeExtensions.Dll.

Because net461 doesn't require the implementations in System.Reflection.TypeExtensions.dll the DLL is included in the build only for netstandard1.4. The result is now a single LiteDb.Dll in net461 which depends only on the the net461 framework assemblies.
