### PR TITLE
Added flushing OS cache to medium

### DIFF
--- a/LiteDB/Engine/Disks/FileDiskService.cs
+++ b/LiteDB/Engine/Disks/FileDiskService.cs
@@ -208,6 +208,10 @@ namespace LiteDB
                 _journal.Write(buffer, 0, BasePage.PAGE_SIZE);
             }
 
+#if !NET35
+            _journal.Flush(true);
+#endif
+
             // journal file will be unlocked only in ClearJournal
         }
 
@@ -265,6 +269,16 @@ namespace LiteDB
 
             // unlock journal file
             _journal.TryUnlock(0, 1);
+        }
+
+        /// <summary>
+        /// Ensures all pages from the OS cache are persisted on medium
+        /// </summary>
+        public void Flush()
+        {
+#if !NET35
+            _stream.Flush(true);
+#endif
         }
 
         /// <summary>

--- a/LiteDB/Engine/Disks/IDiskService.cs
+++ b/LiteDB/Engine/Disks/IDiskService.cs
@@ -52,6 +52,11 @@ namespace LiteDB
         void ClearJournal();
 
         /// <summary>
+        /// Ensures all pages from the OS cache are persisted on medium
+        /// </summary>
+        void Flush();
+
+        /// <summary>
         /// Lock datafile returning lock position
         /// </summary>
         void Lock(LockState state, TimeSpan timeout);

--- a/LiteDB/Engine/Disks/StreamDiskService.cs
+++ b/LiteDB/Engine/Disks/StreamDiskService.cs
@@ -149,6 +149,13 @@ namespace LiteDB
         {
         }
 
+        /// <summary>
+        /// No flush implemented
+        /// </summary>
+        public void Flush()
+        {
+        }
+
         #endregion
 
     }

--- a/LiteDB/Engine/Services/TransactionService.cs
+++ b/LiteDB/Engine/Services/TransactionService.cs
@@ -80,6 +80,9 @@ namespace LiteDB
                 // mark all dirty pages in clean pages (all are persisted in disk and are valid pages)
                 _cache.MarkDirtyAsClean();
 
+                // ensure all pages from OS cache has been persisted on medium
+                _disk.Flush();
+
                 // discard journal file
                 _disk.ClearJournal();
             }


### PR DESCRIPTION
This solves #574 . However only the for the portable version, because Flush(true) API has been added in .NET Framework 4 (and works properly since .NET Framework 4.5). So it will not work in .NET Framework 3.5.