### PR TITLE
Feature/performance benchmarks v5

### DIFF
--- a/LiteDB.Benchmarks/Benchmarks/BenchmarkBase.cs
+++ b/LiteDB.Benchmarks/Benchmarks/BenchmarkBase.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+
+namespace LiteDB.Benchmarks.Benchmarks
+{
+    public abstract class BenchmarkBase
+    {
+        // Insertion data size
+        [Params(10, 50, 100, 500, 1000, 5000, 10000)]
+        public int DatasetSize;
+
+        public virtual string DatabasePath
+        {
+            get => Constants.DATABASE_NAME;
+            set => throw new System.NotImplementedException();
+        }
+
+        [Params(ConnectionType.Direct)]
+        public ConnectionType ConnectionType;
+
+        [Params(null, "SecurePassword")]
+        public string Password;
+
+        public ConnectionString ConnectionString() => new ConnectionString(DatabasePath)
+        {
+            Connection = ConnectionType,
+            Password = Password
+        };
+
+        protected ILiteDatabase DatabaseInstance { get; set; }
+    }
+}

--- a/LiteDB.Benchmarks/Benchmarks/Constants.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Constants.cs
@@ -2,6 +2,8 @@ namespace LiteDB.Benchmarks.Benchmarks
 {
     internal static class Constants
     {
+        internal const string DATABASE_NAME = "Lite.db";
+
         internal static class Categories
         {
             internal const string DATA_GEN = nameof(DATA_GEN);

--- a/LiteDB.Benchmarks/Benchmarks/Deletion/DeletionBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Deletion/DeletionBenchmark.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using LiteDB.Benchmarks.Models;
+using LiteDB.Benchmarks.Models.Generators;
+
+namespace LiteDB.Benchmarks.Benchmarks.Deletion
+{
+    [BenchmarkCategory(Constants.Categories.DELETION)]
+    public class DeletionBenchmark : BenchmarkBase
+    {
+        private List<FileMetaBase> data;
+
+        private ILiteCollection<FileMetaBase> _fileMetaCollection;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            File.Delete(DatabasePath);
+
+            DatabaseInstance = new LiteDatabase(ConnectionString());
+            _fileMetaCollection = DatabaseInstance.GetCollection<FileMetaBase>();
+            _fileMetaCollection.EnsureIndex(file => file.IsFavorite);
+            _fileMetaCollection.EnsureIndex(file => file.ShouldBeShown);
+
+            data = FileMetaGenerator<FileMetaBase>.GenerateList(DatasetSize);
+        }
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            _fileMetaCollection.Insert(data);
+            DatabaseInstance.Checkpoint();
+        }
+
+        [Benchmark(Baseline = true)]
+        public int DeleteAllExpression()
+        {
+            var count = _fileMetaCollection.DeleteMany("1 = 1");
+            DatabaseInstance.Checkpoint();
+            return count;
+        }
+
+        [Benchmark]
+        public void DropCollectionAndRecreate()
+        {
+            const string collectionName = nameof(FileMetaBase);
+
+            var indexesCollection = DatabaseInstance.GetCollection("$indexes");
+            var droppedCollectionIndexes = indexesCollection.Query().Where(x => x["collection"] == collectionName && x["name"] != "_id").ToDocuments().ToList();
+
+            DatabaseInstance.DropCollection(collectionName);
+
+            foreach (var indexInfo in droppedCollectionIndexes)
+            {
+                DatabaseInstance.GetCollection(collectionName).EnsureIndex(indexInfo["name"], BsonExpression.Create(indexInfo["expression"]), indexInfo["unique"]);
+            }
+
+            DatabaseInstance.Checkpoint();
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            // Disposing logic
+            DatabaseInstance.DropCollection(nameof(FileMetaBase));
+            DatabaseInstance.Checkpoint();
+            DatabaseInstance.Dispose();
+
+            File.Delete(DatabasePath);
+        }
+    }
+}

--- a/LiteDB.Benchmarks/Benchmarks/Insertion/InsertionBasicBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Insertion/InsertionBasicBenchmark.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using LiteDB.Benchmarks.Models;
+using LiteDB.Benchmarks.Models.Generators;
+
+namespace LiteDB.Benchmarks.Benchmarks.Insertion
+{
+    [BenchmarkCategory(Constants.Categories.INSERTION)]
+    public class InsertionBasicBenchmark : BenchmarkBase
+    {
+        private List<FileMetaBase> data;
+
+        private ILiteCollection<FileMetaBase> _fileMetaCollection { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            File.Delete(DatabasePath);
+
+            DatabaseInstance = new LiteDatabase(ConnectionString());
+            _fileMetaCollection = DatabaseInstance.GetCollection<FileMetaBase>();
+
+            data = FileMetaGenerator<FileMetaBase>.GenerateList(DatasetSize); // executed once per each N value
+        }
+
+        [Benchmark(Baseline = true)]
+        public int Insertion()
+        {
+            var count = _fileMetaCollection.Insert(data);
+            DatabaseInstance.Checkpoint();
+            return count;
+        }
+
+        [Benchmark]
+        public void InsertionWithLoop()
+        {
+            // ReSharper disable once ForCanBeConvertedToForeach
+            for (var i = 0; i < data.Count; i++)
+            {
+                _fileMetaCollection.Insert(data[i]);
+            }
+            DatabaseInstance.Checkpoint();
+        }
+
+        [Benchmark]
+        public int Upsertion()
+        {
+            var count = _fileMetaCollection.Upsert(data);
+            DatabaseInstance.Checkpoint();
+            return count;
+        }
+
+        [Benchmark]
+        public void UpsertionWithLoop()
+        {
+            // ReSharper disable once ForCanBeConvertedToForeach
+            for (var i = 0; i < data.Count; i++)
+            {
+                _fileMetaCollection.Upsert(data[i]);
+            }
+            DatabaseInstance.Checkpoint();
+        }
+
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            const string collectionName = nameof(FileMetaBase);
+
+            DatabaseInstance.DropCollection(collectionName);
+
+            DatabaseInstance.Checkpoint();
+            DatabaseInstance.Rebuild();
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            DatabaseInstance.DropCollection(nameof(FileMetaBase));
+            DatabaseInstance.Checkpoint();
+            DatabaseInstance.Dispose();
+
+            File.Delete(DatabasePath);
+        }
+    }
+}

