### PR TITLE
Throw ENSURE exception also with attached debugger

### DIFF
--- a/LiteDB/Utils/Constants.cs
+++ b/LiteDB/Utils/Constants.cs
@@ -129,10 +129,8 @@ namespace LiteDB
                 {
                     Debug.Fail(message);
                 }
-                else
-                {
-                    throw new Exception("LiteDB ENSURE: " + message);
-                }
+                
+                throw new Exception("LiteDB ENSURE: " + message);
             }
         }
 
@@ -148,10 +146,8 @@ namespace LiteDB
                 {
                     Debug.Fail(message);
                 }
-                else
-                {
-                    throw new Exception("LiteDB ENSURE: " + message);
-                }
+                
+                throw new Exception("LiteDB ENSURE: " + message);
             }
         }
 
@@ -168,10 +164,8 @@ namespace LiteDB
                 {
                     Debug.Fail(message);
                 }
-                else
-                {
-                    throw new Exception("LiteDB DEBUG: " + message);
-                }
+                
+                throw new Exception("LiteDB DEBUG: " + message);
             }
         }
     }


### PR DESCRIPTION
When using the nuget package, in debug builds the ensure swallows any error. The "Debug.Fail()" is being optimized away.

This is the code from the latest nuget package:

```
/// <summary>
    /// Ensure condition is true, otherwise throw exception (check contract)
    /// </summary>
    [DebuggerHidden]
    public static void ENSURE(bool conditional, string message = null)
    {
      if (!conditional && !Debugger.IsAttached)
        throw new Exception("LiteDB ENSURE: " + message);
    }
```

In debug builds, errors are just swallowed without any information.

