### PR TITLE
Update LockService.cs to fix "The read lock is being released without being held" error. Fix for #641, 1637, 1993, 2017

### DIFF
--- a/LiteDB/Engine/Services/LockService.cs
+++ b/LiteDB/Engine/Services/LockService.cs
@@ -53,8 +53,16 @@ namespace LiteDB.Engine
         {
             // if current thread are in reserved mode, do not exit transaction (will be exit from ExitExclusive)
             if (_transaction.IsWriteLockHeld) return;
-
-            _transaction.ExitReadLock();
+            
+            //This can be called when a lock has either been released by the slim or somewhere else therefore there is no lock to release from ExitReadLock()
+            if (_transaction.IsReadLockHeld)
+            {
+                try
+                {
+                    _transaction.ExitReadLock();
+                }
+                catch { }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fix for:
#641, #1637, #1993, #2017

resolving issue of 
"ClassName": "System.Threading.SynchronizationLockException",
"Message": "The read lock is being released without being held.",

Issue is that the ReaderWriterLockSlim can be released or not set if not needed and so the code as it stands will attempt to call ExitReadLock() and this will throw an unhandled exception error. 

I've added and If statement check to ensure there is exactly a ReadLock and also put it in a try catch in the event the Read is released within the small fraction of time the exit is called, so the remaining execution of code can run as needed. 

I suspect that this ReleaseTransaction method that is referenced is multiple places is being called, or its just the lock is released too soon, but this fixes that until a better solution can be implemented. 

I Know other have had this issue, so it would be good to get the PR in or if there is a better place to resolve this let me know and I'll investigate. 