--- a/LiteDB.Benchmarks/Benchmarks/Insertion/InsertionIgnoreExpressionPropertyBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Insertion/InsertionIgnoreExpressionPropertyBenchmark.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using LiteDB.Benchmarks.Models;
+using LiteDB.Benchmarks.Models.Generators;
+
+namespace LiteDB.Benchmarks.Benchmarks.Insertion
+{
+    [BenchmarkCategory(Constants.Categories.INSERTION)]
+    public class InsertionIgnoreExpressionPropertyBenchmark : BenchmarkBase
+    {
+        private List<FileMetaBase> baseData;
+        private List<FileMetaWithExclusion> baseDataWithBsonIgnore;
+
+        private ILiteCollection<FileMetaBase> _fileMetaCollection { get; set; }
+        private ILiteCollection<FileMetaWithExclusion> _fileMetaExclusionCollection { get; set; }
+
+        [GlobalSetup(Target = nameof(Insertion))]
+        public void GlobalBsonIgnoreSetup()
+        {
+            File.Delete(DatabasePath);
+
+            DatabaseInstance = new LiteDatabase(ConnectionString());
+            _fileMetaCollection = DatabaseInstance.GetCollection<FileMetaBase>();
+            _fileMetaCollection.EnsureIndex(fileMeta => fileMeta.ShouldBeShown);
+
+            baseData = FileMetaGenerator<FileMetaBase>.GenerateList(DatasetSize); // executed once per each N value
+        }
+
+        [GlobalSetup(Target = nameof(InsertionWithBsonIgnore))]
+        public void GlobalIgnorePropertySetup()
+        {
+            File.Delete(DatabasePath);
+
+            DatabaseInstance = new LiteDatabase(ConnectionString());
+            _fileMetaExclusionCollection = DatabaseInstance.GetCollection<FileMetaWithExclusion>();
+            _fileMetaExclusionCollection.EnsureIndex(fileMeta => fileMeta.ShouldBeShown);
+
+            baseDataWithBsonIgnore = FileMetaGenerator<FileMetaWithExclusion>.GenerateList(DatasetSize); // executed once per each N value
+        }
+
+        [Benchmark(Baseline = true)]
+        public int Insertion()
+        {
+            var count = _fileMetaCollection.Insert(baseData);
+            DatabaseInstance.Checkpoint();
+            return count;
+        }
+
+        [Benchmark]
+        public int InsertionWithBsonIgnore()
+        {
+            var count = _fileMetaExclusionCollection.Insert(baseDataWithBsonIgnore);
+            DatabaseInstance.Checkpoint();
+            return count;
+        }
+
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            var indexesCollection = DatabaseInstance.GetCollection("$indexes");
+            var droppedCollectionIndexes = indexesCollection.Query().Where(x => x["name"] != "_id").ToDocuments().ToList();
+
+            var collectionNames = DatabaseInstance.GetCollectionNames();
+            foreach (var name in collectionNames)
+            {
+                DatabaseInstance.DropCollection(name);
+            }
+
+            foreach (var indexInfo in droppedCollectionIndexes)
+            {
+                DatabaseInstance.GetCollection(indexInfo["collection"]).EnsureIndex(indexInfo["name"], BsonExpression.Create(indexInfo["expression"]), indexInfo["unique"]);
+            }
+            
+            DatabaseInstance.Checkpoint();
+            DatabaseInstance.Rebuild();
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            baseData?.Clear();
+            baseData = null;
+
+            baseDataWithBsonIgnore?.Clear();
+            baseDataWithBsonIgnore = null;
+
+            DatabaseInstance.DropCollection(nameof(FileMetaBase));
+            DatabaseInstance.DropCollection(nameof(FileMetaWithExclusion));
+            DatabaseInstance.Checkpoint();
+            DatabaseInstance.Dispose();
+
+            File.Delete(DatabasePath);
+        }
+    }
+}

