### PR TITLE
ResolveMember Extension

### DIFF
--- a/LiteDB/Client/Mapper/BsonMapper.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.cs
@@ -328,7 +328,8 @@ namespace LiteDB
                 this.ResolveMember?.Invoke(type, memberInfo, member);
 
                 // test if has name and there is no duplicate field
-                if (member.FieldName != null && mapper.Members.Any(x => x.FieldName.Equals(name, StringComparison.OrdinalIgnoreCase)) == false)
+                // when member is not ignore
+                if (member.FieldName != null && mapper.Members.Any(x => x.FieldName.Equals(name, StringComparison.OrdinalIgnoreCase)) == false && !member.IsIgnore)
                 {
                     mapper.Members.Add(member);
                 }

--- a/LiteDB/Client/Mapper/MemberMapper.cs
+++ b/LiteDB/Client/Mapper/MemberMapper.cs
@@ -63,5 +63,10 @@ namespace LiteDB
         /// When property is an array of items, gets underlying type (otherwise is same type of PropertyType)
         /// </summary>
         public Type UnderlyingType { get; set; }
+
+        /// <summary>
+        /// Is this property ignore
+        /// </summary>
+        public bool IsIgnore { get; set; }
     }
 }


### PR DESCRIPTION
support Ignore 
code use like 
```C#
BsonMapper.Global.ResolveMember = (Type type, MemberInfo memberInfo, MemberMapper memberMapper) =>
            {
                if (type.IsSubclassOf(typeof(EntityBase)))
                {
                    if (memberInfo.GetCustomAttributes<PrimaryKeyAttribute>().Any())
                    {
                        memberMapper.FieldName = "_id";
                    }
                    if (memberInfo.GetCustomAttributes<AutoIncrementAttribute>().Any())
                    {
                        memberMapper.AutoId = true;
                    }
                    if (memberInfo.GetCustomAttributes<IgnoreAttribute>().Any())
                    {
                        memberMapper.IsIgnore = true;
                    }
                }
            };

```