### PR TITLE
Optimize performance of IsAnonymousType method.

### DIFF
--- a/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
@@ -135,12 +135,6 @@ namespace LiteDB
                 return custom(value);
             }
 
-            // if type is anonymous use special handler
-            else if(type.IsAnonymousType() && value.IsDocument)
-            {
-                return this.DeserializeAnonymousType(type, value.AsDocument);
-            }
-
             // if value is array, deserialize as array
             else if (value.IsArray)
             {
@@ -162,6 +156,12 @@ namespace LiteDB
             // if value is document, deserialize as document
             else if (value.IsDocument)
             {
+                // if type is anonymous use special handler
+                if (type.IsAnonymousType())
+                {
+                    return this.DeserializeAnonymousType(type, value.AsDocument);
+                }
+
                 var doc = value.AsDocument;
 
                 // test if value is object and has _type

--- a/LiteDB/Utils/Extensions/TypeInfoExtensions.cs
+++ b/LiteDB/Utils/Extensions/TypeInfoExtensions.cs
@@ -12,9 +12,9 @@ namespace LiteDB
     {
         public static bool IsAnonymousType(this Type type)
         {
-            var hasCompilerGeneratedAttribute = type.GetTypeInfo().GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Any();
-            var nameContainsAnonymousType = type.FullName.Contains("AnonymousType");
-            var isAnonymousType = hasCompilerGeneratedAttribute && nameContainsAnonymousType;
+            bool isAnonymousType = 
+                type.FullName.Contains("AnonymousType") &&
+                type.GetTypeInfo().GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Any();
 
             return isAnonymousType;
         }


### PR DESCRIPTION
I have came across performance drop when reading from DB after upgrade from v3 to v5.
The profiler shows that one of bottlenecks is `IsAnonymousType` method which is quite expensive.

This fix resolves two problems.
1. call `IsAnonymousType` only if `BsonValue.IsDocument`
2. optimise `IsAnonymousType` method - use `Attribute.IsDefined` instead of `GetCustomAttributes`, because it is more performant (there is `#if` because it is not available for .NET Standard 1.3)