--- a/LiteDB.Benchmarks/Benchmarks/Insertion/InsertionInMemoryBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Insertion/InsertionInMemoryBenchmark.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using LiteDB.Benchmarks.Models;
+using LiteDB.Benchmarks.Models.Generators;
+
+namespace LiteDB.Benchmarks.Benchmarks.Insertion
+{
+    [BenchmarkCategory(Constants.Categories.INSERTION)]
+    public class InsertionInMemoryBenchmark : BenchmarkBase
+    {
+        private List<FileMetaBase> data;
+
+        private ILiteDatabase DatabaseInstanceNormal { get; set; }
+        private ILiteDatabase DatabaseInstanceInMemory { get; set; }
+        private ILiteCollection<FileMetaBase> _fileMetaNormalCollection { get; set; }
+        private ILiteCollection<FileMetaBase> _fileMetaInMemoryCollection { get; set; }
+
+        [GlobalSetup(Target = nameof(InsertionNormal))]
+        public void GlobalSetupNormal()
+        {
+            File.Delete(DatabasePath);
+
+            data = FileMetaGenerator<FileMetaBase>.GenerateList(DatasetSize); // executed once per each N value
+
+            DatabaseInstanceNormal = new LiteDatabase(ConnectionString());
+            _fileMetaNormalCollection = DatabaseInstanceNormal.GetCollection<FileMetaBase>();
+        }
+
+        [GlobalSetup(Target = nameof(InsertionInMemory))]
+        public void GlobalSetupInMemory()
+        {
+            data = FileMetaGenerator<FileMetaBase>.GenerateList(DatasetSize); // executed once per each N value
+
+            DatabaseInstanceInMemory = new LiteDatabase(new MemoryStream());
+            _fileMetaInMemoryCollection = DatabaseInstanceInMemory.GetCollection<FileMetaBase>();
+        }
+
+        [Benchmark(Baseline = true)]
+        public int InsertionNormal()
+        {
+            var count = _fileMetaNormalCollection.Insert(data);
+            DatabaseInstanceNormal.Checkpoint();
+            return count;
+        }
+
+        [Benchmark]
+        public int InsertionInMemory()
+        {
+            var count = _fileMetaInMemoryCollection.Insert(data);
+            DatabaseInstanceNormal.Checkpoint();
+            return count;
+        }
+
+        [IterationCleanup(Target = nameof(InsertionNormal))]
+        public void CleanUpNormal()
+        {
+            const string collectionName = nameof(FileMetaBase);
+
+            var indexesCollection = DatabaseInstanceNormal.GetCollection("$indexes");
+            var droppedCollectionIndexes = indexesCollection.Query().Where(x => x["collection"] == collectionName && x["name"] != "_id").ToDocuments().ToList();
+
+            DatabaseInstanceNormal.DropCollection(collectionName);
+
+            foreach (var indexInfo in droppedCollectionIndexes)
+            {
+                DatabaseInstanceNormal.GetCollection(collectionName).EnsureIndex(indexInfo["name"], BsonExpression.Create(indexInfo["expression"]), indexInfo["unique"]);
+            }
+            DatabaseInstanceNormal.Checkpoint();
+            DatabaseInstanceNormal.Rebuild();
+        }
+
+        [IterationCleanup(Target = nameof(InsertionInMemory))]
+        public void CleanUpInMemory()
+        {
+            const string collectionName = nameof(FileMetaBase);
+
+            var indexesCollection = DatabaseInstanceInMemory.GetCollection("$indexes");
+            var droppedCollectionIndexes = indexesCollection.Query().Where(x => x["collection"] == collectionName && x["name"] != "_id").ToDocuments().ToList();
+
+            DatabaseInstanceInMemory.DropCollection(collectionName);
+
+            foreach (var indexInfo in droppedCollectionIndexes)
+            {
+                DatabaseInstanceInMemory.GetCollection(collectionName).EnsureIndex(indexInfo["name"], BsonExpression.Create(indexInfo["expression"]), indexInfo["unique"]);
+            }
+            DatabaseInstanceInMemory.Checkpoint();
+            DatabaseInstanceInMemory.Rebuild();
+        }
+
+        [GlobalCleanup(Target = nameof(InsertionNormal))]
+        public void GlobalCleanupNormal()
+        {
+            _fileMetaNormalCollection = null;
+
+            DatabaseInstanceNormal.DropCollection(nameof(FileMetaBase));
+            DatabaseInstanceNormal.Checkpoint();
+            DatabaseInstanceNormal.Dispose();
+
+            File.Delete(DatabasePath);
+        }
+
+        [GlobalCleanup(Target = nameof(InsertionInMemory))]
+        public void GlobalCleanupInMemory()
+        {
+            _fileMetaInMemoryCollection = null;
+
+            DatabaseInstanceInMemory.DropCollection(nameof(FileMetaBase));
+            DatabaseInstanceInMemory.Checkpoint();
+            DatabaseInstanceInMemory.Dispose();
+        }
+    }
+}

