### PR TITLE
Make BsonExpression explicitly sealed.

### DIFF
--- a/LiteDB/Document/Expression/BsonExpression.cs
+++ b/LiteDB/Document/Expression/BsonExpression.cs
@@ -15,7 +15,7 @@ namespace LiteDB
     /// <summary>
     /// Compile and execute string expressions using BsonDocuments. Used in all document manipulation (transform, filter, indexes, updates). See https://github.com/mbdavid/LiteDB/wiki/Expressions
     /// </summary>
-    public class BsonExpression
+    public sealed class BsonExpression
     {
         /// <summary>
         /// Get formatted expression


### PR DESCRIPTION
- It is de-facto sealed because it provides no public or protected constructors.
- Avoid questions like #1468 and unsuccessful attempts to derive from BsonExpression.