### PR TITLE
Fix limit and offset Query parameters being overriden with default values in Find method call

### DIFF
--- a/LiteDB/Client/Database/Collections/Find.cs
+++ b/LiteDB/Client/Database/Collections/Find.cs
@@ -41,8 +41,8 @@ namespace LiteDB
         {
             if (query == null) throw new ArgumentNullException(nameof(query));
 
-            query.Offset = skip;
-            query.Limit = limit;
+            if(skip != 0) query.Offset = skip;
+            if(limit != int.MaxValue) query.Limit = limit;
 
             return new LiteQueryable<T>(_engine, _mapper, _collection, query)
                 .ToEnumerable();


### PR DESCRIPTION
See #1506 