### PR TITLE
Fix "new ConnectionString()" not containing default values

### DIFF
--- a/LiteDB.Tests/Database/ConnectionString_Tests.cs
+++ b/LiteDB.Tests/Database/ConnectionString_Tests.cs
@@ -1,8 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.IO;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace LiteDB.Tests.Database
 {
@@ -10,12 +9,21 @@ namespace LiteDB.Tests.Database
     public class ConnectionString_Tests
     {
         [TestMethod]
+        public void ConnectionString_NoArguments()
+        {
+            // Verify that the default ConnectionString contains the appropriate defaults
+            var defaults = new ConnectionString();
+            AssertDefaults(defaults, false);
+        }
+
+        [TestMethod]
         public void ConnectionString_Parser()
         {
             // only filename
             var onlyfile = new ConnectionString(@"demo.db");
 
             Assert.AreEqual(@"demo.db", onlyfile.Filename);
+            AssertDefaults(onlyfile, true);
 
             // file with spaces without "
             var normal = new ConnectionString(@"filename=c:\only file\demo.db; journal=false");
@@ -30,8 +38,7 @@ namespace LiteDB.Tests.Database
             Assert.AreEqual(TimeSpan.FromHours(1), filenameTimeout.Timeout);
 
             // file with spaces with " and ;
-            var full = new ConnectionString(
-                @"filename=""c:\only;file\""d\""emo.db""; 
+            var fullConnectionString = @"filename=""c:\only;file\""d\""emo.db""; 
                   journal =false;
                   password =   ""john-doe "" ;
                   cache SIZE = 1000 ;
@@ -39,7 +46,11 @@ namespace LiteDB.Tests.Database
                   initial size = 10 MB ;
                   mode =  excluSIVE ;
                   limit SIZE = 20mb;
-                  log = 255;utc=true");
+                  log = 255 ;
+                  utc=true ;
+                  upgrade=true;
+                  async=true";
+            var full = new ConnectionString(fullConnectionString);
 
             Assert.AreEqual(@"c:\only;file""d""emo.db", full.Filename);
             Assert.AreEqual(false, full.Journal);
@@ -51,7 +62,8 @@ namespace LiteDB.Tests.Database
             Assert.AreEqual(20 * 1024 * 1024, full.LimitSize);
             Assert.AreEqual(255, full.Log);
             Assert.AreEqual(true, full.UtcDate);
-
+            Assert.AreEqual(true, full.Upgrade);
+            Assert.AreEqual(true, full.Async);
         }
 
         [TestMethod]
@@ -64,6 +76,52 @@ namespace LiteDB.Tests.Database
             connectionString = "filename=foo;log=" + Logger.FULL;
             db = new LiteDatabase(connectionString);
             Assert.AreEqual(Logger.FULL, db.Log.Level);
+        }
+
+        [TestMethod]
+        public void ConnectionString_MetaTest()
+        {
+            // This test is a meta test that verifies that all of the properties present in ConnectionString are also tested by this test.
+            // If this test fails, you should make sure that you don't need to update this test. (In particular, you almost certainly need to update AssertDefaults.)
+            var expectedProperties = new HashSet<string>()
+            {
+                "Filename",
+                "Journal",
+                "Password",
+                "CacheSize",
+                "Timeout",
+                "Mode",
+                "InitialSize",
+                "LimitSize",
+                "Log",
+                "UtcDate",
+                "Upgrade",
+                "Async"
+            };
+
+            var actualProperties = new HashSet<string>(typeof(ConnectionString).GetProperties().Select(p => p.Name));
+            actualProperties.ExceptWith(expectedProperties);
+            
+            // If the below assert fails, properties were added to ConnectionString without updating this test.
+            Assert.AreEqual(0, actualProperties.Count);
+        }
+
+        private void AssertDefaults(ConnectionString connectionString, bool skipFilename)
+        {
+            if (!skipFilename)
+            { Assert.AreEqual("", connectionString.Filename); }
+
+            Assert.AreEqual(true, connectionString.Journal);
+            Assert.AreEqual(null, connectionString.Password);
+            Assert.AreEqual(5000, connectionString.CacheSize);
+            Assert.AreEqual(new TimeSpan(0, 1, 0), connectionString.Timeout);
+            Assert.AreEqual(FileMode.Shared, connectionString.Mode);
+            Assert.AreEqual(0, connectionString.InitialSize);
+            Assert.AreEqual(long.MaxValue, connectionString.LimitSize);
+            Assert.AreEqual(Logger.NONE, connectionString.Log);
+            Assert.AreEqual(false, connectionString.UtcDate);
+            Assert.AreEqual(false, connectionString.Upgrade);
+            Assert.AreEqual(false, connectionString.Async);
         }
     }
 }

