### PR TITLE
Alternative fix for #657 (TFM for net45)

### DIFF
--- a/LiteDB.Shell/Properties/AssemblyInfo.cs
+++ b/LiteDB.Shell/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("01ce385b-31a7-4b1a-9487-23fe8acb3888")]
-[assembly: AssemblyVersion("3.1.1.0")]
-[assembly: AssemblyFileVersion("3.1.1.0")]
+[assembly: AssemblyVersion("3.1.2.0")]
+[assembly: AssemblyFileVersion("3.1.2.0")]
 [assembly: NeutralResourcesLanguage("en")]
 

--- a/LiteDB.Tests/Properties/AssemblyInfo.cs
+++ b/LiteDB.Tests/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: NeutralResourcesLanguage("en")]
 [assembly: ComVisible(false)]
 [assembly: Guid("de183e83-7df6-475c-8185-b0070d098821")]
-[assembly: AssemblyVersion("3.1.1.0")]
-[assembly: AssemblyFileVersion("3.1.1.0")]
+[assembly: AssemblyVersion("3.1.2.0")]
+[assembly: AssemblyFileVersion("3.1.2.0")]

--- a/LiteDB.nuspec
+++ b/LiteDB.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
     <metadata>
         <id>LiteDB</id>
-        <version>3.1.1</version>
+        <version>3.1.2</version>
         <title>LiteDB</title>
         <authors>Mauricio David</authors>
         <projectUrl>http://www.litedb.org</projectUrl>
@@ -17,6 +17,8 @@
     <files>
         <file src="LiteDB\bin\Release\net35\LiteDB.dll" target="lib\net35\LiteDB.dll" />
         <file src="LiteDB\bin\Release\net35\LiteDB.xml" target="lib\net35\LiteDB.xml" />
+        <file src="LiteDB\bin\Release\netstandard\LiteDB.dll" target="lib\net45\LiteDB.dll" />
+        <file src="LiteDB\bin\Release\netstandard\LiteDB.xml" target="lib\net45\LiteDB.xml" />
         <file src="LiteDB\bin\Release\netstandard\LiteDB.dll" target="lib\netstandard1.4\LiteDB.dll" />
         <file src="LiteDB\bin\Release\netstandard\LiteDB.xml" target="lib\netstandard1.4\LiteDB.xml" />
     </files>

--- a/LiteDB/Properties/AssemblyInfo.cs
+++ b/LiteDB/Properties/AssemblyInfo.cs
@@ -13,6 +13,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("54989b5c-4bcf-4d58-b8ba-9b014a324f76")]
-[assembly: AssemblyVersion("3.1.1.0")]
-[assembly: AssemblyFileVersion("3.1.1.0")]
+[assembly: AssemblyVersion("3.1.2.0")]
+[assembly: AssemblyFileVersion("3.1.2.0")]
 [assembly: NeutralResourcesLanguage("en")]


### PR DESCRIPTION
Alternative fix for #657 

This fix does not alter the build process it just adds a proper reference in nupkg and bumps version.

@mbdavid This is quite important and urgent because net45 version still has no protection against #574 because it uses a wrong DLL.