### PR TITLE
Fix wrong NRE on passing null expression to EnsureIndex.

### DIFF
--- a/LiteDB.Tests/Engine/Index_Tests.cs
+++ b/LiteDB.Tests/Engine/Index_Tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using FluentAssertions;
 using Xunit;
 
@@ -111,6 +112,31 @@ namespace LiteDB.Tests.Engine
                 var r6 = db.Execute("SELECT name FROM names WHERE name LIKE 'marc__o").ToArray();
 
                 r6.Length.Should().Be(1);
+            }
+        }
+
+        [Fact]
+        public void EnsureIndex_Invalid_Arguments()
+        {
+            using var db = new LiteDatabase("filename=:memory:");
+            var test = db.GetCollection("test");
+
+            // null name
+            {
+                var exn = Assert.Throws<ArgumentNullException>(() => test.EnsureIndex(null, "x", false));
+                Assert.Equal("name", exn.ParamName);
+            }
+
+            // null expression 1
+            {
+                var exn = Assert.Throws<ArgumentNullException>(() => test.EnsureIndex(null, false));
+                Assert.Equal("expression", exn.ParamName);
+            }
+
+            // null expression 2
+            {
+                var exn = Assert.Throws<ArgumentNullException>(() => test.EnsureIndex("x", null, false));
+                Assert.Equal("expression", exn.ParamName);
             }
         }
     }

--- a/LiteDB/Client/Database/Collections/Index.cs
+++ b/LiteDB/Client/Database/Collections/Index.cs
@@ -18,7 +18,7 @@ namespace LiteDB
         public bool EnsureIndex(string name, BsonExpression expression, bool unique = false)
         {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
-            if (string.IsNullOrEmpty(expression)) throw new ArgumentNullException(nameof(expression));
+            if (expression == null) throw new ArgumentNullException(nameof(expression));
 
             return _engine.EnsureIndex(_collection, name, expression, unique);
         }
@@ -30,7 +30,7 @@ namespace LiteDB
         /// <param name="unique">If is a unique index</param>
         public bool EnsureIndex(BsonExpression expression, bool unique = false)
         {
-            if (string.IsNullOrEmpty(expression)) throw new ArgumentNullException(nameof(expression));
+            if (expression == null) throw new ArgumentNullException(nameof(expression));
 
             var name = Regex.Replace(expression.Source, @"[^a-z0-9]", "", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 


### PR DESCRIPTION
Both overloads of `EnsureIndex` used wrong `string.IsNullOrEmpty` for checking
the expression parameter (probably copy/paste mistake). This triggered the
implicit operator `String` on null expressions and resulted in not clear
NRE exceptions instead of clear `ArgumentNullException`.

Also added a test covering both overloads with null expressions and, for
completeness, with null name.