--- a/LiteDB/Utils/ConnectionString.cs
+++ b/LiteDB/Utils/ConnectionString.cs
@@ -1,11 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Text.RegularExpressions;
 
 namespace LiteDB
 {
@@ -17,63 +11,67 @@ namespace LiteDB
         /// <summary>
         /// "filename": Full path or relative path from DLL directory
         /// </summary>
-        public string Filename { get; set; }
+        public string Filename { get; set; } = "";
 
         /// <summary>
         /// "journal": Enabled or disable double write check to ensure durability (default: true)
         /// </summary>
-        public bool Journal { get; set; }
+        public bool Journal { get; set; } = true;
 
         /// <summary>
         /// "password": Encrypt (using AES) your datafile with a password (default: null - no encryption)
         /// </summary>
-        public string Password { get; set; }
+        public string Password { get; set; } = null;
 
         /// <summary>
         /// "cache size": Max number of pages in cache. After this size, flush data to disk to avoid too memory usage (default: 5000)
         /// </summary>
-        public int CacheSize { get; set; }
+        public int CacheSize { get; set; } = 5000;
 
         /// <summary>
         /// "timeout": Timeout for waiting unlock operations (default: 1 minute)
         /// </summary>
-        public TimeSpan Timeout { get; set; }
+        public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(1);
 
         /// <summary>
-        /// "mode": Define if datafile will be shared, exclusive or read only access (default: Shared)
+        /// "mode": Define if datafile will be shared, exclusive or read only access (default in environments with file locking: Shared, otherwise: Exclusive)
         /// </summary>
-        public FileMode Mode { get; set; }
+#if HAVE_LOCK
+        public FileMode Mode { get; set; } = FileMode.Shared;
+#else
+        public FileMode Mode { get; set; } = FileMode.Exclusive;
+#endif
 
         /// <summary>
-        /// "initial size": If database is new, initialize with allocated space - support KB, MB, GB (default: null)
+        /// "initial size": If database is new, initialize with allocated space - support KB, MB, GB (default: 0 bytes)
         /// </summary>
-        public long InitialSize { get; set; }
+        public long InitialSize { get; set; } = 0;
 
         /// <summary>
-        /// "limit size": Max limit of datafile - support KB, MB, GB (default: null)
+        /// "limit size": Max limit of datafile - support KB, MB, GB (default: long.MaxValue - no limit)
         /// </summary>
-        public long LimitSize { get; set; }
+        public long LimitSize { get; set; } = long.MaxValue;
 
         /// <summary>
         /// "log": Debug messages from database - use `LiteDatabase.Log` (default: Logger.NONE)
         /// </summary>
-        public byte Log { get; set; }
+        public byte Log { get; set; } = Logger.NONE;
 
         /// <summary>
-        /// "utc": Returns date in UTC timezone from BSON deserialization (default: false == LocalTime)
+        /// "utc": Returns date in UTC timezone from BSON deserialization (default: false - LocalTime)
         /// </summary>
-        public bool UtcDate { get; set; }
+        public bool UtcDate { get; set; } = false;
 
         /// <summary>
         /// "upgrade": Test if database is in old version and update if needed (default: false)
         /// </summary>
-        public bool Upgrade { get; set; }
+        public bool Upgrade { get; set; } = false;
 
 #if HAVE_SYNC_OVER_ASYNC
         /// <summary>
-        /// "async": Use "sync over async" to UWP apps access any directory
+        /// "async": Use "sync over async" to UWP apps access any directory (default: false)
         /// </summary>
-        public bool Async { get; set; }
+        public bool Async { get; set; } = false;
 #endif
 
         /// <summary>
@@ -103,23 +101,19 @@ namespace LiteDB
             }
 
             // setting values to properties
-            this.Filename = values.GetValue("filename", "");
-            this.Journal = values.GetValue("journal", true);
-            this.Password = values.GetValue<string>("password", null);
-            this.CacheSize = values.GetValue(@"cache size", 5000);
-            this.Timeout = values.GetValue("timeout", TimeSpan.FromMinutes(1));
-#if HAVE_LOCK
-            this.Mode = values.GetValue("mode", FileMode.Shared);
-#else
-            this.Mode = values.GetValue("mode", FileMode.Exclusive);
-#endif
-            this.InitialSize = values.GetFileSize(@"initial size", 0);
-            this.LimitSize = values.GetFileSize(@"limit size", long.MaxValue);
-            this.Log = values.GetValue("log", Logger.NONE);
-            this.UtcDate = values.GetValue("utc", false);
-            this.Upgrade = values.GetValue("upgrade", false);
+            this.Filename = values.GetValue("filename", this.Filename);
+            this.Journal = values.GetValue("journal", this.Journal);
+            this.Password = values.GetValue<string>("password", this.Password);
+            this.CacheSize = values.GetValue(@"cache size", this.CacheSize);
+            this.Timeout = values.GetValue("timeout", this.Timeout);
+            this.Mode = values.GetValue("mode", this.Mode);
+            this.InitialSize = values.GetFileSize(@"initial size", this.InitialSize);
+            this.LimitSize = values.GetFileSize(@"limit size", this.LimitSize);
+            this.Log = values.GetValue("log", this.Log);
+            this.UtcDate = values.GetValue("utc", this.UtcDate);
+            this.Upgrade = values.GetValue("upgrade", this.Upgrade);
 #if HAVE_SYNC_OVER_ASYNC
-            this.Async = values.GetValue("async", false);
+            this.Async = values.GetValue("async", this.Async);
 #endif
         }
     }


### PR DESCRIPTION
This an amended version of #883 with suggested property initializer usage and unnecessary LiteDbBuildConfiguration removed.