### PR TITLE
Fix security issue for V4

### DIFF
--- a/LiteDB.Tests/Mapper/Mapper_Tests.cs
+++ b/LiteDB.Tests/Mapper/Mapper_Tests.cs
@@ -1,0 +1,21 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace LiteDB.Tests.Mapper
+{
+    public class Mapper_Tests
+    {
+        private BsonMapper _mapper = new BsonMapper();
+
+        [Fact]
+        public void ToDocument_ReturnsNull_WhenFail()
+        {
+            var array = new int[] { 1, 2, 3, 4, 5 };
+            var doc1 = _mapper.ToDocument(array);
+            doc1.Should<BsonDocument>().Be(null);
+
+            var doc2 = _mapper.ToDocument(typeof(int[]), array);
+            doc2.Should<BsonDocument>().Be(null);
+        }
+    }
+}

--- a/LiteDB.Tests/Mapper/Mapper_Tests.cs
+++ b/LiteDB.Tests/Mapper/Mapper_Tests.cs
@@ -1,21 +1,57 @@
-﻿using FluentAssertions;
-using Xunit;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
+using System;
+using System.IO;
+
 
 namespace LiteDB.Tests.Mapper
 {
+    [TestClass]
     public class Mapper_Tests
     {
         private BsonMapper _mapper = new BsonMapper();
 
-        [Fact]
+        [TestMethod]
         public void ToDocument_ReturnsNull_WhenFail()
         {
             var array = new int[] { 1, 2, 3, 4, 5 };
             var doc1 = _mapper.ToDocument(array);
-            doc1.Should<BsonDocument>().Be(null);
+            Assert.IsNull(doc1);
 
             var doc2 = _mapper.ToDocument(typeof(int[]), array);
-            doc2.Should<BsonDocument>().Be(null);
+            Assert.IsNull(doc2);
+        }
+
+        [TestMethod]
+        public void Class_Not_Assignable()
+        {
+            using (var db = new LiteDatabase(new MemoryStream()))
+            {
+                var col = db.GetCollection<MyClass>("Test");
+                col.Insert(new MyClass { Id = 1, Member = null });
+                var type = typeof(OtherClass);
+                var typeName = type.FullName + ", " + type.GetTypeInfo().Assembly.GetName().Name;
+
+                var bsonDocumentCollection = db.GetCollection("Test");
+                var bsonDocument = bsonDocumentCollection.FindById(1);
+                bsonDocument["_type"] = typeName;
+
+                bsonDocumentCollection.Update(bsonDocument);
+
+                Func<MyClass> func = (() => col.FindById(1));
+                Assert.ThrowsException<LiteException>(func);
+            }
+        }
+
+        public class MyClass
+        {
+            public int Id { get; set; }
+            public MyClass Member { get; set; }
+        }
+
+        public class OtherClass
+        {
+            public string Name { get; set; }
         }
     }
 }

--- a/LiteDB.sln
+++ b/LiteDB.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26730.3

--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
     <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>

--- a/LiteDB/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Mapper/BsonMapper.Deserialize.cs
@@ -150,13 +150,18 @@ namespace LiteDB
             // if value is document, deserialize as document
             else if (value.IsDocument)
             {
-                BsonValue typeField;
+                // if type is anonymous use special handler
+                if (type.IsAnonymousType())
+                {
+                    return this.DeserializeAnonymousType(type, value.AsDocument);
+                }
+
                 var doc = value.AsDocument;
 
                 // test if value is object and has _type
-                if (doc.RawValue.TryGetValue("_type", out typeField))
+                if (doc.TryGetValue("_type", out var typeField) && typeField.IsString)
                 {
-                    type = Type.GetType(typeField.AsString);
+                    var actualType = Type.GetType(typeField.AsString);
 
                     if (actualType == null) throw LiteException.InvalidTypedName(typeField.AsString);
 
@@ -274,6 +279,23 @@ namespace LiteDB
                     }
                 }
             }
+        }
+
+        private object DeserializeAnonymousType(Type type, BsonDocument value)
+        {
+            var args = new List<object>();
+            var ctor = type.GetConstructors()[0];
+
+            foreach (var par in ctor.GetParameters())
+            {
+                var arg = this.Deserialize(par.ParameterType, value[par.Name]);
+
+                args.Add(arg);
+            }
+
+            var obj = Activator.CreateInstance(type, args.ToArray());
+
+            return obj;
         }
     }
 }

