### PR TITLE
Fix issue with leaking transaction in TransactionMonitor.GetTransaction

### DIFF
--- a/LiteDB/Engine/Services/TransactionMonitor.cs
+++ b/LiteDB/Engine/Services/TransactionMonitor.cs
@@ -73,7 +73,21 @@ namespace LiteDB.Engine
                 // enter in lock transaction after release _transaction lock
                 if (alreadyLock == false)
                 {
-                    _locker.EnterTransaction();
+                    try
+                    {
+                        _locker.EnterTransaction();
+                    }
+                    catch
+                    {
+                        transaction.Dispose();
+                        lock (_transactions)
+                        {
+                            // return pages
+                            _freePages += transaction.MaxTransactionSize;
+                            _transactions.Remove(transaction.TransactionID);
+                        }
+                        throw;
+                    }
                 }
 
                 // do not store in thread query-only transaction


### PR DESCRIPTION
We have problem with our server which eventually became unstable. In log I can see something like:
```
[21:12:18.597] [75] [Error] [Eco] Error inserting stat of type ItemCraftedAction into databaseLiteDB.LiteException: Database lock timeout when entering in transaction mode after 00:01:00
   at LiteDB.Engine.LockService.EnterTransaction()
   at LiteDB.Engine.TransactionMonitor.GetTransaction(Boolean create, Boolean queryOnly, Boolean& isNew)
   at LiteDB.Engine.LiteEngine.AutoTransaction[T](Func`2 fn)
   at LiteDB.Engine.LiteEngine.Insert(String collection, IEnumerable`1 docs, BsonAutoId autoId)
   at LiteDB.LiteCollection`1.Insert(T entity)
   at Eco.Stats.Stats.Record(IStat obj)
 
[21:12:18.597] [146] [Error] [Eco] Error inserting stat of type ItemCraftedAction into databaseLiteDB.LiteException: Database lock timeout when entering in transaction mode after 00:01:00
   at LiteDB.Engine.LockService.EnterTransaction()
   at LiteDB.Engine.TransactionMonitor.GetTransaction(Boolean create, Boolean queryOnly, Boolean& isNew)
   at LiteDB.Engine.LiteEngine.AutoTransaction[T](Func`2 fn)
   at LiteDB.Engine.LiteEngine.Insert(String collection, IEnumerable`1 docs, BsonAutoId autoId)
   at LiteDB.LiteCollection`1.Insert(T entity)
   at Eco.Stats.Stats.Record(IStat obj)
```
eventually followed by
```
[00:29:41.410] [106] [Error] [Eco] Error inserting stat of type ItemCraftedAction into databaseSystem.Threading.SynchronizationLockException: Object synchronization method was called from an unsynchronized block of code.
   at System.Threading.Monitor.Exit(Object obj)
   at LiteDB.Engine.LockService.ExitLock(String collectionName)
   at LiteDB.Engine.TransactionService.Rollback()
   at LiteDB.Engine.LiteEngine.AutoTransaction[T](Func`2 fn)
   at LiteDB.LiteCollection`1.Insert(T entity)
   at Eco.Stats.Stats.Record(IStat obj)
```
and lot of other strange errors like
```
[00:29:08.318] [1100] [Error] [Eco] Error inserting stat of type Play into databaseSystem.IndexOutOfRangeException: Index was outside the bounds of the array.
   at LiteDB.Engine.IndexService.AddNode(CollectionIndex index, BsonValue key, PageAddress dataBlock, Byte level, IndexNode last)
   at LiteDB.Engine.IndexService.AddNode(CollectionIndex index, BsonValue key, PageAddress dataBlock, IndexNode last)
   at LiteDB.Engine.LiteEngine.InsertDocument(Snapshot snapshot, BsonDocument doc, BsonAutoId autoId, IndexService indexer, DataService data)
   at LiteDB.Engine.LiteEngine.<>c__DisplayClass7_0.<Insert>b__0(TransactionService transaction)
   at LiteDB.Engine.LiteEngine.AutoTransaction[T](Func`2 fn)
   at LiteDB.LiteCollection`1.Insert(T entity)
   at Eco.Stats.Stats.Record(IStat obj)
```

I did some investigation and found that it happens because of leaking transactions in TransactionMonitor.GetTransaction:
```csharp
                // must lock _transaction before work with _transactions (GetInitialSize use _transactions)
                lock (_transactions)
                {
                    if (_transactions.Count >= MAX_OPEN_TRANSACTIONS) throw new LiteException(0, "Maximum number of transactions reached");

                    var initialSize = this.GetInitialSize();

                    // check if current thread contains any transaction
                    alreadyLock = _transactions.Values.Any(x => x.ThreadID == Environment.CurrentManagedThreadId);

                    transaction = new TransactionService(_header, _locker, _disk, _walIndex, initialSize, this, queryOnly);

                    // add transaction to execution transaction dict
                    _transactions[transaction.TransactionID] = transaction;
                }

                // enter in lock transaction after release _transaction lock
                if (alreadyLock == false)
                {
                        _locker.EnterTransaction();
                }
```
As you can see in this code if EnterTransaction fails then we have transaction in dictionary which won't be ever removed. So next time when we call GetTransaction on same thread (either if handle exception in the thread or using thread pool) then it will find transaction for this thread id and assume it already locked, but it isn't. It leads to tons of problems including database consistency problems because you can modify database effectively without lock.

I added test which reproduces the case and implemented fix which ensures transaction removed from dictionary in case of exception.

Without the fix I have when try to enter transaction in same thread second time for already locked db:
```
Xunit.Sdk.ThrowsException
Assert.Throws() Failure
Expected: typeof(LiteDB.LiteException)
Actual:   typeof(System.Exception): LiteDB ENSURE: Use EnterTransaction() before EnterLock(name)
```