### PR TITLE
ObjectId's Equals should return false when other is null.

### DIFF
--- a/LiteDB.Tests/Engine/ObjectIdTest.cs
+++ b/LiteDB.Tests/Engine/ObjectIdTest.cs
@@ -31,5 +31,15 @@ namespace LiteDB.Tests
 
             Assert.AreEqual(c1, jc1);
         }
+
+        [TestMethod]
+        public void ObjectId_equals_null_does_not_throw()
+        {
+            var oid0 = default(ObjectId);
+            var oid1 = ObjectId.NewObjectId();
+
+            Assert.IsFalse(oid1.Equals(null));
+            Assert.IsFalse(oid1.Equals(oid0));
+        }
     }
 }

--- a/LiteDB/Document/ObjectId.cs
+++ b/LiteDB/Document/ObjectId.cs
@@ -134,7 +134,7 @@ namespace LiteDB
         /// </summary>
         public bool Equals(ObjectId other)
         {
-            return
+            return other != null && 
                 this.Timestamp == other.Timestamp &&
                 this.Machine == other.Machine &&
                 this.Pid == other.Pid &&
@@ -146,12 +146,7 @@ namespace LiteDB
         /// </summary>
         public override bool Equals(object other)
         {
-            if (other is ObjectId)
-            {
-                return this.Equals((ObjectId)other);
-            }
-
-            return false;
+            return Equals(other as ObjectId);
         }
 
         /// <summary>


### PR DESCRIPTION
Current implementation of Equals for ObjectId throws NullReferenceException when other is null when it should return false (see https://msdn.microsoft.com/en-us/library/bsc2ak47(v=vs.110).aspx).
Added test to reproduce the issue then fixed the implementation.