### PR TITLE
Fix Min(Func<T,TResult>) handling

### DIFF
--- a/LiteDB.Tests/Mapper/LinqBsonExpression_Tests.cs
+++ b/LiteDB.Tests/Mapper/LinqBsonExpression_Tests.cs
@@ -180,6 +180,9 @@ namespace LiteDB.Tests.Mapper
 
             // aggregate with map
             TestExpr<User>(x => x.Phones.Sum(w => w.Number), "SUM(MAP($.Phones => @.Number))");
+            TestExpr<User>(x => x.Phones.Average(w => w.Number), "AVG(MAP($.Phones => @.Number))");
+            TestExpr<User>(x => x.Phones.Max(w => w.Number), "MAX(MAP($.Phones => @.Number))");
+            TestExpr<User>(x => x.Phones.Min(w => w.Number), "MIN(MAP($.Phones => @.Number))");
 
             // map
             TestExpr<User>(x => x.Phones.Select(y => y.Type), "MAP($.Phones => @.Type)");

--- a/LiteDB/Client/Mapper/Linq/TypeResolver/EnumerableResolver.cs
+++ b/LiteDB/Client/Mapper/Linq/TypeResolver/EnumerableResolver.cs
@@ -57,7 +57,7 @@ namespace LiteDB
                 case "Sum(Func<T,TResult>)": return "SUM(MAP(@0 => @1))";
                 case "Average(Func<T,TResult>)": return "AVG(MAP(@0 => @1))";
                 case "Max(Func<T,TResult>)": return "MAX(MAP(@0 => @1))";
-                case "Min(Func<T,TResult>)": return "MAP(MIN(@0 => @1))";
+                case "Min(Func<T,TResult>)": return "MIN(MAP(@0 => @1))";
 
                 // convert to array
                 case "ToList()": 


### PR DESCRIPTION
It looks like there's a typo in EnumerableResolver.ResolveMethod()'s handling for "Min(Func<T,TResult>)" (comparing against the three similar query expressions above).

This fixes it (and slightly improves the tests).