### PR TITLE
replace ToUpper with ToUpperInvariant

### DIFF
--- a/LiteDB.Stress/Test/InsertTaskItem.cs
+++ b/LiteDB.Stress/Test/InsertTaskItem.cs
@@ -23,7 +23,7 @@ namespace LiteDB.Stress
 
         public InsertTaskItem(XmlElement el)
         {
-            this.Name = string.IsNullOrEmpty(el.GetAttribute("name")) ? "INSERT_" + el.GetAttribute("collection").ToUpper() : el.GetAttribute("name");
+            this.Name = string.IsNullOrEmpty(el.GetAttribute("name")) ? "INSERT_" + el.GetAttribute("collection").ToUpperInvariant() : el.GetAttribute("name");
             this.Sleep = string.IsNullOrEmpty(el.GetAttribute("sleep")) ? TimeSpan.FromSeconds(1) : TimeSpanEx.Parse(el.GetAttribute("sleep"));
             this.AutoId = string.IsNullOrEmpty(el.GetAttribute("autoId")) ? BsonAutoId.ObjectId : (BsonAutoId)Enum.Parse(typeof(BsonAutoId), el.GetAttribute("autoId"), true);
             this.Collection = el.GetAttribute("collection");

--- a/LiteDB.Tests/Mapper/LinqBsonExpression_Tests.cs
+++ b/LiteDB.Tests/Mapper/LinqBsonExpression_Tests.cs
@@ -298,14 +298,14 @@ namespace LiteDB.Tests.Mapper
         public void Linq_Methods()
         {
             // string instance methods
-            TestExpr<User>(x => x.Name.ToUpper(), "UPPER(Name)");
+            TestExpr<User>(x => x.Name.ToUpperInvariant(), "UPPER(Name)");
             TestExpr<User>(x => x.Name.Substring(10), "SUBSTRING(Name, @p0)", 10);
             TestExpr<User>(x => x.Name.Substring(10, 20), "SUBSTRING(Name, @p0, @p1)", 10, 20);
             TestExpr<User>(x => x.Name.Replace('+', '-'), "REPLACE(Name, @p0, @p1)", "+", "-");
             TestExpr<User>(x => x.Name.IndexOf("m"), "INDEXOF(Name, @p0)", "m");
             TestExpr<User>(x => x.Name.IndexOf("m", 20), "INDEXOF(Name, @p0, @p1)", "m", 20);
-            TestExpr<User>(x => x.Name.ToUpper().Trim(), "TRIM(UPPER(Name))");
-            TestExpr<User>(x => x.Name.ToUpper().Trim().PadLeft(5, '0'), "LPAD(TRIM(UPPER($.Name)), @p0, @p1)", 5, "0");
+            TestExpr<User>(x => x.Name.ToUpperInvariant().Trim(), "TRIM(UPPER(Name))");
+            TestExpr<User>(x => x.Name.ToUpperInvariant().Trim().PadLeft(5, '0'), "LPAD(TRIM(UPPER($.Name)), @p0, @p1)", 5, "0");
 
             // string LIKE
             TestExpr<User>(x => x.Name.StartsWith("Mauricio"), "Name LIKE (@p0 + '%')", "Mauricio");
@@ -399,7 +399,7 @@ namespace LiteDB.Tests.Mapper
             TestExpr<User>(x => new User { Id = 1, Active = false }, "{ _id: @p0, Active: @p1 }", 1, false);
 
             // used in UpdateMany extend document
-            TestExpr<User>(x => new User { Name = x.Name.ToUpper(), Salary = x.Salary * 2 }, "{ Name: UPPER($.Name), Salary: ($.Salary * @p0) }", 2);
+            TestExpr<User>(x => new User { Name = x.Name.ToUpperInvariant(), Salary = x.Salary * 2 }, "{ Name: UPPER($.Name), Salary: ($.Salary * @p0) }", 2);
         }
 
         [Fact]

--- a/LiteDB.Tests/Query/Select_Tests.cs
+++ b/LiteDB.Tests/Query/Select_Tests.cs
@@ -31,11 +31,11 @@ namespace LiteDB.Tests.QueryTest
         public void Query_Select_New_Document()
         {
             var r0 = local
-                .Select(x => new {city = x.Address.City.ToUpper(), phone0 = x.Phones[0], address = new Address {Street = x.Name}})
+                .Select(x => new {city = x.Address.City.ToUpperInvariant(), phone0 = x.Phones[0], address = new Address {Street = x.Name}})
                 .ToArray();
 
             var r1 = collection.Query()
-                .Select(x => new {city = x.Address.City.ToUpper(), phone0 = x.Phones[0], address = new Address {Street = x.Name}})
+                .Select(x => new {city = x.Address.City.ToUpperInvariant(), phone0 = x.Phones[0], address = new Address {Street = x.Name}})
                 .ToArray();
 
             foreach (var r in r0.Zip(r1, (l, r) => new {left = l, right = r}))

--- a/LiteDB/Client/Database/Collections/Update.cs
+++ b/LiteDB/Client/Database/Collections/Update.cs
@@ -67,7 +67,7 @@ namespace LiteDB
 
         /// <summary>
         /// Update many document based on merge current document with extend expression. Use your class with initializers. 
-        /// Eg: col.UpdateMany(x => new Customer { Name = x.Name.ToUpper(), Salary: 100 }, x => x.Name == "John")
+        /// Eg: col.UpdateMany(x => new Customer { Name = x.Name.ToUpperInvariant(), Salary: 100 }, x => x.Name == "John")
         /// </summary>
         public int UpdateMany(Expression<Func<T, T>> extend, Expression<Func<T, bool>> predicate)
         {
@@ -79,7 +79,7 @@ namespace LiteDB
 
             if (ext.Type != BsonExpressionType.Document)
             {
-                throw new ArgumentException("Extend expression must return an anonymous class to be merge with entities. Eg: `col.UpdateMany(x => new { Name = x.Name.ToUpper() }, x => x.Age > 10)`");
+                throw new ArgumentException("Extend expression must return an anonymous class to be merge with entities. Eg: `col.UpdateMany(x => new { Name = x.Name.ToUpperInvariant() }, x => x.Age > 10)`");
             }
 
             return _engine.UpdateMany(_collection, ext, pred);

--- a/LiteDB/Client/Database/ILiteCollection.cs
+++ b/LiteDB/Client/Database/ILiteCollection.cs
@@ -71,7 +71,7 @@ namespace LiteDB
 
         /// <summary>
         /// Update many document based on merge current document with extend expression. Use your class with initializers. 
-        /// Eg: col.UpdateMany(x => new Customer { Name = x.Name.ToUpper(), Salary: 100 }, x => x.Name == "John")
+        /// Eg: col.UpdateMany(x => new Customer { Name = x.Name.ToUpperInvariant(), Salary: 100 }, x => x.Name == "John")
         /// </summary>
         int UpdateMany(Expression<Func<T, T>> extend, Expression<Func<T, bool>> predicate);
 

--- a/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
+++ b/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
@@ -177,7 +177,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Visit :: x => x.Customer.Name.`ToUpper()`
+        /// Visit :: x => x.Customer.Name.`ToUpperInvariant()`
         /// </summary>
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {

--- a/LiteDB/Client/SqlParser/Commands/Insert.cs
+++ b/LiteDB/Client/SqlParser/Commands/Insert.cs
@@ -44,7 +44,7 @@ namespace LiteDB
 
                 var type = _tokenizer.ReadToken().Expect(TokenType.Word);
 
-                switch(type.Value.ToUpper())
+                switch(type.Value.ToUpperInvariant())
                 {
                     case "GUID": return BsonAutoId.Guid;
                     case "INT": return BsonAutoId.Int32;

--- a/LiteDB/Client/SqlParser/SqlParser.cs
+++ b/LiteDB/Client/SqlParser/SqlParser.cs
@@ -29,9 +29,9 @@ namespace LiteDB
         {
             var ahead = _tokenizer.LookAhead().Expect(TokenType.Word);
 
-            LOG($"executing `{ahead.Value.ToUpper()}`", "SQL");
+            LOG($"executing `{ahead.Value.ToUpperInvariant()}`", "SQL");
 
-            switch (ahead.Value.ToUpper())
+            switch (ahead.Value.ToUpperInvariant())
             {
                 case "SELECT": 
                 case "EXPLAIN":

--- a/LiteDB/Document/Expression/BsonExpression.cs
+++ b/LiteDB/Document/Expression/BsonExpression.cs
@@ -414,14 +414,14 @@ namespace LiteDB
         /// </summary>
         private static Dictionary<string, MethodInfo> _methods =
             typeof(BsonExpressionMethods).GetMethods(BindingFlags.Public | BindingFlags.Static)
-            .ToDictionary(m => m.Name.ToUpper() + "~" + m.GetParameters().Where(p => p.ParameterType != typeof(Collation)).Count());
+            .ToDictionary(m => m.Name.ToUpperInvariant() + "~" + m.GetParameters().Where(p => p.ParameterType != typeof(Collation)).Count());
 
         /// <summary>
         /// Get expression method with same name and same parameter - return null if not found
         /// </summary>
         internal static MethodInfo GetMethod(string name, int parameterCount)
         {
-            var key = name.ToUpper() + "~" + parameterCount;
+            var key = name.ToUpperInvariant() + "~" + parameterCount;
 
             return _methods.GetOrDefault(key);
         }
@@ -440,7 +440,7 @@ namespace LiteDB
         /// </summary>
         private static Dictionary<string, MethodInfo> _functions =
             typeof(BsonExpressionFunctions).GetMethods(BindingFlags.Public | BindingFlags.Static)
-            .ToDictionary(m => m.Name.ToUpper() + "~" + m.GetParameters()
+            .ToDictionary(m => m.Name.ToUpperInvariant() + "~" + m.GetParameters()
             .Skip(5).Count());
 
         /// <summary>
@@ -448,7 +448,7 @@ namespace LiteDB
         /// </summary>
         internal static MethodInfo GetFunction(string name, int parameterCount = 0)
         {
-            var key = name.ToUpper() + "~" + parameterCount;
+            var key = name.ToUpperInvariant() + "~" + parameterCount;
 
             return _functions.GetOrDefault(key);
         }

--- a/LiteDB/Document/Expression/Parser/BsonExpressionParser.cs
+++ b/LiteDB/Document/Expression/Parser/BsonExpressionParser.cs
@@ -121,7 +121,7 @@ namespace LiteDB
                 }
 
                 values.Add(expr);
-                ops.Add(op.ToUpper());
+                ops.Add(op.ToUpperInvariant());
             }
 
             var order = 0;
@@ -888,7 +888,7 @@ namespace LiteDB
             var useSource = false;
             var fields = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            src.Append(token.Value.ToUpper() + "(");
+            src.Append(token.Value.ToUpperInvariant() + "(");
 
             // method call with no parameters
             if (tokenizer.LookAhead().Type == TokenType.CloseParenthesis)
@@ -926,7 +926,7 @@ namespace LiteDB
 
             var method = BsonExpression.GetMethod(token.Value, pars.Count);
 
-            if (method == null) throw LiteException.UnexpectedToken($"Method '{token.Value.ToUpper()}' does not exist or contains invalid parameters", token);
+            if (method == null) throw LiteException.UnexpectedToken($"Method '{token.Value.ToUpperInvariant()}' does not exist or contains invalid parameters", token);
 
             // test if method are decorated with "Variable" (immutable = false)
             if (method.GetCustomAttribute<VolatileAttribute>() != null)
@@ -1170,7 +1170,7 @@ namespace LiteDB
             if (tokenizer.Current.Type != TokenType.Word) return null;
             if (tokenizer.LookAhead().Type != TokenType.OpenParenthesis) return null;
 
-            var token = tokenizer.Current.Value.ToUpper();
+            var token = tokenizer.Current.Value.ToUpperInvariant();
 
             switch (token)
             {
@@ -1385,7 +1385,7 @@ namespace LiteDB
 
             if (token.Is("ALL") || token.Is("ANY"))
             {
-                var key = token.Value.ToUpper();
+                var key = token.Value.ToUpperInvariant();
 
                 tokenizer.ReadToken(); // consume operant
 
@@ -1474,7 +1474,7 @@ namespace LiteDB
                 Expression = Expression.New(ctor, expr),
                 Left = left,
                 Right = right,
-                Source = left.Source + " " + (type.ToString().ToUpper()) + " " + right.Source
+                Source = left.Source + " " + (type.ToString().ToUpperInvariant()) + " " + right.Source
             };
 
             return result;

--- a/LiteDB/Utils/Collation.cs
+++ b/LiteDB/Utils/Collation.cs
@@ -76,7 +76,7 @@ namespace LiteDB
         public int Compare(char left, char right)
         {
             //TODO implementar o compare corretamente
-            return char.ToUpper(left) == char.ToUpper(right) ? 0 : 1;
+            return char.ToUpperInvariant(left) == char.ToUpperInvariant(right) ? 0 : 1;
         }
 
         public int Compare(BsonValue left, BsonValue rigth)

--- a/LiteDB/Utils/Extensions/StringExtensions.cs
+++ b/LiteDB/Utils/Extensions/StringExtensions.cs
@@ -108,7 +108,7 @@ namespace LiteDB
 
                 if (isWildCardOn)
                 {
-                    if (char.ToUpper(c) == char.ToUpper(p))
+                    if (char.ToUpperInvariant(c) == char.ToUpperInvariant(p))
                     {
                         isWildCardOn = false;
                         patternIndex++;
@@ -120,7 +120,7 @@ namespace LiteDB
                 }
                 else if (isCharSetOn || isNotCharSetOn)
                 {
-                    //var charMatch = (set.Contains(char.ToUpper(c))); // -- always "false" - remove [abc] support
+                    //var charMatch = (set.Contains(char.ToUpperInvariant(c))); // -- always "false" - remove [abc] support
                     //if ((isNotCharSetOn && charMatch) || (isCharSetOn && !charMatch))
 
                     if (isCharSetOn)


### PR DESCRIPTION
Fix for https://github.com/mbdavid/LiteDB/issues/1995. It
Replaces ToUpper with ToUpperInvariant, so Min can't be transformed to MİN