### PR TITLE
Fixed memory leak due to infinite static caches

### DIFF
--- a/LiteDB/Document/Expression/BsonExpression.cs
+++ b/LiteDB/Document/Expression/BsonExpression.cs
@@ -284,6 +284,11 @@ namespace LiteDB
         private static readonly IMemoryCache _cacheScalar = new MemoryCache(new MemoryCacheOptions());
 
         /// <summary>
+        /// Gets or sets how long a cache entry can be inactive (e.g. not accessed) before it will be removed.
+        /// </summary>
+        public static TimeSpan? CacheSlidingExpiration { get; set; }
+
+        /// <summary>
         /// Parse string and create new instance of BsonExpression - can be cached
         /// </summary>
         public static BsonExpression Create(string expression)
@@ -361,7 +366,7 @@ namespace LiteDB
             {
                 var cached = _cacheScalar.GetOrCreate(expr.Source, cacheEntry =>
                 {
-                    cacheEntry.SlidingExpiration = TimeSpan.FromMinutes(1);
+                    cacheEntry.SlidingExpiration = CacheSlidingExpiration;
 
                     var lambda = Expression.Lambda<BsonExpressionScalarDelegate>(expr.Expression, context.Source, context.Root, context.Current, context.Collation, context.Parameters);
 
@@ -374,7 +379,7 @@ namespace LiteDB
             {
                 var cached = _cacheEnumerable.GetOrCreate(expr.Source, cacheEntry =>
                 {
-                    cacheEntry.SlidingExpiration = TimeSpan.FromMinutes(1);
+                    cacheEntry.SlidingExpiration = CacheSlidingExpiration;
 
                     var lambda = Expression.Lambda<BsonExpressionEnumerableDelegate>(expr.Expression, context.Source, context.Root, context.Current, context.Collation, context.Parameters);
 

--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net4.5;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net4.5.1;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyVersion>5.0.19</AssemblyVersion>
     <FileVersion>5.0.19</FileVersion>
     <VersionPrefix>5.0.19</VersionPrefix>
@@ -56,15 +56,24 @@
     <None Include="..\icon_64x64.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net4.5.1'">
     <Reference Include="System" />
     <Reference Include="System.Runtime" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
+  </ItemGroup>
+
   
   <!-- End References -->
 

--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net4.5.1;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net4.5;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyVersion>5.0.19</AssemblyVersion>
     <FileVersion>5.0.19</FileVersion>
     <VersionPrefix>5.0.19</VersionPrefix>
@@ -42,7 +42,7 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net4.5'">
     <DefineConstants>HAVE_SHA1_MANAGED;HAVE_APP_DOMAIN;HAVE_PROCESS;HAVE_ENVIRONMENT</DefineConstants>
   </PropertyGroup>
 
@@ -56,24 +56,15 @@
     <None Include="..\icon_64x64.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net4.5.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net4.5'">
     <Reference Include="System" />
     <Reference Include="System.Runtime" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
-  </ItemGroup>
-
   
   <!-- End References -->
 

--- a/LiteDB/Utils/SlidingCache.cs
+++ b/LiteDB/Utils/SlidingCache.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace LiteDB.Utils
+{
+    public class SlidingCache<TKey, TValue> : IDisposable
+    {
+        private readonly ConcurrentDictionary<TKey, CacheItem<TValue>> _cache = new ConcurrentDictionary<TKey, CacheItem<TValue>>();
+        private readonly Timer _timer;
+
+        public SlidingCache(TimeSpan expirationScanFrequency)
+        {
+            _timer = new Timer(OnTimerCallback, null, expirationScanFrequency, expirationScanFrequency);
+        }
+
+        public void Dispose()
+        {
+            _timer?.Dispose();
+        }
+
+        public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory, TimeSpan? slidingExpiration = default)
+        {
+            if (key == null)
+                throw new ArgumentNullException(nameof(key));
+            if (valueFactory == null)
+                throw new ArgumentNullException(nameof(valueFactory));
+            
+            var cacheItem = _cache.GetOrAdd(key, k => new CacheItem<TValue>(valueFactory(k), DateTime.UtcNow, slidingExpiration));
+            cacheItem.LastAccessed = DateTime.UtcNow;
+
+            return cacheItem.Value;
+        }
+
+        private void OnTimerCallback(object state)
+        {
+            var now = DateTime.UtcNow;
+            foreach (var pair in _cache)
+            {
+                var key = pair.Key;
+                var item = pair.Value;
+                if (item.Expired(now))
+                    _cache.TryRemove(key, out _);
+            }
+        }
+
+        private class CacheItem<T>
+        {
+            private readonly TimeSpan? _slidingExpiration;
+
+            public CacheItem(T value, DateTime lastAccessed, TimeSpan? slidingExpiration)
+            {
+                _slidingExpiration = slidingExpiration;
+                Value = value;
+                LastAccessed = lastAccessed;
+            }
+
+            public T Value { get; }
+            public DateTime LastAccessed { get; set; }
+
+            public bool Expired(DateTime now)
+            {
+                if (_slidingExpiration == null)
+                    return false;
+
+                return now - LastAccessed > _slidingExpiration;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Use MemoryCache with fixed SlidingExpiration.
Increasing the required framework version to 4.5.1
Not the best solution, but better than endlessly eating up memory

#2421