### PR TITLE
Bug fix for https://github.com/mbdavid/LiteDB/issues/2298

### DIFF
--- a/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
@@ -194,6 +194,11 @@ namespace LiteDB
 
                 var entity = this.GetEntityMapper(type);
 
+                if (entity.CTor)
+                {
+	                return entity.CreateInstance(doc);
+                }
+
                 // initialize CreateInstance
                 if (entity.CreateInstance == null)
                 {

--- a/LiteDB/Client/Mapper/EntityBuilder.cs
+++ b/LiteDB/Client/Mapper/EntityBuilder.cs
@@ -73,6 +73,7 @@ namespace LiteDB
         /// </summary>
         public EntityBuilder<T> Ctor(Func<BsonDocument, T> createInstance)
         {
+            _entity.CTor = true; // flag _entity as having a customer CTor
             _entity.CreateInstance = v => createInstance(v);
 
             return this;

--- a/LiteDB/Client/Mapper/EntityMapper.cs
+++ b/LiteDB/Client/Mapper/EntityMapper.cs
@@ -33,6 +33,11 @@ namespace LiteDB
         /// </summary>
         public CreateObject CreateInstance { get; set; }
 
+        /// <summary>
+        /// Flag indicating CreateInstance was defined by a CTor
+        /// </summary>
+        internal bool CTor { get; set; } = false;
+
         public EntityMapper(Type forType)
         {
             this.ForType = forType;


### PR DESCRIPTION
Adding flag to EntityMapper that a CTor was defined. This will allow BsonMapper.Deserialize to bypass the regular entity deserialization in favor of the custom defined constructor.