--- a/LiteDB.Benchmarks/Benchmarks/Queries/QueryAllBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Queries/QueryAllBenchmark.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using LiteDB.Benchmarks.Models;
+using LiteDB.Benchmarks.Models.Generators;
+
+namespace LiteDB.Benchmarks.Benchmarks.Queries
+{
+    [BenchmarkCategory(Constants.Categories.QUERIES)]
+    public class QueryAllBenchmark : BenchmarkBase
+    {
+        private ILiteCollection<FileMetaBase> _fileMetaCollection { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            File.Delete(DatabasePath);
+
+            DatabaseInstance = new LiteDatabase(ConnectionString());
+            _fileMetaCollection = DatabaseInstance.GetCollection<FileMetaBase>();
+
+            _fileMetaCollection.Insert(FileMetaGenerator<FileMetaBase>.GenerateList(DatasetSize)); // executed once per each N value
+            DatabaseInstance.Checkpoint();
+        }
+
+        [Benchmark(Baseline = true)]
+        public List<FileMetaBase> FindAll()
+        {
+            return _fileMetaCollection.FindAll().ToList();
+        }
+
+        [Benchmark]
+        public List<FileMetaBase> FindAllWithExpression()
+        {
+            return _fileMetaCollection.Find(_ => true).ToList();
+        }
+
+        [Benchmark]
+        public List<FileMetaBase> FindAllWithQuery()
+        {
+            return _fileMetaCollection.Find(Query.All()).ToList();
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            // Disposing logic
+            DatabaseInstance.DropCollection(nameof(FileMetaBase));
+            DatabaseInstance.Checkpoint();
+            DatabaseInstance.Dispose();
+
+            File.Delete(DatabasePath);
+        }
+    }
+}

--- a/LiteDB.Benchmarks/Benchmarks/Queries/QueryAllBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Queries/QueryAllBenchmark.cs
@@ -30,11 +30,12 @@ namespace LiteDB.Benchmarks.Benchmarks.Queries
             return _fileMetaCollection.FindAll().ToList();
         }
 
-        [Benchmark]
+        // TODO: Fix benchmark
+        /*[Benchmark]
         public List<FileMetaBase> FindAllWithExpression()
         {
             return _fileMetaCollection.Find(_ => true).ToList();
-        }
+        }*/
 
         [Benchmark]
         public List<FileMetaBase> FindAllWithQuery()

