### PR TITLE
reduce exception throw when use complex linq query

### DIFF
--- a/LiteDB/Mapper/Linq/QueryVisitor.cs
+++ b/LiteDB/Mapper/Linq/QueryVisitor.cs
@@ -179,7 +179,7 @@ namespace LiteDB
                     }
                 }
 
-                throw new NotSupportedException("Not implemented Linq expression");
+                return new QueryLinq<T>(expr, _param, _mapper);
             }
             catch(NotSupportedException)
             {


### PR DESCRIPTION
Hi ,  
Actually，it,s not a good idea to use exception for flow control. 
This update can reduce exception throw when use complex linq query.   
When I open  ' break all exception when Common Language Runtime Exceptions happen' in visual studio , it always break when I use complex linq . 