### PR TITLE
Additional constructor in LiteRepository and EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4

--- a/LiteDB/Repository/LiteQueryable.cs
+++ b/LiteDB/Repository/LiteQueryable.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 

--- a/LiteDB/Repository/LiteRepository.cs
+++ b/LiteDB/Repository/LiteRepository.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Linq.Expressions;
 
 namespace LiteDB
@@ -30,27 +29,36 @@ namespace LiteDB
         #region Ctor
 
         /// <summary>
+        /// Creates an instance of the repository.
+        /// </summary>
+        /// <param name="database">The LiteDB database instance.</param>
+        public LiteRepository(LiteDatabase database)
+        {
+            _db = database;
+        }
+
+        /// <summary>
         /// Starts LiteDB database using a connection string for file system database
         /// </summary>
         public LiteRepository(string connectionString, BsonMapper mapper = null)
+            : this(new LiteDatabase(connectionString, mapper))
         {
-            _db = new LiteDB.LiteDatabase(connectionString, mapper);
         }
 
         /// <summary>
         /// Starts LiteDB database using a connection string for file system database
         /// </summary>
         public LiteRepository(ConnectionString connectionString, BsonMapper mapper = null)
+            : this(new LiteDatabase(connectionString, mapper))
         {
-            _db = new LiteDB.LiteDatabase(connectionString, mapper);
         }
 
         /// <summary>
         /// Starts LiteDB database using a Stream disk
         /// </summary>
         public LiteRepository(Stream stream, BsonMapper mapper = null, string password = null)
+            : this (new LiteDatabase(stream, mapper, password))
         {
-            _db = new LiteDB.LiteDatabase(stream, mapper, password);
         }
 
         #endregion
@@ -281,7 +289,8 @@ namespace LiteDB
 
         public void Dispose()
         {
-            _db.Dispose();
+            _db?.Dispose();
+            _db = null;
         }
     }
 }

--- a/LiteDB/Repository/LiteRepository.cs
+++ b/LiteDB/Repository/LiteRepository.cs
@@ -13,6 +13,7 @@ namespace LiteDB
         #region Properties
 
         private LiteDatabase _db = null;
+        private readonly bool _disposeDatabase;
 
         /// <summary>
         /// Get database instance
@@ -31,17 +32,17 @@ namespace LiteDB
         /// <summary>
         /// Creates an instance of the repository.
         /// </summary>
-        /// <param name="database">The LiteDB database instance.</param>
-        public LiteRepository(LiteDatabase database)
+        public LiteRepository(LiteDatabase database, bool disposeDatabase = false)
         {
             _db = database;
+            _disposeDatabase = disposeDatabase;
         }
 
         /// <summary>
         /// Starts LiteDB database using a connection string for file system database
         /// </summary>
         public LiteRepository(string connectionString, BsonMapper mapper = null)
-            : this(new LiteDatabase(connectionString, mapper))
+            : this(new LiteDatabase(connectionString, mapper), true)
         {
         }
 
@@ -49,7 +50,7 @@ namespace LiteDB
         /// Starts LiteDB database using a connection string for file system database
         /// </summary>
         public LiteRepository(ConnectionString connectionString, BsonMapper mapper = null)
-            : this(new LiteDatabase(connectionString, mapper))
+            : this(new LiteDatabase(connectionString, mapper), true)
         {
         }
 
@@ -57,7 +58,7 @@ namespace LiteDB
         /// Starts LiteDB database using a Stream disk
         /// </summary>
         public LiteRepository(Stream stream, BsonMapper mapper = null, string password = null)
-            : this (new LiteDatabase(stream, mapper, password))
+            : this (new LiteDatabase(stream, mapper, password), true)
         {
         }
 
@@ -289,7 +290,11 @@ namespace LiteDB
 
         public void Dispose()
         {
-            _db?.Dispose();
+            if (_disposeDatabase)
+            {
+                _db?.Dispose();
+            }
+
             _db = null;
         }
     }


### PR DESCRIPTION
I added an EditorConfig file in order to set the indentation globally (works on VS2017+ and with ReSharper).

Also I added a LiteRepository constructor which accepts a pre-existent LiteDatabase instance instead of creating a new one (useful in case of an encrypted database or of needing logging for debugging purposes). The new constructor also gives the option to dispose the database's instance together with the repository's. Old constructors have been redirected to the new one for consistency.