### PR TITLE
fix bug double.NaN

### DIFF
--- a/LiteDB/Document/Json/JsonReader.cs
+++ b/LiteDB/Document/Json/JsonReader.cs
@@ -97,6 +97,8 @@ namespace LiteDB
                         case "null": return BsonValue.Null;
                         case "true": return true;
                         case "false": return false;
+                        case "nan": return double.NaN;
+
                         default: throw LiteException.UnexpectedToken(token);
                     }
             }


### PR DESCRIPTION

// Creates a simple document
BsonDocument doc = new BsonDocument();
doc["Test"] =  double.NaN ;

// Convert to JSON
string json = JsonSerializer.Serialize(doc);

// Convert back to document, exception "Unexpected token `NaN` in position 9" is throw
BsonDocument doc2 = JsonSerializer.Deserialize(json).AsDocument;