--- a/LiteDB/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Mapper/BsonMapper.Deserialize.cs
@@ -168,8 +168,7 @@ namespace LiteDB
 
                     // avoid use of "System.Diagnostics.Process" in object type definition
                     // using String test to work in .netstandard 1.3
-                    if (actualType.FullName.Equals("System.Diagnostics.Process", StringComparison.OrdinalIgnoreCase) &&
-                        actualType.Assembly.GetName().Name.Equals("System", StringComparison.OrdinalIgnoreCase))
+                    if (actualType.FullName.Equals("System.Diagnostics.Process", StringComparison.OrdinalIgnoreCase))
                     {
                         throw LiteException.AvoidUseOfProcess();
                     }

--- a/LiteDB/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Mapper/BsonMapper.Deserialize.cs
@@ -159,7 +159,20 @@ namespace LiteDB
                     type = Type.GetType(typeField.AsString);
 
                     if (actualType == null) throw LiteException.InvalidTypedName(typeField.AsString);
-                    if (!type.IsAssignableFrom(actualType)) throw LiteException.DataTypeNotAssignable(type.FullName, actualType.FullName);
+
+                    // avoid initialize class that are not assignable 
+                    if (!type.IsAssignableFrom(actualType))
+                    {
+                        throw LiteException.DataTypeNotAssignable(type.FullName, actualType.FullName);
+                    }
+
+                    // avoid use of "System.Diagnostics.Process" in object type definition
+                    // using String test to work in .netstandard 1.3
+                    if (actualType.FullName.Equals("System.Diagnostics.Process", StringComparison.OrdinalIgnoreCase) &&
+                        actualType.Assembly.GetName().Name.Equals("System", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw LiteException.AvoidUseOfProcess();
+                    }
 
                     type = actualType;
                 }

--- a/LiteDB/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Mapper/BsonMapper.Deserialize.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
@@ -158,7 +158,10 @@ namespace LiteDB
                 {
                     type = Type.GetType(typeField.AsString);
 
-                    if (type == null) throw LiteException.InvalidTypedName(typeField.AsString);
+                    if (actualType == null) throw LiteException.InvalidTypedName(typeField.AsString);
+                    if (!type.IsAssignableFrom(actualType)) throw LiteException.DataTypeNotAssignable(type.FullName, actualType.FullName);
+
+                    type = actualType;
                 }
                 // when complex type has no definition (== typeof(object)) use Dictionary<string, object> to better set values
                 else if (type == typeof(object))

--- a/LiteDB/Mapper/BsonMapper.Serialize.cs
+++ b/LiteDB/Mapper/BsonMapper.Serialize.cs
@@ -26,7 +26,7 @@ namespace LiteDB
         /// </summary>
         public virtual BsonDocument ToDocument<T>(T entity)
         {
-            return this.ToDocument(typeof(T), entity).AsDocument;
+            return this.ToDocument(typeof(T), entity)?.AsDocument;
         }
 
         internal BsonValue Serialize(Type type, object obj, int depth)

--- a/LiteDB/Utils/Extensions/TypeInfoExtensions.cs
+++ b/LiteDB/Utils/Extensions/TypeInfoExtensions.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Reflection;
+using System.Collections;
+using System.Runtime.CompilerServices;
 
 namespace LiteDB
 {
@@ -21,5 +23,21 @@ namespace LiteDB
             return type;
         }
 #endif
+
+        public static bool IsAnonymousType(this Type type)
+        {
+            bool isAnonymousType =
+                type.FullName.Contains("AnonymousType") &&
+                type.GetTypeInfo().GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Any();
+
+            return isAnonymousType;
+        }
+
+        public static bool IsEnumerable(this Type type)
+        {
+            return
+                type != typeof(String) &&
+                typeof(IEnumerable).IsAssignableFrom(type);
+        }
     }
 }

--- a/LiteDB/Utils/LiteException.cs
+++ b/LiteDB/Utils/LiteException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 
 namespace LiteDB

--- a/LiteDB/Utils/LiteException.cs
+++ b/LiteDB/Utils/LiteException.cs
@@ -38,6 +38,12 @@ namespace LiteDB
         public const int INVALID_TYPED_NAME = 207;
         public const int NEED_RECOVER = 208;
         public const int PROPERTY_READ_WRITE = 209;
