### PR TITLE
Fixed "Property was not mapped into BsonDocument" errors on Expressio…

### DIFF
--- a/LiteDB/Utils/Extensions/ExpressionExtensions.cs
+++ b/LiteDB/Utils/Extensions/ExpressionExtensions.cs
@@ -22,6 +22,14 @@ namespace LiteDB
             // quick and dirty solution to support x.Name.SubName
             // http://stackoverflow.com/questions/671968/retrieving-property-name-from-lambda-expression
 
+            // enum properties seem to get compiled with Convert(prop, Int32) wrapper calls on Mono 5.0+
+            // this causes path extraction code below to fail, since a clean "x.y.z" string is expected
+            // thus we strip out any Converts found, using a loop in case there are nested Convert expressions
+            while (expr.NodeType == ExpressionType.Convert || expr.NodeType == ExpressionType.ConvertChecked)
+            {
+                expr = ((UnaryExpression)expr).Operand;
+            }
+            
             var str = expr.ToString(); // gives you: "o => o.Whatever"
             var firstDelim = str.IndexOf('.'); // make sure there is a beginning property indicator; the "." in "o.Whatever" -- this may not be necessary?
 


### PR DESCRIPTION
…n queries that involve enum properties

It seems that the latest Xamarin (which recently moved to Mono 5.0+ under the hood) compiles Expressions differently - in particular references to Enum properties are now wrapped in a Convert() call.

e.g. col.Find(t => t.MyEnumProp == MyEnum.Something) 
 - used to compile to a clean "t.MyEnumProp" on the left hand side
 - now compiles to "Convert(t.MyEnumProp, Int32)" in latest Xamarin

This code change caters for the potential Convert() wrapping and extracts the inner Operand in order to restore the expected behaviour of the GetPath() method, which in turn is used in various Mapper and Query areas of LiteDb.