### PR TITLE
Switch to using PackageLicenseExpression

### DIFF
--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -15,7 +15,7 @@
     <PackageId>LiteDB</PackageId>
     <PackageTags>database nosql embedded</PackageTags>
     <PackageIcon>icon_64x64.png</PackageIcon>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://www.litedb.org</PackageProjectUrl>
     <RepositoryUrl>https://github.com/mbdavid/LiteDB</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
By using license expression it will show up correctly on nuget.org and helps license validators/checkers to know what is the exact license type. 