### PR TITLE
throw exception if lock cannot be acquired #630

### DIFF
--- a/LiteDB.Tests/Database/LockTimeoutTests.cs
+++ b/LiteDB.Tests/Database/LockTimeoutTests.cs
@@ -1,0 +1,48 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LiteDB.Tests.Database
+{
+    [TestClass]
+    public class LockTimeoutTests
+    {
+        [TestMethod]
+        public void ThrowsExceptionOnLockTimeout()
+        {
+            using (var tmp = new TempFile())
+            {
+                using (var db = new LiteDatabase($"filename={tmp.Filename};timeout=00:00:01"))
+                {
+                    var transactionStarted = new AutoResetEvent(false);
+                    var transactionBlock = new AutoResetEvent(false);
+                    Task.Run(() =>
+                    {
+                        using (db.BeginTrans())
+                        {
+                            transactionStarted.Set();
+                            transactionBlock.WaitOne(TimeSpan.FromSeconds(10));
+                        }
+                    });
+
+                    transactionStarted.WaitOne(TimeSpan.FromSeconds(10));
+                    LiteException lockException = null;
+                    try
+                    {
+                        using (db.BeginTrans())
+                        {
+                        }
+                    }
+                    catch (LiteException e)
+                    {
+                        lockException = e;
+                        transactionBlock.Set();
+                    }
+                    Assert.IsNotNull(lockException);
+                    Assert.AreEqual(LiteException.LOCK_TIMEOUT, lockException.ErrorCode);
+                }
+            }
+        }
+    }
+}

--- a/LiteDB.Tests/Database/LockTimeoutTests.cs
+++ b/LiteDB.Tests/Database/LockTimeoutTests.cs
@@ -17,7 +17,7 @@ namespace LiteDB.Tests.Database
                 {
                     var transactionStarted = new AutoResetEvent(false);
                     var transactionBlock = new AutoResetEvent(false);
-                    Task.Run(() =>
+                    var blockTask = Task.Run(() =>
                     {
                         using (db.BeginTrans())
                         {
@@ -39,6 +39,7 @@ namespace LiteDB.Tests.Database
                         lockException = e;
                         transactionBlock.Set();
                     }
+                    blockTask.Wait();
                     Assert.IsNotNull(lockException);
                     Assert.AreEqual(LiteException.LOCK_TIMEOUT, lockException.ErrorCode);
                 }

--- a/LiteDB.Tests/LiteDB.Tests.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Concurrency\ProcessTest.cs" />
     <Compile Include="Database\BigDatabaseTest.cs" />
     <Compile Include="Database\AutoIndexDatabaseTest.cs" />
+    <Compile Include="Database\LockTimeoutTests.cs" />
     <Compile Include="Database\ULongListTest.cs" />
     <Compile Include="Database\UpgradeScriptTest.cs" />
     <Compile Include="Engine\BulkInsertTest.cs" />

--- a/LiteDB/Engine/Services/LockService.cs
+++ b/LiteDB/Engine/Services/LockService.cs
@@ -232,7 +232,10 @@ namespace LiteDB
             }
 
             // try enter in write mode
-            _thread.TryEnterWriteLock(_timeout);
+            if (!_thread.TryEnterWriteLock(_timeout))
+            {
+                throw LiteException.LockTimeout(_timeout);
+            }
 
             // and release when dispose
             return () => _thread.ExitWriteLock();


### PR DESCRIPTION
If LiteDB cannot acquire lock in given timeout an exception is thrown