### PR TITLE
Fix for issue: https://github.com/mbdavid/LiteDB/issues/2307

### DIFF
--- a/LiteDB/Engine/Disk/DiskWriterQueue.cs
+++ b/LiteDB/Engine/Disk/DiskWriterQueue.cs
@@ -1,12 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using static LiteDB.Constants;
@@ -24,7 +19,7 @@ namespace LiteDB.Engine
         // async thread controls
         private Task _task;
 
-        private ConcurrentQueue<PageBuffer> _queue = new ConcurrentQueue<PageBuffer>();
+        private readonly ConcurrentQueue<PageBuffer> _queue = new ConcurrentQueue<PageBuffer>();
 
         private int _running = 0;
 
@@ -92,8 +87,6 @@ namespace LiteDB.Engine
         /// </summary>
         private void ExecuteQueue()
         {
-            if (_queue.Count == 0) return;
-
             do
             {
                 if (_queue.TryDequeue(out var page))


### PR DESCRIPTION
Remove if queue empty check that does not reset running flag. If the queue was already emptied out by the previous ExecuteQueue, then this way it will always reset running flag back to 0.