### PR TITLE
Fix Rebuild so that it truncates the database file correctly

### DIFF
--- a/LiteDB/Engine/Engine/Rebuild.cs
+++ b/LiteDB/Engine/Engine/Rebuild.cs
@@ -64,7 +64,7 @@ namespace LiteDB.Engine
                 _disk.Write(new[] { _header.UpdateBuffer() }, FileOrigin.Data);
 
                 // set new fileLength
-                _disk.SetLength((_header.LastPageID + 1) * PAGE_SIZE, FileOrigin.Data);
+                _disk.SetLength((long)(_header.LastPageID + 1) * PAGE_SIZE, FileOrigin.Data);
 
                 // get new filelength to compare
                 var newLength = _disk.GetVirtualLength(FileOrigin.Data);


### PR DESCRIPTION
Rebuild operation truncates the database file too short when the file size is greater than 4 GB.
This fix addresses the above issue.