--- a/LiteDB.Benchmarks/Benchmarks/Queries/QueryCompoundIndexBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Queries/QueryCompoundIndexBenchmark.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using LiteDB.Benchmarks.Models;
+using LiteDB.Benchmarks.Models.Generators;
+
+namespace LiteDB.Benchmarks.Benchmarks.Queries
+{
+    [BenchmarkCategory(Constants.Categories.QUERIES)]
+    public class QueryCompoundIndexBenchmark : BenchmarkBase
+    {
+        private const string _compoundIndexName = "CompoundIndex1";
+
+        private ILiteCollection<FileMetaBase> _fileMetaCollection { get; set; }
+
+        [GlobalSetup(Target = nameof(Query_SimpleIndex_Baseline))]
+        public void GlobalSetupSimpleIndexBaseline()
+        {
+            File.Delete(DatabasePath);
+
+            DatabaseInstance = new LiteDatabase(ConnectionString());
+            _fileMetaCollection = DatabaseInstance.GetCollection<FileMetaBase>();
+            _fileMetaCollection.EnsureIndex(fileMeta => fileMeta.ShouldBeShown);
+            _fileMetaCollection.EnsureIndex(fileMeta => fileMeta.IsFavorite);
+
+            _fileMetaCollection.Insert(FileMetaGenerator<FileMetaBase>.GenerateList(DatasetSize)); // executed once per each N value
+
+            DatabaseInstance.Checkpoint();
+        }
+
+        [GlobalSetup(Target = nameof(Query_CompoundIndexVariant))]
+        public void GlobalSetupCompoundIndexVariant()
+        {
+            DatabaseInstance = new LiteDatabase(ConnectionString());
+            _fileMetaCollection = DatabaseInstance.GetCollection<FileMetaBase>();
+            _fileMetaCollection.EnsureIndex(_compoundIndexName, $"$.{nameof(FileMetaBase.IsFavorite)};$.{nameof(FileMetaBase.ShouldBeShown)}");
+
+            _fileMetaCollection.Insert(FileMetaGenerator<FileMetaBase>.GenerateList(DatasetSize)); // executed once per each N value
+
+            DatabaseInstance.Checkpoint();
+        }
+
+        [Benchmark(Baseline = true)]
+        public List<FileMetaBase> Query_SimpleIndex_Baseline()
+        {
+            return _fileMetaCollection.Find(Query.And(
+                    Query.EQ(nameof(FileMetaBase.IsFavorite), false),
+                    Query.EQ(nameof(FileMetaBase.ShouldBeShown), true)))
+                .ToList();
+        }
+
+        [Benchmark]
+        public List<FileMetaBase> Query_CompoundIndexVariant()
+        {
+            return _fileMetaCollection.Find(Query.EQ(_compoundIndexName, $"{false};{true}")).ToList();
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            // Disposing logic
+            DatabaseInstance.DropCollection(nameof(FileMetaBase));
+            DatabaseInstance.Checkpoint();
+            DatabaseInstance.Dispose();
+
+            File.Delete(DatabasePath);
+        }
+    }
+}

--- a/LiteDB.Benchmarks/Benchmarks/Queries/QueryCountBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Queries/QueryCountBenchmark.cs
@@ -1,0 +1,57 @@
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using LiteDB.Benchmarks.Models;
+using LiteDB.Benchmarks.Models.Generators;
+
+namespace LiteDB.Benchmarks.Benchmarks.Queries
+{
+    [BenchmarkCategory(Constants.Categories.QUERIES)]
+    public class QueryCountBenchmark : BenchmarkBase
+    {
+        private ILiteCollection<FileMetaBase> _fileMetaCollection { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            File.Delete(DatabasePath);
+
+            DatabaseInstance = new LiteDatabase(ConnectionString());
+            _fileMetaCollection = DatabaseInstance.GetCollection<FileMetaBase>();
+            _fileMetaCollection.EnsureIndex(fileMeta => fileMeta.ShouldBeShown);
+
+            _fileMetaCollection.Insert(FileMetaGenerator<FileMetaBase>.GenerateList(DatasetSize)); // executed once per each N value
+
+            DatabaseInstance.Checkpoint();
+        }
+
+        [Benchmark(Baseline = true)]
+        public int CountWithLinq()
+        {
+            return _fileMetaCollection.Find(Query.EQ(nameof(FileMetaBase.ShouldBeShown), true)).Count();
+        }
+
+        [Benchmark]
+        public int CountWithExpression()
+        {
+            return _fileMetaCollection.Count(fileMeta => fileMeta.ShouldBeShown);
+        }
+
+        [Benchmark]
+        public int CountWithQuery()
+        {
+            return _fileMetaCollection.Count(Query.EQ(nameof(FileMetaBase.ShouldBeShown), true));
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            // Disposing logic
+            DatabaseInstance.DropCollection(nameof(FileMetaBase));
+            DatabaseInstance.Checkpoint();
+            DatabaseInstance.Dispose();
+
+            File.Delete(DatabasePath);
+        }
+    }
+}

