### PR TITLE
Fix BsonValue enum CompareTo for newer CoreCLR versions

### DIFF
--- a/LiteDB/Document/BsonValue.cs
+++ b/LiteDB/Document/BsonValue.cs
@@ -463,7 +463,8 @@ namespace LiteDB
                 // if not, order by sort type order
                 else
                 {
-                    return this.Type.CompareTo(other.Type);
+                    var result = this.Type.CompareTo(other.Type);
+                    return result < 0 ? -1 : result > 0 ? +1 : 0;
                 }
             }
 


### PR DESCRIPTION
See #1529 .

The documentation of the `Enum.CompareTo` (on which `BsonValue.CompareTo` depends) method states that it might return any number greater than zero if `this` is greater than `target`. However, the implementation of the method always returned `1` in this case. Our implementation of `BsonValue.CompareTo` depended on this fact.

The implementation of `Enum.CompareTo` was recently changed in the CoreCLR, which broke `BsonValue.CompareTo`.