### PR TITLE
Fix serialization of non-generic IDictionary, for example Hashtable.

### DIFF
--- a/LiteDB.Tests/Mapper/Dictionary_Tests.cs
+++ b/LiteDB.Tests/Mapper/Dictionary_Tests.cs
@@ -57,5 +57,17 @@ namespace LiteDB.Tests.Mapper
             Assert.Single(dic);
             Assert.Equal(1, dic["x"]);
         }
+
+        [Fact]
+        public void Serialize_Hashtable()
+        {
+            var data = new Hashtable() { ["x"] = 1 };
+
+            //! used to fail
+            var result = _mapper.Serialize(data).AsDocument;
+
+            Assert.Single(result);
+            Assert.Equal(1, result["x"].AsInt32);
+        }
     }
 }

--- a/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
@@ -189,18 +189,18 @@ namespace LiteDB
 
                 var o = _typeInstantiator(type) ?? entity.CreateInstance(doc);
 
-                if (o is IDictionary)
+                if (o is IDictionary dict)
                 {
                     if (o.GetType().GetTypeInfo().IsGenericType)
                     {
                         var k = type.GetGenericArguments()[0];
                         var t = type.GetGenericArguments()[1];
 
-                        this.DeserializeDictionary(k, t, (IDictionary)o, value.AsDocument);
+                        this.DeserializeDictionary(k, t, dict, value.AsDocument);
                     }
                     else
                     {
-                        this.DeserializeDictionary(typeof(object), typeof(object), (IDictionary)o, value.AsDocument);
+                        this.DeserializeDictionary(typeof(object), typeof(object), dict, value.AsDocument);
                     }
                 }
                 else

--- a/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
@@ -120,7 +120,7 @@ namespace LiteDB
                 return custom(obj);
             }
             // for dictionary
-            else if (obj is IDictionary)
+            else if (obj is IDictionary dict)
             {
                 // when you are converting Dictionary<string, object>
                 if (type == typeof(object))
@@ -128,9 +128,9 @@ namespace LiteDB
                     type = obj.GetType();
                 }
 
-                var itemType = type.GetGenericArguments()[1];
+                var itemType = type.GetTypeInfo().IsGenericType ? type.GetGenericArguments()[1] : typeof(object);
 
-                return this.SerializeDictionary(itemType, obj as IDictionary, depth);
+                return this.SerializeDictionary(itemType, dict, depth);
             }
             // check if is a list or array
             else if (obj is IEnumerable)


### PR DESCRIPTION
It used to fail due to ``Exception calling "Serialize" with "2" argument(s): "Index was outside the bounds of the array."`` because the original code assumed IDictionary is generic and requested invalid ``GetGenericArguments()[1]``.

Also added the test covering the problem case.

Also tweaked my previous fix of deserializing dictionaries, to avoid redundant "expensive" casts.