### PR TITLE
Created UNION and EXCEPT methods

### DIFF
--- a/LiteDB.Studio/ICSharpCode.TextEditor/Resources/SQL-Mode.xshd
+++ b/LiteDB.Studio/ICSharpCode.TextEditor/Resources/SQL-Mode.xshd
@@ -187,6 +187,8 @@ http://minisqlquery.codeplex.com/license
         <Key word="COALESCE" />
         <Key word="LENGTH" />
         <Key word="TOP" />
+        <Key word="UNION" />
+        <Key word="EXCEPT" />
 
         <!-- String.cs -->
         <Key word="LOWER" />

--- a/LiteDB.Tests/Expressions/Expressions_Exec_Tests.cs
+++ b/LiteDB.Tests/Expressions/Expressions_Exec_Tests.cs
@@ -295,6 +295,24 @@ namespace LiteDB.Tests.Expressions
 
             // flaten
             A("*.arr[*]").ExpectValues(1, 2, 1, 3, 5, 9, 1, 5, 5);
+
+            // Top Method
+            A("TOP([1,2,3,4,5],3)").ExpectValues(1, 2, 3);
+            A("TOP([1,2,3,4,5],0)").ExpectValues();
+            A("TOP([1,2,3,4,5],-3)").ExpectValues();
+            A("TOP([1,2,3,4,5],10)").ExpectValues(1, 2, 3, 4, 5);
+
+            // Union Method
+            A("UNION([1,2,3],4)").ExpectValues(1, 2, 3, 4);
+            A("UNION([1,2,3],[4])").ExpectValues(1, 2, 3, 4);
+            A("UNION([1,2,3],[4,5,6,7])").ExpectValues(1, 2, 3, 4, 5, 6, 7);
+            A("UNION([1,2,3],[1,2,3])").ExpectValues(1, 2, 3);
+
+            // Except Method
+            A("EXCEPT([1,2,3],4)").ExpectValues(1, 2, 3);
+            A("EXCEPT([1,2,3],1)").ExpectValues(2, 3);
+            A("EXCEPT([1,2,3],[1,3])").ExpectValues(2);
+            A("EXCEPT([1,2,3],[4,5])").ExpectValues(1, 2, 3);
         }
     }
 }

--- a/LiteDB/Document/Expression/Methods/Misc.cs
+++ b/LiteDB/Document/Expression/Methods/Misc.cs
@@ -167,5 +167,21 @@ namespace LiteDB
             }
             return Enumerable.Empty<BsonValue>();                          
         }
+
+        /// <summary>
+        /// Returns the union of the two enumerables.
+        /// </summary>
+        public static IEnumerable<BsonValue> UNION(IEnumerable<BsonValue> left, IEnumerable<BsonValue> right)
+        {
+            return left.Union(right);
+        }
+
+        /// <summary>
+        /// Returns the set difference between the two enumerables.
+        /// </summary>
+        public static IEnumerable<BsonValue> EXCEPT(IEnumerable<BsonValue> left, IEnumerable<BsonValue> right)
+        {
+            return left.Except(right);
+        }
     }
 }


### PR DESCRIPTION
`UNION(enumerable1, enumerable2)`: returns the set-union between `enumerable1` and `enumerable2`.

`EXCEPT(enumerable1, enumerable2)`: returns the set-difference between `enumerable1` and `enumerable2`.

Unit tests for `TOP`, `UNION` and `EXCEPT` methods were also created.