### PR TITLE
Microfix for ToString method within QueryIn class.

### DIFF
--- a/LiteDB/Engine/Query/QueryIn.cs
+++ b/LiteDB/Engine/Query/QueryIn.cs
@@ -11,7 +11,7 @@ namespace LiteDB
         public QueryIn(string field, IEnumerable<BsonValue> values)
             : base(field)
         {
-            _values = values;
+            _values = values ?? Enumerable.Empty<BsonValue>();
         }
 
         internal override IEnumerable<IndexNode> ExecuteIndex(IndexService indexer, CollectionIndex index)
@@ -45,7 +45,7 @@ namespace LiteDB
             return string.Format("{0}({1} in {2})",
                 this.UseFilter ? "Filter" : this.UseIndex ? "Seek" : "",
                 this.Expression?.ToString() ?? this.Field,
-                _values);
+                 string.Join(",", _values.Select(a => a != null ? a.ToString() : "Null" ).ToArray()));
         }
     }
 }


### PR DESCRIPTION
The **ToString** method in the **QueryIn** class returns only a collection of types with no values. The remaining **Query** classes return all required values as a string. I use this method for the test, and for QueryIn it's not impossible.
I added output of all values, separated by a comma. Maybe it will be interesting to you.
Sorry for poor english.


