### PR TITLE
Changes to properly support Mutexes on NET6.0

### DIFF
--- a/LiteDB/Client/Shared/MutexGenerator.cs
+++ b/LiteDB/Client/Shared/MutexGenerator.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+
+using System.Text;
+using System.Threading;
+using System.Diagnostics;
+
+#if NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NET6_0_OR_GREATER
+using System.Security.AccessControl;
+using System.Security.Principal;
+#endif
+
+namespace LiteDB.Client.Shared;
+
+internal static class MutexGenerator
+{
+#if NET6_0_OR_GREATER
+    private static Mutex CreateMutexForNet6OrGreater(string name)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return new Mutex(false, "Global\\" + name + ".Mutex");
+        }
+
+        var allowEveryoneRule = new MutexAccessRule(new SecurityIdentifier(WellKnownSidType.WorldSid, null),
+                   MutexRights.FullControl, AccessControlType.Allow);
+
+        var securitySettings = new MutexSecurity();
+        securitySettings.AddAccessRule(allowEveryoneRule);
+
+        return MutexAcl.Create(false, "Global\\" + name + ".Mutex", out _, securitySettings);
+    }
+#endif
+
+#if NETSTANDARD2_0_OR_GREATER
+    private static Mutex CreateMutexForNetStandard(string name)
+    {
+        var allowEveryoneRule = new MutexAccessRule(new SecurityIdentifier(WellKnownSidType.WorldSid, null),
+                   MutexRights.FullControl, AccessControlType.Allow);
+
+        var securitySettings = new MutexSecurity();
+        securitySettings.AddAccessRule(allowEveryoneRule);
+
+        var mutex = new Mutex(false, "Global\\" + name + ".Mutex");
+        ThreadingAclExtensions.SetAccessControl(mutex, securitySettings);
+
+        return mutex;
+    }
+#endif
+
+#if NETFRAMEWORK
+    private static Mutex CreateMutexForNetFramework(string name)
+    {
+        var allowEveryoneRule = new MutexAccessRule(new SecurityIdentifier(WellKnownSidType.WorldSid, null),
+                   MutexRights.FullControl, AccessControlType.Allow);
+
+        var securitySettings = new MutexSecurity();
+        securitySettings.AddAccessRule(allowEveryoneRule);
+
+        return new Mutex(false, "Global\\" + name + ".Mutex", out _, securitySettings);
+    }
+#endif
+
+    public static Mutex CreateMutex(string name)
+    {
+#if NET6_0_OR_GREATER
+        return CreateMutexForNet6OrGreater(name);
+#endif
+#if NETSTANDARD2_0_OR_GREATER
+        return CreateMutexForNetStandard(name);
+#endif
+#if NETFRAMEWORK
+        return CreateMutexForNetFramework(name);
+#endif
+
+        return new Mutex(false, "Global\\" + name + ".Mutex");
+    }
+}

--- a/LiteDB/Client/Shared/SharedEngine.cs
+++ b/LiteDB/Client/Shared/SharedEngine.cs
@@ -87,7 +87,7 @@ namespace LiteDB
             }
         }
 
-#region Transaction Operations
+        #region Transaction Operations
 
         public bool BeginTrans()
         {
@@ -139,9 +139,9 @@ namespace LiteDB
             }
         }
 
-#endregion
+        #endregion Transaction Operations
 
-#region Read Operation
+        #region Read Operation
 
         public IBsonDataReader Query(string collection, Query query)
         {
@@ -180,9 +180,9 @@ namespace LiteDB
             }
         }
 
-#endregion
+        #endregion Read Operation
 
-#region Write Operations
+        #region Write Operations
 
         public int Checkpoint()
         {
@@ -352,7 +352,7 @@ namespace LiteDB
             }
         }
 
