### PR TITLE
Fix #2300 issue with big collection sort

### DIFF
--- a/LiteDB/Engine/Sort/SortDisk.cs
+++ b/LiteDB/Engine/Sort/SortDisk.cs
@@ -88,8 +88,11 @@ namespace LiteDB.Engine
             // there is only a single writer instance, must be lock to ensure only 1 single thread are writing
             lock(writer)
             {
-                writer.Position = position;
-                writer.Write(buffer.Array, buffer.Offset, _containerSize);
+                for (var i = 0; i < _containerSize / PAGE_SIZE; ++i)
+                {
+                    writer.Position = position + i * PAGE_SIZE;
+                    writer.Write(buffer.Array, buffer.Offset + i * PAGE_SIZE, PAGE_SIZE);
+                }
             }
         }
 


### PR DESCRIPTION
One way to fix error sorting large collections in a database with enabled AES encryption.

Now the buffer is written page by page knowing that the container size is always a multiple of the PAGE_SIZE.

This will avoid problems no matter what type of writer is used.