### PR TITLE
Update MemoryCache.cs

### DIFF
--- a/LiteDB/Engine/Disk/MemoryCache.cs
+++ b/LiteDB/Engine/Disk/MemoryCache.cs
@@ -222,6 +222,10 @@ namespace LiteDB.Engine
 
                 added = false;
 
+                // Bug 2184: readable page was updated, need to set the page.ShareCounter back to writeable
+                // so that DiscardPage can free the page and put it into the queue.
+                page.ShareCounter = BUFFER_WRITABLE;
+
                 return current;
             });
 


### PR DESCRIPTION
When readable page is updated from a writable page buffer, the ShareCounter was set to 1 before it is copied, but when writable page is discarded the Ensure will throw an exception because the ShareCounter isn't set to BUFFER_WRITABLE.