### PR TITLE
Remove unused BsonDocument.MAX_DOCUMENT_SIZE

### DIFF
--- a/LiteDB/Document/BsonDocument.cs
+++ b/LiteDB/Document/BsonDocument.cs
@@ -7,8 +7,6 @@ namespace LiteDB
 {
     public class BsonDocument : BsonValue, IDictionary<string, BsonValue>
     {
-        public const int MAX_DOCUMENT_SIZE = 256 * BasePage.PAGE_AVAILABLE_BYTES; // limits in 1.044.224b max document size to avoid large documents, memory usage and slow performance
-
         public BsonDocument()
             : base(new Dictionary<string, BsonValue>())
         {


### PR DESCRIPTION
The maximum document size of 1 megabyte is no longer enforced. Creating bson documents larger than 1 megabyte works fine. BsonDocument.MAX_DOCUMENT_SIZE is not referenced by any code. (The 512 byte size limit for indexed fields remains).