+        public const int INITIALSIZE_CRYPTO_NOT_SUPPORTED = 210;
+        public const int INVALID_INITIALSIZE = 211;
+        public const int INVALID_NULL_CHAR_STRING = 212;
+        public const int INVALID_FREE_SPACE_PAGE = 213;
+        public const int DATA_TYPE_NOT_ASSIGNABLE = 214;
+        public const int AVOID_USE_OF_PROCESS = 215;
 
         #endregion
 
@@ -205,6 +211,44 @@ namespace LiteDB
                 Line = s.Source,
                 Position = s.Index
             };
+        }
+
+        internal static LiteException InvalidInitialSize()
+        {
+            return new LiteException(INVALID_INITIALSIZE, "Initial Size must be a multiple of page size ({0} bytes).", PAGE_SIZE);
+        }
+
+        internal static LiteException InvalidNullCharInString()
+        {
+            return new LiteException(INVALID_NULL_CHAR_STRING, "Invalid null character (\\0) was found in the string");
+        }
+
+        internal static LiteException InvalidPageType(PageType pageType, BasePage page)
+        {
+            var sb = new StringBuilder($"Invalid {pageType} on {page.PageID}. ");
+
+            sb.Append($"Full zero: {page.Buffer.All(0)}. ");
+            sb.Append($"Page Type: {page.PageType}. ");
+            sb.Append($"Prev/Next: {page.PrevPageID}/{page.NextPageID}. ");
+            sb.Append($"UniqueID: {page.Buffer.UniqueID}. ");
+            sb.Append($"ShareCounter: {page.Buffer.ShareCounter}. ");
+
+            return new LiteException(0, sb.ToString());
+        }
+
+        internal static LiteException InvalidFreeSpacePage(uint pageID, int freeBytes, int length)
+        {
+            return new LiteException(INVALID_FREE_SPACE_PAGE, $"An operation that would corrupt page {pageID} was prevented. The operation required {length} free bytes, but the page had only {freeBytes} available.");
+        }
+
+        internal static LiteException DataTypeNotAssignable(string type1, string type2)
+        {
+            return new LiteException(DATA_TYPE_NOT_ASSIGNABLE, $"Data type {type1} is not assignable from data type {type2}");
+        }
+
+        internal static LiteException AvoidUseOfProcess()
+        {
+            return new LiteException(AVOID_USE_OF_PROCESS, $"LiteDB do not accept System.Diagnostics.Process class in deserialize mapper");
         }
 
         #endregion

--- a/LiteDB/Utils/LiteException.cs
+++ b/LiteDB/Utils/LiteException.cs
@@ -213,27 +213,9 @@ namespace LiteDB
             };
         }
 
-        internal static LiteException InvalidInitialSize()
-        {
-            return new LiteException(INVALID_INITIALSIZE, "Initial Size must be a multiple of page size ({0} bytes).", PAGE_SIZE);
-        }
-
         internal static LiteException InvalidNullCharInString()
         {
             return new LiteException(INVALID_NULL_CHAR_STRING, "Invalid null character (\\0) was found in the string");
-        }
-
-        internal static LiteException InvalidPageType(PageType pageType, BasePage page)
-        {
-            var sb = new StringBuilder($"Invalid {pageType} on {page.PageID}. ");
-
-            sb.Append($"Full zero: {page.Buffer.All(0)}. ");
-            sb.Append($"Page Type: {page.PageType}. ");
-            sb.Append($"Prev/Next: {page.PrevPageID}/{page.NextPageID}. ");
-            sb.Append($"UniqueID: {page.Buffer.UniqueID}. ");
-            sb.Append($"ShareCounter: {page.Buffer.ShareCounter}. ");
-
-            return new LiteException(0, sb.ToString());
         }
 
         internal static LiteException InvalidFreeSpacePage(uint pageID, int freeBytes, int length)


### PR DESCRIPTION
Fix the [severity issue](https://github.com/advisories/GHSA-3x49-g6rc-c284) for the old v4 liteDB version.
The goal is to have a patch for application who cannot update to V5.

Because this is my first PR for this project I think my changes should be properly checked and validated.

fix #2418 

PS: This branch should not be merged on master but probably stay on a fix branch.