### PR TITLE
Disk problems

### DIFF
--- a/LiteDB/Engine/Disk/DiskService.cs
+++ b/LiteDB/Engine/Disk/DiskService.cs
@@ -186,8 +186,6 @@ namespace LiteDB.Engine
                 count++;
             }
 
-            _queue.Value.Run();
-
             return count;
         }
 

--- a/LiteDB/Engine/Disk/DiskWriterQueue.cs
+++ b/LiteDB/Engine/Disk/DiskWriterQueue.cs
@@ -83,10 +83,22 @@ namespace LiteDB.Engine
                         _queueHasItems.Reset();
                         if (_shouldClose) return;
                     }
-                    _stream.FlushToDisk();
+                    TryFlushStream();
 
                     await _queueHasItems.WaitAsync();
                 }
+            }
+        }
+
+        private void TryFlushStream()
+        {
+            try
+            {
+                _stream.FlushToDisk();
+            }
+            catch (IOException)
+            {
+                // Disk is probably full. This may be unrecoverable problem but until we have enough space in the buffer we may be ok.
             }
         }
 

--- a/LiteDB/Engine/Disk/DiskWriterQueue.cs
+++ b/LiteDB/Engine/Disk/DiskWriterQueue.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using static LiteDB.Constants;
@@ -18,14 +17,17 @@ namespace LiteDB.Engine
 
         // async thread controls
         private Task _task;
+        private bool _shouldClose = false;
 
         private readonly ConcurrentQueue<PageBuffer> _queue = new ConcurrentQueue<PageBuffer>();
-
-        private int _running = 0;
+        private readonly object _queueSync = new object();
+        private readonly ManualResetEventSlim _queueHasItems = new ManualResetEventSlim(false);
+        private readonly ManualResetEventSlim _queueIsEmpty = new ManualResetEventSlim(true);
 
         public DiskWriterQueue(Stream stream)
         {
             _stream = stream;
+            _task = Task.Run(ExecuteQueue);
         }
 
         /// <summary>
@@ -40,27 +42,11 @@ namespace LiteDB.Engine
         public void EnqueuePage(PageBuffer page)
         {
             ENSURE(page.Origin == FileOrigin.Log, "async writer must use only for Log file");
-
-            _queue.Enqueue(page);
-        }
-
-        /// <summary>
-        /// If queue contains pages and are not running, starts run queue again now
-        /// </summary>
-        public void Run()
-        {
-            lock (_queue)
+            lock (_queueSync)
             {
-                if (_queue.Count == 0) return;
-
-                var oldValue = Interlocked.CompareExchange(ref _running, 1, 0);
-
-                if (oldValue == 0)
-                {
-                    // Schedule a new thread to process the pages in the queue.
-                    // https://blog.stephencleary.com/2013/08/startnew-is-dangerous.html
-                    _task = Task.Run(ExecuteQueue);
-                }
+                _queueIsEmpty.Reset();
+                _queue.Enqueue(page);
+                _queueHasItems.Set();
             }
         }
 
@@ -69,16 +55,7 @@ namespace LiteDB.Engine
         /// </summary>
         public void Wait()
         {
-            lock (_queue)
-            {
-                if (_task != null)
-                {
-                    _task.Wait();
-                }
-
-                Run();
-            }
-
+            _queueIsEmpty.Wait();
             ENSURE(_queue.Count == 0, "queue should be empty after wait() call");
         }
 
@@ -87,35 +64,25 @@ namespace LiteDB.Engine
         /// </summary>
         private void ExecuteQueue()
         {
-            do
+            while (true)
             {
                 if (_queue.TryDequeue(out var page))
                 {
                     WritePageToStream(page);
                 }
-
-                while (page == null)
+                else
                 {
                     _stream.FlushToDisk();
-                    Volatile.Write(ref _running, 0);
-
-                    if (!_queue.Any()) return;
-
-                    // Another item was added to the queue after we detected it was empty.
-                    var oldValue = Interlocked.CompareExchange(ref _running, 1, 0);
-
-                    if (oldValue == 1)
+                    lock (_queueSync)
                     {
-                        // A new thread was already scheduled for execution, this thread can return.
-                        return;
+                        if (_queue.Count > 0) continue;
+                        _queueIsEmpty.Set();
                     }
 
-                    // This thread will continue to process the queue as a new thread was not scheduled.
-                    _queue.TryDequeue(out page);
-                    WritePageToStream(page);
+                    _queueHasItems.Wait();
+                    if (_shouldClose) return;
                 }
-
-            } while (true);
+            }
         }
 
         private void WritePageToStream(PageBuffer page)
@@ -137,8 +104,12 @@ namespace LiteDB.Engine
         {
             LOG($"disposing disk writer queue (with {_queue.Count} pages in queue)", "DISK");
 
+            _shouldClose = true;
+            
             // run all items in queue before dispose
             this.Wait();
+            _task?.Wait();
+            _task = null;
         }
     }
 }

--- a/LiteDB/Utils/AsyncManualResetEvent.cs
+++ b/LiteDB/Utils/AsyncManualResetEvent.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace LiteDB
+{
+    /// <summary>
+    /// Async implementation of ManualResetEvent
+    /// https://devblogs.microsoft.com/pfxteam/building-async-coordination-primitives-part-1-asyncmanualresetevent/
+    /// </summary>
+    internal class AsyncManualResetEvent
+    {
+        private volatile TaskCompletionSource<bool> _tcs = new TaskCompletionSource<bool>();
+
+        public Task WaitAsync()
+        {
+            return _tcs.Task;
+        }
+
+        public void Set()
+        {
+            _tcs.TrySetResult(true);
+        }
+
+        public void Reset()
+        {
+            while (true)
+            {
+                var tcs = _tcs;
+                if (!tcs.Task.IsCompleted ||
+                    Interlocked.CompareExchange(ref _tcs, new TaskCompletionSource<bool>(), tcs) == tcs)
+                    return;
+            }
+        }
+    }
+}


### PR DESCRIPTION
this includes https://github.com/mbdavid/LiteDB/pull/2411

Flush fails if the disk is full. But the internal FileStream write buffer may be still big enough to withhold some temporary issues (e.g. disk is full but OS kicks in immediately to clean up temps).

solves https://github.com/mbdavid/LiteDB/issues/2286