### PR TITLE
Remove unnecessary finalizers

### DIFF
--- a/LiteDB/Client/Shared/SharedDataReader.cs
+++ b/LiteDB/Client/Shared/SharedDataReader.cs
@@ -29,11 +29,6 @@ namespace LiteDB
             _dispose();
         }
 
-        ~SharedDataReader()
-        {
-            this.Dispose();
-        }
-
         public BsonValue this[string field] => _reader[field];
 
         public string Collection => _reader.Collection;

--- a/LiteDB/Client/Shared/SharedEngine.cs
+++ b/LiteDB/Client/Shared/SharedEngine.cs
@@ -119,11 +119,6 @@ namespace LiteDB
             }
         }
 
-        ~SharedEngine()
-        {
-            this.Dispose();
-        }
-
         #region Transaction Operations
 
         public bool BeginTrans()

--- a/LiteDB/Client/Storage/LiteFileStream.cs
+++ b/LiteDB/Client/Storage/LiteFileStream.cs
@@ -78,23 +78,18 @@ namespace LiteDB
 
         private bool _disposed = false;
 
-        ~LiteFileStream()
-        {
-            Dispose(false);
-        }
-
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
 
-            if (!_disposed)
+            if (_disposed) return;
+
+            if (disposing && this.CanWrite)
             {
-                if (this.CanWrite)
-                {
-                    this.Flush();
-                }
-                _disposed = true;
+                this.Flush();
             }
+
+            _disposed = true;
         }
 
         #endregion

--- a/LiteDB/Document/DataReader/BsonDataReader.cs
+++ b/LiteDB/Document/DataReader/BsonDataReader.cs
@@ -103,27 +103,12 @@ namespace LiteDB
             }
         }
 
-        protected virtual void Dispose(bool disposing)
+        public void Dispose()
         {
             if (_disposed) return;
 
-            //if (disposing)
-            {
-                _source?.Dispose();
-            }
-
+            _source?.Dispose();
             _disposed = true;
-        }
-
-        public void Dispose()
-        {
-            this.Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        ~BsonDataReader()
-        {
-            this.Dispose(false);
         }
     }
 }

--- a/LiteDB/Engine/LiteEngine.cs
+++ b/LiteDB/Engine/LiteEngine.cs
@@ -164,14 +164,7 @@ namespace LiteDB.Engine
             // dispose data file
             this.Dispose(true);
 
-            GC.SuppressFinalize(this);
-
             LOG("engine disposed", "ENGINE");
-        }
-
-        ~LiteEngine()
-        {
-            this.Dispose(false);
         }
     }
 }

--- a/LiteDB/Engine/Structures/PageBuffer.cs
+++ b/LiteDB/Engine/Structures/PageBuffer.cs
@@ -62,10 +62,12 @@ namespace LiteDB.Engine
             Interlocked.Decrement(ref this.ShareCounter);
         }
 
+#if DEBUG
         ~PageBuffer()
         {
             ENSURE(this.ShareCounter == 0, "share count must be 0 in destroy PageBuffer");
         }
+#endif
 
         public override string ToString()
         {


### PR DESCRIPTION
Remove unnecessary finalizers which would end up in the finalizer queue, doing unnecessary work.

Objects with finalizers will survive at least one garbage collection and get promoted to a higher generation since the GC has to wait for their finalizers to get executed before reclaiming their memory. This means that they need at least 2 garbage collection before their memory is reclaimed which is especially bad for `PageBuffer` since it maintains a reference to a large `byte[]` object.

I did a simple test on a relatively large dataset (same dataset generated by LiteDB.Demo, that is, 1 million documents) and ran `col.FindAll().Count()` on it. It registered 29001 `PageBuffer` objects in the finalizer queue which is unnecessary, since `PageBuffer` does not do any meaningful work in its finalizer.

Before PR:
29001 `PageBuffer` objects registered and some other unnecessary ones by LiteDB.
![Before](https://user-images.githubusercontent.com/8182340/67158479-96d1ba00-f349-11e9-911c-0f7c91ca9e88.PNG)

After PR:
![After](https://user-images.githubusercontent.com/8182340/67158476-8588ad80-f349-11e9-9949-761adaedf65c.PNG)

Potential fix for #1345.