### PR TITLE
Added StringComparison.InvariantCulture to CompareTo string.Compare (issue #1099)

### DIFF
--- a/LiteDB/Document/BsonValue.cs
+++ b/LiteDB/Document/BsonValue.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.Text;
 
 namespace LiteDB

--- a/LiteDB/Document/BsonValue.cs
+++ b/LiteDB/Document/BsonValue.cs
@@ -690,7 +690,7 @@ namespace LiteDB
                 case BsonType.Double: return ((Double)this.RawValue).CompareTo((Double)other.RawValue);
                 case BsonType.Decimal: return ((Decimal)this.RawValue).CompareTo((Decimal)other.RawValue);
 
-                case BsonType.String: return string.Compare((String)this.RawValue, (String)other.RawValue);
+                case BsonType.String: return string.Compare((String)this.RawValue, (String)other.RawValue, StringComparison.InvariantCulture);
 
                 case BsonType.Document: return this.AsDocument.CompareTo(other);
                 case BsonType.Array: return this.AsArray.CompareTo(other);


### PR DESCRIPTION
This fixes the problem with finnish, swedish and estonian cultures with string comparison