### PR TITLE
Fix Deserialize Object (as Dictionary) and Hashtable.

### DIFF
--- a/LiteDB.Tests/Mapper/Dictionary_Tests.cs
+++ b/LiteDB.Tests/Mapper/Dictionary_Tests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -27,6 +28,34 @@ namespace LiteDB.Tests.Mapper
             var newobj = _mapper.ToObject<Dict>(doc);
 
             newobj.DateDict.Keys.First().Should().Be(obj.DateDict.Keys.First());
+        }
+
+        [Fact]
+        public void Deserialize_Object()
+        {
+            var doc = new BsonDocument() { ["x"] = 1 };
+
+            var result = _mapper.Deserialize(typeof(object), doc);
+            Assert.Equal(typeof(Dictionary<string, object>), result.GetType());
+
+            //! used to be empty
+            var dic = (Dictionary<string, object>)result;
+            Assert.Single(dic);
+            Assert.Equal(1, dic["x"]);
+        }
+
+        [Fact]
+        public void Deserialize_Hashtable()
+        {
+            var doc = new BsonDocument() { ["x"] = 1 };
+
+            var result = _mapper.Deserialize(typeof(Hashtable), doc);
+            Assert.Equal(typeof(Hashtable), result.GetType());
+
+            //! used to be empty
+            var dic = (Hashtable)result;
+            Assert.Single(dic);
+            Assert.Equal(1, dic["x"]);
         }
     }
 }

--- a/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
@@ -189,12 +189,19 @@ namespace LiteDB
 
                 var o = _typeInstantiator(type) ?? entity.CreateInstance(doc);
 
-                if (o is IDictionary && typeInfo.IsGenericType)
+                if (o is IDictionary)
                 {
-                    var k = type.GetGenericArguments()[0];
-                    var t = type.GetGenericArguments()[1];
+                    if (o.GetType().GetTypeInfo().IsGenericType)
+                    {
+                        var k = type.GetGenericArguments()[0];
+                        var t = type.GetGenericArguments()[1];
 
-                    this.DeserializeDictionary(k, t, (IDictionary)o, value.AsDocument);
+                        this.DeserializeDictionary(k, t, (IDictionary)o, value.AsDocument);
+                    }
+                    else
+                    {
+                        this.DeserializeDictionary(typeof(object), typeof(object), (IDictionary)o, value.AsDocument);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Problem: BsonMapper correctly creates Dictionary and Hashtable instances but the collections are empty.
P.S. Hashtables are important, for example they are used as "native dictionaries" in PowerShell.

The original line `if (o is IDictionary && typeInfo.IsGenericType)` has two problems:

- it excludes non-generic dictionaries, for example `Hashtable` (quite important type in PowerShell)
- it fails to deserialize `object` as `Dictionary` because it checks `typeInfo` obtained for `object` (non-generic of course)
