### PR TITLE
Don't capture synchronization context in DiskWriterQueue

### DIFF
--- a/LiteDB/Engine/Disk/DiskWriterQueue.cs
+++ b/LiteDB/Engine/Disk/DiskWriterQueue.cs
@@ -50,15 +50,15 @@ namespace LiteDB.Engine
             // throw last exception that stop running queue
             if (_exception != null) throw _exception;
 
+            _queueIsEmpty.Reset();
+            _queue.Enqueue(page);
+            _queueHasItems.Set();
+
             lock (_queueSync)
             {
-                _queueIsEmpty.Reset();
-                _queue.Enqueue(page);
-                _queueHasItems.Set();
-
                 if (_task == null)
                 {
-                    _task = Task.Factory.StartNew(ExecuteQueue, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+                    _task = Task.Factory.StartNew(ExecuteQueue, TaskCreationOptions.LongRunning);
                 }
             }
         }
@@ -76,7 +76,7 @@ namespace LiteDB.Engine
         /// <summary>
         /// Execute all items in queue sync
         /// </summary>
-        private async Task ExecuteQueue()
+        private void ExecuteQueue()
         {
             try
             {
@@ -88,19 +88,17 @@ namespace LiteDB.Engine
                     }
                     else
                     {
-                        lock (_queueSync)
-                        {
-                            if (_queue.Count > 0) continue;
 
-                            _queueIsEmpty.Set();
-                            _queueHasItems.Reset();
+                        if (_queue.Count > 0) continue;
 
-                            if (_shouldClose) return;
-                        }
+                        _queueIsEmpty.Set();
+                        _queueHasItems.Reset();
+
+                        if (_shouldClose) return;
 
                         _stream.FlushToDisk();
 
-                        await _queueHasItems.WaitAsync().ConfigureAwait(false);
+                        _queueHasItems.WaitAsync().GetAwaiter().GetResult();
                     }
                 }
             }
@@ -137,7 +135,7 @@ namespace LiteDB.Engine
             _shouldClose = true;
             _queueHasItems.Set(); // unblock the running loop in case there are no items
 
-            _task?.Wait();
+            _task?.GetAwaiter().GetResult();
             _task = null;
         }
     }

--- a/LiteDB/Engine/Disk/DiskWriterQueue.cs
+++ b/LiteDB/Engine/Disk/DiskWriterQueue.cs
@@ -58,7 +58,7 @@ namespace LiteDB.Engine
 
                 if (_task == null)
                 {
-                    _task = Task.Factory.StartNew(ExecuteQueue, TaskCreationOptions.LongRunning);
+                    _task = Task.Factory.StartNew(ExecuteQueue, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
                 }
             }
         }
@@ -100,7 +100,7 @@ namespace LiteDB.Engine
 
                         _stream.FlushToDisk();
 
-                        await _queueHasItems.WaitAsync();
+                        await _queueHasItems.WaitAsync().ConfigureAwait(false);
                     }
                 }
             }


### PR DESCRIPTION
This addresses #2446 

Task.Factory.StartNew tries to use task scheduler from the current task, so TaskScheduler.Default needs to be passed here.