### PR TITLE
Fix mixed leading whitespace in sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,25 +65,25 @@ using(var db = new LiteDatabase(@"MyData.db"))
     var col = db.GetCollection<Customer>("customers");
 
     // Create your new customer instance
-	var customer = new Customer
+    var customer = new Customer
     { 
         Name = "John Doe", 
         Phones = new string[] { "8000-0000", "9000-0000" }, 
         Age = 39,
         IsActive = true
     };
-    
+
     // Create unique index in Name field
     col.EnsureIndex(x => x.Name, true);
-	
+
     // Insert new customer document (Id will be auto-incremented)
     col.Insert(customer);
-	
+
     // Update a document inside a collection
     customer.Name = "Joana Doe";
-	
+
     col.Update(customer);
-	
+
     // Use LINQ to query documents (with no index)
     var results = col.Find(x => x.Age > 20);
 }


### PR DESCRIPTION
Just noticed that there were mixed tabs and spaces in the README sample code, causing it to misalign. Several of the blank lines also started with tabs, so I cleaned them up as well.

<img width="493" alt="Screenshot of README with misaligned `var customer` line" src="https://user-images.githubusercontent.com/713665/57477975-0bf77a00-7257-11e9-83ab-94c508166881.png">
