### PR TITLE
Make upsert return true if updating.

### DIFF
--- a/LiteDB/Engine/Engine/Upsert.cs
+++ b/LiteDB/Engine/Engine/Upsert.cs
@@ -33,12 +33,24 @@ namespace LiteDB
 
                 foreach (var doc in docs)
                 {
-                    // first try update document (if exists _id)
-                    // if not found, insert
-                    if (doc["_id"] == BsonValue.Null || this.UpdateDocument(col, doc) == false)
+                    if (doc["_id"] == BsonValue.Null)
                     {
+                        // Try insert document (if doc has no _id)
                         this.InsertDocument(col, doc, autoId);
                         count++;
+                    }
+                    else {
+                        if (this.UpdateDocument(col, doc))
+                        {
+                            // Try update document (if doc has _id)
+                            count++;
+                        }
+                        else
+                        {
+                            // Try insert document (if doc has _id, but couldn't update)
+                            this.InsertDocument(col, doc, autoId);
+                            count++;
+                        }
                     }
 
                     _trans.CheckPoint();


### PR DESCRIPTION
We're looking at switching from SQLite to LiteDB in one of our products, but we found that `false` is returned when doing an `upsert` if the document was updated rather than inserted.

We would argue that the user only cares if an `upsert` worked, and doesn't care if it was actually inserted or updated, so `true` should be returned in both insert and update cases.

This pull request changes the logic of `upsert` in the engine so that the return value of up `UpdateDocument` is accounted for in the `count` variable.