--- a/LiteDB.Benchmarks/Benchmarks/Queries/QueryIgnoreExpressionPropertiesBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Queries/QueryIgnoreExpressionPropertiesBenchmark.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using LiteDB.Benchmarks.Models;
+using LiteDB.Benchmarks.Models.Generators;
+
+namespace LiteDB.Benchmarks.Benchmarks.Queries
+{
+    [BenchmarkCategory(Constants.Categories.QUERIES)]
+    public class QueryIgnoreExpressionPropertiesBenchmark : BenchmarkBase
+    {
+        private ILiteCollection<FileMetaBase> _fileMetaCollection { get; set; }
+        private ILiteCollection<FileMetaWithExclusion> _fileMetaExclusionCollection { get; set; }
+
+        [GlobalSetup(Target = nameof(DeserializeBaseline))]
+        public void GlobalSetup()
+        {
+            File.Delete(DatabasePath);
+
+            DatabaseInstance = new LiteDatabase(ConnectionString());
+            _fileMetaCollection = DatabaseInstance.GetCollection<FileMetaBase>();
+            _fileMetaCollection.EnsureIndex(fileMeta => fileMeta.ShouldBeShown);
+
+            _fileMetaCollection.Insert(FileMetaGenerator<FileMetaBase>.GenerateList(DatasetSize)); // executed once per each N value
+            
+            DatabaseInstance.Checkpoint();
+        }
+
+        [GlobalSetup(Target = nameof(DeserializeWithIgnore))]
+        public void GlobalIndexSetup()
+        {
+            File.Delete(DatabasePath);
+
+            DatabaseInstance = new LiteDatabase(ConnectionString());
+            _fileMetaExclusionCollection = DatabaseInstance.GetCollection<FileMetaWithExclusion>();
+            _fileMetaExclusionCollection.EnsureIndex(fileMeta => fileMeta.ShouldBeShown);
+
+            _fileMetaExclusionCollection.Insert(FileMetaGenerator<FileMetaWithExclusion>.GenerateList(DatasetSize)); // executed once per each N value
+            
+            DatabaseInstance.Checkpoint();
+        }
+
+        [Benchmark(Baseline = true)]
+        public List<FileMetaBase> DeserializeBaseline()
+        {
+            return _fileMetaCollection.Find(fileMeta => fileMeta.ShouldBeShown).ToList();
+        }
+
+        [Benchmark]
+        public List<FileMetaWithExclusion> DeserializeWithIgnore()
+        {
+            return _fileMetaExclusionCollection.Find(fileMeta => fileMeta.ShouldBeShown).ToList();
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            // Disposing logic
+            DatabaseInstance.DropCollection(nameof(FileMetaBase));
+            _fileMetaCollection = null;
+
+            DatabaseInstance.DropCollection(nameof(FileMetaWithExclusion));
+            _fileMetaExclusionCollection = null;
+            
+            DatabaseInstance.Checkpoint();
+            DatabaseInstance.Dispose();
+
+            File.Delete(DatabasePath);
+        }
+    }
+}

--- a/LiteDB.Benchmarks/Benchmarks/Queries/QueryMultipleParametersBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Queries/QueryMultipleParametersBenchmark.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using LiteDB.Benchmarks.Models;
+using LiteDB.Benchmarks.Models.Generators;
+
+namespace LiteDB.Benchmarks.Benchmarks.Queries
+{
+    [BenchmarkCategory(Constants.Categories.QUERIES)]
+    public class QueryMultipleParametersBenchmark : BenchmarkBase
+    {
+        private ILiteCollection<FileMetaBase> _fileMetaCollection { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            File.Delete(DatabasePath);
+
+            DatabaseInstance = new LiteDatabase(ConnectionString());
+            _fileMetaCollection = DatabaseInstance.GetCollection<FileMetaBase>();
+            _fileMetaCollection.EnsureIndex(fileMeta => fileMeta.IsFavorite);
+            _fileMetaCollection.EnsureIndex(fileMeta => fileMeta.ShouldBeShown);
+
+            _fileMetaCollection.Insert(FileMetaGenerator<FileMetaBase>.GenerateList(DatasetSize)); // executed once per each N value
+
+            DatabaseInstance.Checkpoint();
+        }
+
+        [Benchmark(Baseline = true)]
+        public List<FileMetaBase> Expression_Normal_Baseline()
+        {
+            return _fileMetaCollection.Find(fileMeta => fileMeta.IsFavorite && fileMeta.ShouldBeShown).ToList();
+        }
+
+        [Benchmark]
+        public List<FileMetaBase> Query_Normal()
+        {
+            return _fileMetaCollection.Find(Query.And(
+                    Query.EQ(nameof(FileMetaBase.IsFavorite), true),
+                    Query.EQ(nameof(FileMetaBase.ShouldBeShown), true)))
+                .ToList();
+        }
+
+        [Benchmark]
+        public List<FileMetaBase> Expression_ParametersSwitched()
+        {
+            return _fileMetaCollection.Find(fileMeta => fileMeta.ShouldBeShown && fileMeta.IsFavorite).ToList();
+        }
+
+        [Benchmark]
+        public List<FileMetaBase> Query_ParametersSwitched()
+        {
+            return _fileMetaCollection.Find(Query.And(
+                    Query.EQ(nameof(FileMetaBase.ShouldBeShown), true),
+                    Query.EQ(nameof(FileMetaBase.IsFavorite), true)))
+                .ToList();
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            // Disposing logic
+            DatabaseInstance.DropCollection(nameof(FileMetaBase));
+            DatabaseInstance.Checkpoint();
+            DatabaseInstance.Dispose();
+
+            File.Delete(DatabasePath);
+        }
+    }
+}

