### PR TITLE
If FileStream.Lock is not supported, point towards the solution

### DIFF
--- a/LiteDB/Utils/Extensions/StreamExtensions.cs
+++ b/LiteDB/Utils/Extensions/StreamExtensions.cs
@@ -48,6 +48,10 @@ namespace LiteDB
             {
                 return false;
             }
+            catch (PlatformNotSupportedException pex)
+            {
+                throw CreateLockNotSupportedException(pex);
+            }
         }
 
         /// <summary>
@@ -59,8 +63,20 @@ namespace LiteDB
 
             FileHelper.TryExec(() =>
             {
-                stream.Lock(position, length);
+                try
+                {
+                    stream.Lock(position, length);
+                }
+                catch (PlatformNotSupportedException pex)
+                {
+                    throw CreateLockNotSupportedException(pex);
+                }
             }, timeout);
+        }
+
+        private static Exception CreateLockNotSupportedException(PlatformNotSupportedException innerEx)
+        {
+            throw new InvalidOperationException("Your platform does not support FileStream.Lock. Please set mode=Exclusive in your connnection string to avoid this error.", innerEx);
         }
 #endif
     }


### PR DESCRIPTION
Ran into this issue on OS X, same as #787 and #908 

Unfortunately, .net Core has no way to see if FileStream.Lock is supported, the code [just throws an Exception](https://github.com/dotnet/corefx/blob/cbdc1817946b44b747c481a3782450d8d2a54942/src/Common/src/CoreLib/System/IO/FileStream.OSX.cs).

One option would be to try to open and Lock the file during `FileDiskService.Initialize`, and change to Exclusive if it throws, but that would be a bigger functional change than just catching and showing the message.