### PR TITLE
Added StringComparison.InvariantCulture to BsonValue CompareTo string.Compare (Issue #1099)

### DIFF
--- a/LiteDB/Document/BsonValue.cs
+++ b/LiteDB/Document/BsonValue.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
@@ -634,9 +634,7 @@ namespace LiteDB
                 case BsonType.Int64: return ((Int64)this.RawValue).CompareTo((Int64)other.RawValue);
                 case BsonType.Double: return ((Double)this.RawValue).CompareTo((Double)other.RawValue);
                 case BsonType.Decimal: return ((Decimal)this.RawValue).CompareTo((Decimal)other.RawValue);
-
-                case BsonType.String: return string.Compare((String)this.RawValue, (String)other.RawValue);
-
+                case BsonType.String: return string.Compare((String)this.RawValue, (String)other.RawValue, StringComparison.InvariantCulture);
                 case BsonType.Document: return this.AsDocument.CompareTo(other);
                 case BsonType.Array: return this.AsArray.CompareTo(other);
 

--- a/LiteDB/Document/BsonValue.cs
+++ b/LiteDB/Document/BsonValue.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Text;
 
 namespace LiteDB
@@ -634,7 +633,10 @@ namespace LiteDB
                 case BsonType.Int64: return ((Int64)this.RawValue).CompareTo((Int64)other.RawValue);
                 case BsonType.Double: return ((Double)this.RawValue).CompareTo((Double)other.RawValue);
                 case BsonType.Decimal: return ((Decimal)this.RawValue).CompareTo((Decimal)other.RawValue);
+                    
                 case BsonType.String: return string.Compare((String)this.RawValue, (String)other.RawValue, StringComparison.InvariantCulture);
+
+
                 case BsonType.Document: return this.AsDocument.CompareTo(other);
                 case BsonType.Array: return this.AsArray.CompareTo(other);
 


### PR DESCRIPTION
This fixes the problem with finnish, swedish and estonian cultures with string comparison. 