### PR TITLE
Changes in BufferExtensions.ToBytes for float and double

### DIFF
--- a/LiteDB/Utils/Extensions/BufferExtensions.cs
+++ b/LiteDB/Utils/Extensions/BufferExtensions.cs
@@ -161,10 +161,12 @@ namespace LiteDB
         /// </summary>
         public static unsafe void ToBytes(this Single value, byte[] array, int startIndex)
         {
-            fixed (byte* ptr = &array[startIndex])
-            {
-                *(Single*)ptr = value;
-            }
+            ToBytes(*(UInt32*)(&value), array, startIndex);
+
+            //fixed (byte* ptr = &array[startIndex])
+            //{
+            //    *(Single*)ptr = value;
+            //}
         }
 
         /// <summary>
@@ -172,10 +174,12 @@ namespace LiteDB
         /// </summary>
         public static unsafe void ToBytes(this Double value, byte[] array, int startIndex)
         {
-            fixed (byte* ptr = &array[startIndex])
-            {
-                *(Double*)ptr = value;
-            }
+            ToBytes(*(UInt64*)(&value), array, startIndex);
+
+            //fixed (byte* ptr = &array[startIndex])
+            //{
+            //    *(Double*)ptr = value;
+            //}
         }
 
         #endregion


### PR DESCRIPTION
float* and double* are now cast to uint* and ulong* before being converter to byte[]. This should fix `DataMisalignedException` being throw in some architectures (see #1373).