### PR TITLE
Added TFM for net45 to avoid improper referencing of net35 in net45+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - os: linux
       dotnet: none
-      mono: 4.6
+      mono: latest
       dist: trusty
 before_install:
   - ./.travis/before-install-$TRAVIS_OS_NAME.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ language: csharp
 matrix:
   include:
     - os: linux
-      dotnet: none
+      dotnet: 1.0.3
       mono: latest
       dist: trusty
-before_install:
-  - ./.travis/before-install-$TRAVIS_OS_NAME.sh
+#before_install:
+#  - ./.travis/before-install-$TRAVIS_OS_NAME.sh
 
 script:
   - dotnet restore ./LiteDB/LiteDB.dotnet.csproj

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - os: linux
       dotnet: none
-      mono: none
+      mono: 4.6
       dist: trusty
 before_install:
   - ./.travis/before-install-$TRAVIS_OS_NAME.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ matrix:
   include:
     - os: linux
       dotnet: 1.0.3
-      mono: latest
+      mono: none
       dist: trusty
-#before_install:
-#  - ./.travis/before-install-$TRAVIS_OS_NAME.sh
+before_install:
+  - ./.travis/before-install-$TRAVIS_OS_NAME.sh
 
 script:
   - dotnet restore ./LiteDB/LiteDB.dotnet.csproj

--- a/LiteDB.nuspec
+++ b/LiteDB.nuspec
@@ -17,7 +17,9 @@
     <files>
         <file src="LiteDB\bin\Release\net35\LiteDB.dll" target="lib\net35\LiteDB.dll" />
         <file src="LiteDB\bin\Release\net35\LiteDB.xml" target="lib\net35\LiteDB.xml" />
-        <file src="LiteDB\bin\Release\netstandard\LiteDB.dll" target="lib\netstandard1.4\LiteDB.dll" />
-        <file src="LiteDB\bin\Release\netstandard\LiteDB.xml" target="lib\netstandard1.4\LiteDB.xml" />
+        <file src="LiteDB\bin\Release\net45\LiteDB.dll" target="lib\net45\LiteDB.dll" />
+        <file src="LiteDB\bin\Release\net45\LiteDB.xml" target="lib\net45\LiteDB.xml" />
+        <file src="LiteDB\bin\Release\netstandard1.4\LiteDB.dll" target="lib\netstandard1.4\LiteDB.dll" />
+        <file src="LiteDB\bin\Release\netstandard1.4\LiteDB.xml" target="lib\netstandard1.4\LiteDB.xml" />
     </files>
 </package>

--- a/LiteDB/LiteDB.dotnet.csproj
+++ b/LiteDB/LiteDB.dotnet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard1.4;net45</TargetFrameworks>
     <AssemblyName>LiteDB</AssemblyName>
     <PackageId>LiteDB</PackageId>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
@@ -17,8 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Condition="'$(TargetFramework)' == 'netstandard1.4'" Include="System.Reflection.TypeExtensions" Version="4.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #656 

I didn't bump the version.
Please note that I have changed the netstandard1.4 reference from Release\netstandard to Release\netstandard1.4 (generated by LiteDB.dotnet.csproj)

