### PR TITLE
fix(1838):ArgumentException thrown when subtracting TimeSpan from DateTimeOffset in query

### DIFF
--- a/LiteDB.Tests/Issues/Issue1838_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue1838_Tests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+using System.Linq;
+
+namespace LiteDB.Tests.Issues
+{
+    public class Issue1838_Tests
+    {
+        [Fact]
+        public void Find_ByDatetime_Offset()
+        {
+            using var db = new LiteDatabase(":memory:");
+            var collection = db.GetCollection<TestType>(nameof(TestType));
+
+            // sample data
+            collection.Insert(new TestType()
+            {
+                Foo = "abc",
+                Timestamp = DateTimeOffset.UtcNow,
+            });
+            collection.Insert(new TestType()
+            {
+                Foo = "def",
+                Timestamp = DateTimeOffset.UtcNow,
+            });
+
+            // filter from 1 hour in the past to 1 hour in the future
+            var timeRange = TimeSpan.FromHours(2);
+
+            var result = collection // throws exception
+                .Find(x => x.Timestamp > (DateTimeOffset.UtcNow - timeRange))
+                .ToList();
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+        }
+
+        public class TestType
+        {
+            [BsonId]
+            public int Id { get; set; }
+            [BsonField]
+            public string Foo { get; set; }
+            [BsonField]
+            public DateTimeOffset Timestamp { get; set; }
+        }
+    }
+}

--- a/LiteDB/Document/Expression/Parser/BsonExpressionOperators.cs
+++ b/LiteDB/Document/Expression/Parser/BsonExpressionOperators.cs
@@ -31,11 +31,11 @@ namespace LiteDB
             // if any side are DateTime and another is number, add days in date
             else if (left.IsDateTime && right.IsNumber)
             {
-                return left.AsDateTime.AddDays(right.AsDouble);
+                return left.AsDateTime.AddTicks(right.AsInt64);
             }
             else if (left.IsNumber && right.IsDateTime)
             {
-                return right.AsDateTime.AddDays(left.AsDouble);
+                return right.AsDateTime.AddTicks(left.AsInt64);
             }
             // if both sides are number, add as math
             else if (left.IsNumber && right.IsNumber)
@@ -53,17 +53,16 @@ namespace LiteDB
         {
             if (left.IsDateTime && right.IsNumber)
             {
-                return left.AsDateTime.AddDays(-right.AsDouble);
+                return left.AsDateTime.AddTicks(-right.AsInt64);
             }
             else if (left.IsNumber && right.IsDateTime)
             {
-                return right.AsDateTime.AddDays(-left.AsDouble);
+                return right.AsDateTime.AddTicks(-left.AsInt64);
             }
             else if (left.IsNumber && right.IsNumber)
             {
                 return left - right;
             }
-
             return BsonValue.Null;
         }
 
@@ -359,7 +358,7 @@ namespace LiteDB
 
             var doc = new BsonDocument();
 
-            for(var i = 0; i < keys.Length; i++)
+            for (var i = 0; i < keys.Length; i++)
             {
                 doc[keys[i]] = values[i];
             }


### PR DESCRIPTION
As per ```BsonMapper``` ,``` TimeSpan``` is mapped to ```Ticks``` i.e. Int64 .
In Minus and Addition , it was trying to cast long value to double and adding as Days.

Looking at the code , instead of adding/substracting days - Ticks can be used.
Other way around is changing BsonMapper to map Days property instead of Ticks, but this could not be sufficient in some scenarios and Ticks provide standard approach.
