### PR TITLE
Add missed throw keyword

### DIFF
--- a/LiteDB/Engine/Pages/CollectionPage.cs
+++ b/LiteDB/Engine/Pages/CollectionPage.cs
@@ -41,7 +41,7 @@ namespace LiteDB.Engine
         {
             ENSURE(this.PageType == PageType.Collection, "page type must be collection page");
 
-            if (this.PageType != PageType.Collection) LiteException.InvalidPageType(PageType.Collection, this);
+            if (this.PageType != PageType.Collection) throw LiteException.InvalidPageType(PageType.Collection, this);
 
             // create new buffer area to store BsonDocument indexes
             var area = _buffer.Slice(PAGE_HEADER_SIZE, PAGE_SIZE - PAGE_HEADER_SIZE);

--- a/LiteDB/Engine/Pages/DataPage.cs
+++ b/LiteDB/Engine/Pages/DataPage.cs
@@ -18,7 +18,7 @@ namespace LiteDB.Engine
         {
             ENSURE(this.PageType == PageType.Data, "page type must be data page");
 
-            if (this.PageType != PageType.Data) LiteException.InvalidPageType(PageType.Data, this);
+            if (this.PageType != PageType.Data) throw LiteException.InvalidPageType(PageType.Data, this);
         }
 
         /// <summary>

--- a/LiteDB/Engine/Pages/IndexPage.cs
+++ b/LiteDB/Engine/Pages/IndexPage.cs
@@ -18,7 +18,7 @@ namespace LiteDB.Engine
         {
             ENSURE(this.PageType == PageType.Index, "page type must be index page");
 
-            if (this.PageType != PageType.Index) LiteException.InvalidPageType(PageType.Index, this);
+            if (this.PageType != PageType.Index) throw LiteException.InvalidPageType(PageType.Index, this);
         }
 
         /// <summary>


### PR DESCRIPTION
Between 5.0.2 and 5.0.3 exception was changed on these lines, but "throw" keyword was missed.

It can cause unexpected behavior, if page is parsed with invalid PageType, what is possible in some cases like in https://github.com/mbdavid/LiteDB/issues/1503