### PR TITLE
Added Linq-to-BsonExpression conversion for DateTime.ToUniversalTime()

### DIFF
--- a/LiteDB.Tests/Mapper/LinqBsonExpression_Tests.cs
+++ b/LiteDB.Tests/Mapper/LinqBsonExpression_Tests.cs
@@ -349,6 +349,8 @@ namespace LiteDB.Tests.Mapper
 
             TestExpr<User>(x => x.CreatedOn.Date, "DATETIME(YEAR(CreatedOn), MONTH(CreatedOn), DAY(CreatedOn))");
 
+            TestExpr<User>(x => x.CreatedOn.ToUniversalTime(), "TO_UTC(CreatedOn)");
+
             // static date
             TestExpr<User>(x => DateTime.Now, "NOW()");
             TestExpr<User>(x => DateTime.UtcNow, "NOW_UTC()");

--- a/LiteDB/Client/Mapper/Linq/TypeResolver/DateTimeResolver.cs
+++ b/LiteDB/Client/Mapper/Linq/TypeResolver/DateTimeResolver.cs
@@ -28,6 +28,7 @@ namespace LiteDB
                     else if (pars.Length == 1 && pars[0].ParameterType == typeof(string)) return "FORMAT(#, @0)";
                     break;
 
+                case "ToUniversalTime": return "TO_UTC(#)";
                 // static methods
                 case "Parse": return "DATETIME(@0)";
                 case "Equals": return "# = @0";


### PR DESCRIPTION
See #1586 