### PR TITLE
Fix NullPointer for shell help command

### DIFF
--- a/LiteDB.Shell/Commands/Help.cs
+++ b/LiteDB.Shell/Commands/Help.cs
@@ -28,7 +28,7 @@ namespace LiteDB.Shell.Commands
             // getting all HelpAttributes inside assemblies
             var helps = AppDomain.CurrentDomain.GetAssemblies()
                 .SelectMany(x => x.GetTypes())
-                .Select(x => CustomAttributeExtensions.GetCustomAttributes(typeof(HelpAttribute), true).FirstOrDefault())
+                .Select(x => CustomAttributeExtensions.GetCustomAttributes(x, typeof(HelpAttribute), true).FirstOrDefault())
                 .Where(x => x != null)
                 .Select(x => x as HelpAttribute)
                 .ToArray();


### PR DESCRIPTION
When you try to run the shell help command you get the exception Object reference not set to an instance of an object.

The reason is that `CustomAttributeExtensions.GetCustomAttributes` where missing the type where to search

Example:
```Welcome to LiteDB Shell

Getting started with `help`

> help
# LiteDB Shell Command Reference

Object reference not set to an instance of an object.
>
```