### PR TITLE
Improve Dispose pattern implementation

### DIFF
--- a/LiteDB/Storage/LiteFileStream.cs
+++ b/LiteDB/Storage/LiteFileStream.cs
@@ -94,9 +94,12 @@ namespace LiteDB
 
             if (!_disposed)
             {
-                if (this.CanWrite)
+                if (disposing)
                 {
-                    this.Flush();
+                    if (this.CanWrite)
+                    {
+                        this.Flush();
+                    }
                 }
                 _disposed = true;
             }


### PR DESCRIPTION
Fixes https://github.com/mbdavid/LiteDB/issues/742

According to MS [documentation](https://docs.microsoft.com/en-us/previous-versions/dotnet/netframework-1.1/b1yfkh5e(v%3dvs.71)) any managed calls can't be called from the finalizer