### PR TITLE
Added unique error codes to encryption-related exceptions

### DIFF
--- a/LiteDB/Engine/Disk/Streams/AesStream.cs
+++ b/LiteDB/Engine/Disk/Streams/AesStream.cs
@@ -65,7 +65,7 @@ namespace LiteDB.Engine
 
                     if (isEncrypted != 1)
                     {
-                        throw new LiteException(0, "This file is not encrypted");
+                        throw LiteException.FileNotEncrypted();
                     }
 
                     _stream.Read(this.Salt, 0, ENCRYPTION_SALT_SIZE);
@@ -116,7 +116,7 @@ namespace LiteDB.Engine
 
                     if (!checkBuffer.All(x => x == 1))
                     {
-                        throw new LiteException(0, "Invalid password");
+                        throw LiteException.InvalidPassword();
                     }
                 }
 

--- a/LiteDB/Engine/FileReader/FileReaderV7.cs
+++ b/LiteDB/Engine/FileReader/FileReaderV7.cs
@@ -32,20 +32,20 @@ namespace LiteDB.Engine
 
             if (password == null && _header["salt"].AsBinary.IsFullZero() == false)
             {
-                throw new LiteException(0, "Current data file requires password");
+                throw LiteException.InvalidPassword();
             }
             else if (password != null)
             {
                 if (_header["salt"].AsBinary.IsFullZero())
                 {
-                    throw new LiteException(0, "Current data file has no encryption - do not use password");
+                    throw LiteException.FileNotEncrypted();
                 }
 
                 var hash = AesEncryption.HashSHA1(password);
 
                 if (hash.SequenceEqual(_header["password"].AsBinary) == false)
                 {
-                    throw new LiteException(0, "Invalid password");
+                    throw LiteException.InvalidPassword();
                 }
             }
 

--- a/LiteDB/Utils/LiteException.cs
+++ b/LiteDB/Utils/LiteException.cs
@@ -51,6 +51,8 @@ namespace LiteDB
         public const int INVALID_INITIALSIZE = 211;
         public const int INVALID_NULL_CHAR_STRING = 212;
         public const int INVALID_FREE_SPACE_PAGE = 213;
+        public const int NOT_ENCRYPTED = 214;
+        public const int INVALID_PASSWORD = 215;
 
         #endregion
 
@@ -304,6 +306,16 @@ namespace LiteDB
         internal static LiteException InvalidFreeSpacePage(uint pageID, int freeBytes, int length)
         {
             return new LiteException(INVALID_FREE_SPACE_PAGE, $"An operation that would corrupt page {pageID} was prevented. The operation required {length} free bytes, but the page had only {freeBytes} available.");
+        }
+
+        internal static LiteException FileNotEncrypted()
+        {
+            return new LiteException(NOT_ENCRYPTED, "File is not encrypted.");
+        }
+
+        internal static LiteException InvalidPassword()
+        {
+            return new LiteException(INVALID_PASSWORD, "Invalid password.");
         }
 
         #endregion


### PR DESCRIPTION
Added dedicated `FileNotEncrypted` and `InvalidPassword` exceptions with their unique error codes to `LiteException`, replaced invocations in `AesStream` and `FileReaderV7`.

Closes https://github.com/mbdavid/LiteDB/issues/2257