--- a/LiteDB.Benchmarks/Benchmarks/Queries/QuerySimpleIndexBenchmarks.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Queries/QuerySimpleIndexBenchmarks.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using LiteDB.Benchmarks.Models;
+using LiteDB.Benchmarks.Models.Generators;
+
+namespace LiteDB.Benchmarks.Benchmarks.Queries
+{
+    [BenchmarkCategory(Constants.Categories.QUERIES)]
+    public class QuerySimpleIndexBenchmarks : BenchmarkBase
+    {
+        private ILiteCollection<FileMetaBase> _fileMetaCollection { get; set; }
+
+        [GlobalSetup(Targets = new[] {nameof(FindWithExpression), nameof(FindWithQuery)})]
+        public void GlobalSetup()
+        {
+            File.Delete(DatabasePath);
+
+            DatabaseInstance = new LiteDatabase(ConnectionString());
+            _fileMetaCollection = DatabaseInstance.GetCollection<FileMetaBase>();
+
+            _fileMetaCollection.Insert(FileMetaGenerator<FileMetaBase>.GenerateList(DatasetSize)); // executed once per each N value
+        }
+
+        [GlobalSetup(Targets = new[] {nameof(FindWithIndexExpression), nameof(FindWithIndexQuery)})]
+        public void GlobalIndexSetup()
+        {
+            File.Delete(DatabasePath);
+
+            DatabaseInstance = new LiteDatabase(ConnectionString());
+            _fileMetaCollection = DatabaseInstance.GetCollection<FileMetaBase>();
+            _fileMetaCollection.EnsureIndex(fileMeta => fileMeta.IsFavorite);
+
+            _fileMetaCollection.Insert(FileMetaGenerator<FileMetaBase>.GenerateList(DatasetSize)); // executed once per each N value
+            
+            DatabaseInstance.Checkpoint();
+        }
+
+        [Benchmark(Baseline = true)]
+        public List<FileMetaBase> FindWithExpression()
+        {
+            return _fileMetaCollection.Find(fileMeta => fileMeta.IsFavorite).ToList();
+        }
+
+        [Benchmark]
+        public List<FileMetaBase> FindWithQuery()
+        {
+            return _fileMetaCollection.Find(Query.EQ(nameof(FileMetaBase.IsFavorite), true)).ToList();
+        }
+
+        [Benchmark]
+        public List<FileMetaBase> FindWithIndexExpression()
+        {
+            return _fileMetaCollection.Find(fileMeta => fileMeta.IsFavorite).ToList();
+        }
+
+        [Benchmark]
+        public List<FileMetaBase> FindWithIndexQuery()
+        {
+            return _fileMetaCollection.Find(Query.EQ(nameof(FileMetaBase.IsFavorite), true)).ToList();
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            // Disposing logic
+            DatabaseInstance.DropCollection(nameof(FileMetaBase));
+            DatabaseInstance.Checkpoint();
+            DatabaseInstance.Dispose();
+
+            File.Delete(DatabasePath);
+        }
+    }
+}

