### PR TITLE
Fixes #1551, Prevent releasing the exclusive lock twice on rebuild.

### DIFF
--- a/LiteDB/Engine/Engine/Rebuild.cs
+++ b/LiteDB/Engine/Engine/Rebuild.cs
@@ -60,6 +60,9 @@ namespace LiteDB.Engine
                 // exit reserved before checkpoint
                 _locker.ExitExclusive();
 
+                // since we have already released the lock, do not attempt to release again in the finally.
+                mustExit = false;
+
                 // do checkpoint
                 _walIndex.Checkpoint();
 


### PR DESCRIPTION
Since mustExit is never set to false, the finally block will always attempt to release the lock. This is fixed by simply setting mustExit to false if we release the lock before executing the finally block.