### PR TITLE
Fixed Part URI cannot start with two forward slashes

### DIFF
--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -52,8 +52,8 @@
 
   <!-- Begin References -->
   <ItemGroup>
-    <None Include="..\LICENSE" Pack="true" PackagePath="\"/>
-    <None Include="..\icon_64x64.png" Pack="true" PackagePath="\"/>
+    <None Include="..\LICENSE" Pack="true" PackagePath="" />
+    <None Include="..\icon_64x64.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">


### PR DESCRIPTION
This PR hopefully fixes #1459, but to fully test whether this change fixes it, we need to bump the version (5.0.3?) and release a new NuGet package