-#endregion
+        #endregion Write Operations
 
         public void Dispose()
         {

--- a/LiteDB/Client/Shared/SharedEngine.cs
+++ b/LiteDB/Client/Shared/SharedEngine.cs
@@ -5,6 +5,8 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
+using LiteDB.Client.Shared;
+
 #if NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NET6_0_OR_GREATER
 using System.Security.AccessControl;
 using System.Security.Principal;
@@ -27,34 +29,7 @@ namespace LiteDB
 
             try
             {
-#if NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NET6_0_OR_GREATER
-#if NET6_0_OR_GREATER
-                if (!OperatingSystem.IsWindows())
-                    _mutex = new Mutex(false, "Global\\" + name + ".Mutex");
-                else
-                {
-#endif
-                    var allowEveryoneRule = new MutexAccessRule(new SecurityIdentifier(WellKnownSidType.WorldSid, null),
-                           MutexRights.FullControl, AccessControlType.Allow);
-
-                    var securitySettings = new MutexSecurity();
-                    securitySettings.AddAccessRule(allowEveryoneRule);
-#if NET6_0_OR_GREATER
-                    _mutex = MutexAcl.Create(false, "Global\\" + name + ".Mutex", out _, securitySettings);
-#endif
-#if NETFRAMEWORK
-                _mutex = new Mutex(false, "Global\\" + name + ".Mutex", out _, securitySettings);
-#endif
-#if NETSTANDARD2_0_OR_GREATER
-                _mutex = new Mutex(false, "Global\\" + name + ".Mutex");
-                ThreadingAclExtensions.SetAccessControl(_mutex, securitySettings);
-#endif
-#else
-                _mutex = new Mutex(false, "Global\\" + name + ".Mutex");
-#endif
-#if NET6_0_OR_GREATER
-                }
-#endif
+                _mutex = MutexGenerator.CreateMutex(name);
             }
             catch (NotSupportedException ex)
             {

--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net6.0</TargetFrameworks>
+	<TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyVersion>5.0.14</AssemblyVersion>
     <FileVersion>5.0.14</FileVersion>
     <VersionPrefix>5.0.14</VersionPrefix>
@@ -27,6 +27,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LiteDB.xml</DocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SignAssembly>True</SignAssembly>
+	<LangVersion>latest</LangVersion>
   </PropertyGroup>
   
   <!--

--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <AssemblyVersion>5.0.12</AssemblyVersion>
-    <FileVersion>5.0.12</FileVersion>
-    <VersionPrefix>5.0.12</VersionPrefix>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net6.0</TargetFrameworks>
+    <AssemblyVersion>5.0.14</AssemblyVersion>
+    <FileVersion>5.0.14</FileVersion>
+    <VersionPrefix>5.0.14</VersionPrefix>
     <Authors>Maurício David</Authors>
     <Product>LiteDB</Product>
     <Description>LiteDB - A lightweight embedded .NET NoSQL document store in a single datafile</Description>
@@ -12,7 +12,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <Title>LiteDB</Title>
     <PackageId>LiteDB</PackageId>
-    <PackageVersion>5.0.12</PackageVersion>
+    <PackageVersion>5.0.14</PackageVersion>
     <PackageTags>database nosql embedded</PackageTags>
     <PackageIcon>icon_64x64.png</PackageIcon>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -25,9 +25,8 @@
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
     <NoWarn>1701;1702;1705;1591;0618</NoWarn>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LiteDB.xml</DocumentationFile>
-    <SignAssembly Condition="'$(OS)'=='Windows_NT'">true</SignAssembly>
-    <AssemblyOriginatorKeyFile Condition="'$(Configuration)' == 'Release'">LiteDB.snk</AssemblyOriginatorKeyFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <SignAssembly>True</SignAssembly>
   </PropertyGroup>
   
   <!--
@@ -65,7 +64,13 @@
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
   </ItemGroup>
-  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <PackageReference Include="System.Threading.AccessControl" Version="4.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Threading.AccessControl" Version="6.0.0" />
+  </ItemGroup>
+
   <!-- End References -->
 
 </Project>


### PR DESCRIPTION
Global Mutexes were being created without insufficient rights for a 2nd process running on same machine to use them

This fix addresses that by using same methodology applied to NETFRAMEWORK but to NET6.0
