### PR TITLE
Change return type of ILiteRepository.Insert to match ILiteDatabase.Insert

### DIFF
--- a/LiteDB/Client/Database/ILiteRepository.cs
+++ b/LiteDB/Client/Database/ILiteRepository.cs
@@ -14,7 +14,7 @@ namespace LiteDB
         /// <summary>
         /// Insert a new document into collection. Document Id must be a new value in collection - Returns document Id
         /// </summary>
-        void Insert<T>(T entity, string collectionName = null);
+        BsonValue Insert<T>(T entity, string collectionName = null);
 
         /// <summary>
         /// Insert an array of new documents into collection. Document Id must be a new value in collection. Can be set buffer size to commit at each N documents

--- a/LiteDB/Client/Database/LiteRepository.cs
+++ b/LiteDB/Client/Database/LiteRepository.cs
@@ -64,9 +64,9 @@ namespace LiteDB
         /// <summary>
         /// Insert a new document into collection. Document Id must be a new value in collection - Returns document Id
         /// </summary>
-        public void Insert<T>(T entity, string collectionName = null)
+        public BsonValue Insert<T>(T entity, string collectionName = null)
         {
-            _db.GetCollection<T>(collectionName).Insert(entity);
+            return _db.GetCollection<T>(collectionName).Insert(entity);
         }
 
         /// <summary>


### PR DESCRIPTION
The documentation of ILiteRepository.Insert implied it returns the ID of the insert, but it returned void

Changed to make this API consistent