--- a/LiteDB.Benchmarks/Benchmarks/Queries/QueryWithDateTimeOffsetBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Queries/QueryWithDateTimeOffsetBenchmark.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using LiteDB.Benchmarks.Models;
+using LiteDB.Benchmarks.Models.Generators;
+
+namespace LiteDB.Benchmarks.Benchmarks.Queries
+{
+    [BenchmarkCategory(Constants.Categories.QUERIES)]
+    public class QueryWithDateTimeOffsetBenchmark : BenchmarkBase
+    {
+        private DateTime _dateTimeConstraint;
+        private BsonValue _dateTimeConstraintBsonValue;
+
+        private ILiteCollection<FileMetaBase> _fileMetaCollection { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            File.Delete(DatabasePath);
+
+            DatabaseInstance = new LiteDatabase(ConnectionString());
+            _fileMetaCollection = DatabaseInstance.GetCollection<FileMetaBase>();
+            _fileMetaCollection.EnsureIndex(fileMeta => fileMeta.ValidFrom);
+            _fileMetaCollection.EnsureIndex(fileMeta => fileMeta.ValidTo);
+            _fileMetaCollection.EnsureIndex(fileMeta => fileMeta.ShouldBeShown);
+
+            _fileMetaCollection.Insert(FileMetaGenerator<FileMetaBase>.GenerateList(DatasetSize)); // executed once per each N value
+            
+            DatabaseInstance.Checkpoint();
+
+            _dateTimeConstraint = DateTime.Now;
+            _dateTimeConstraintBsonValue = new BsonValue(_dateTimeConstraint);
+        }
+
+        [Benchmark(Baseline = true)]
+        public List<FileMetaBase> Expression_Normal_Baseline()
+        {
+            return _fileMetaCollection.Find(fileMeta => (fileMeta.ValidFrom > _dateTimeConstraint || fileMeta.ValidTo < _dateTimeConstraint) && fileMeta.ShouldBeShown).ToList();
+        }
+
+        [Benchmark]
+        public List<FileMetaBase> Query_Normal()
+        {
+            return _fileMetaCollection.Find(Query.And(
+                    Query.Or(
+                        Query.GT(nameof(FileMetaBase.ValidFrom), _dateTimeConstraintBsonValue),
+                        Query.LT(nameof(FileMetaBase.ValidTo), _dateTimeConstraintBsonValue)),
+                    Query.EQ(nameof(FileMetaBase.ShouldBeShown), true)))
+                .ToList();
+        }
+
+        [Benchmark]
+        public List<FileMetaBase> Expression_ParametersSwitched()
+        {
+            return _fileMetaCollection.Find(fileMeta => fileMeta.ShouldBeShown && (fileMeta.ValidFrom > _dateTimeConstraint || fileMeta.ValidTo < _dateTimeConstraint)).ToList();
+        }
+
+        [Benchmark]
+        public List<FileMetaBase> Query_ParametersSwitched()
+        {
+            return _fileMetaCollection.Find(Query.And(
+                    Query.EQ(nameof(FileMetaBase.ShouldBeShown), true),
+                    Query.Or(
+                        Query.GT(nameof(FileMetaBase.ValidFrom), _dateTimeConstraintBsonValue),
+                        Query.LT(nameof(FileMetaBase.ValidTo), _dateTimeConstraintBsonValue))))
+                .ToList();
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            // Disposing logic
+            DatabaseInstance.DropCollection(nameof(FileMetaBase));
+            DatabaseInstance.Checkpoint();
+            DatabaseInstance.Dispose();
+
+            File.Delete(DatabasePath);
+        }
+    }
+}

--- a/LiteDB.Benchmarks/Program.cs
+++ b/LiteDB.Benchmarks/Program.cs
@@ -13,7 +13,7 @@ namespace LiteDB.Benchmarks
         static void Main(string[] args)
         {
             BenchmarkRunner.Run(typeof(Program).Assembly, DefaultConfig.Instance
-                .With(new BenchmarkDotNet.Filters.AnyCategoriesFilter(new[] {Benchmarks.Constants.Categories.DATA_GEN}))
+                //.With(new BenchmarkDotNet.Filters.AnyCategoriesFilter(new[] {Benchmarks.Constants.Categories.DATA_GEN}))
                 .With(Job.Default.With(CoreRuntime.Core31)
                     .With(Jit.RyuJit)
                     .With(CsProjCoreToolchain.NetCoreApp31)


### PR DESCRIPTION
Hereby a set of basic benchmarks related to insertion/upsertion, querying and deletion
My desktop is still running the benchmarks so I'll post the results later when it's done.
If you notice any benchmarks that have been set up incorrectly (or are missing), please let me know. Or feel free to add them later yourself.

As soon as this PR has been merged, I'll do some changes in #1456 so that the benchmarks have been set up in the same way.