### PR TITLE
Fix LockRecursionException when doing FindById

### DIFF
--- a/LiteDB.Tests/Internals/Extensions_Test.cs
+++ b/LiteDB.Tests/Internals/Extensions_Test.cs
@@ -1,0 +1,44 @@
+﻿using LiteDB.Utils.Extensions;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace LiteDB.Tests.Internals;
+
+public class Extensions_Test
+{
+    // Asserts that chained IEnumerable<T>.OnDispose(()=> { }) calls the action on dispose, even when chained
+    [Fact]
+    public void EnumerableExtensions_OnDispose()
+    {
+        var disposed = false;
+        var disposed1 = false;
+        var enumerable = new[] { 1, 2, 3 }.OnDispose(() => disposed = true).OnDispose(() => disposed1 = true);
+
+        foreach (var item in enumerable)
+        {
+            // do nothing
+        }
+
+        Assert.True(disposed);
+        Assert.True(disposed1);
+    }
+
+    // tests IDisposable StartDisposable(this Stopwatch stopwatch)
+    [Fact]
+    public async Task StopWatchExtensions_StartDisposable()
+    {
+        var stopwatch = new System.Diagnostics.Stopwatch();
+        using (stopwatch.StartDisposable())
+        {
+            await Task.Delay(100);
+        }
+
+        Assert.True(stopwatch.ElapsedMilliseconds > 0);
+    }
+}

--- a/LiteDB.Tests/Issues/Issue2471_Test.cs
+++ b/LiteDB.Tests/Issues/Issue2471_Test.cs
@@ -46,4 +46,52 @@ public class Issue2471_Test
             collection.FindById(1);
         }
     }
+
+    #region Model
+
+    public class User
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public int[] Phones { get; set; }
+        public List<Address> Addresses { get; set; }
+    }
+
+    public class Address
+    {
+        public string Street { get; set; }
+    }
+
+    #endregion Model
+
+    // Copied from IndexMultiKeyIndex, but this time we ensure that the lock is released by calling  db.Checkpoint()
+    [Fact]
+    public void Ensure_Query_GetPlan_Releases_Lock()
+    {
+        using var db = new LiteDatabase(new MemoryStream());
+        var col = db.GetCollection<User>();
+
+        col.Insert(new User { Name = "John Doe", Phones = new int[] { 1, 3, 5 }, Addresses = new List<Address> { new Address { Street = "Av.1" }, new Address { Street = "Av.3" } } });
+        col.Insert(new User { Name = "Joana Mark", Phones = new int[] { 1, 4 }, Addresses = new List<Address> { new Address { Street = "Av.3" } } });
+
+        // create indexes
+        col.EnsureIndex(x => x.Phones);
+        col.EnsureIndex(x => x.Addresses.Select(z => z.Street));
+
+        // testing indexes expressions
+        var indexes = db.GetCollection("$indexes").FindAll().ToArray();
+
+        indexes[1]["expression"].AsString.Should().Be("$.Phones[*]");
+        indexes[2]["expression"].AsString.Should().Be("MAP($.Addresses[*]=>@.Street)");
+
+        // doing Phone query
+        var queryPhone = col.Query()
+            .Where(x => x.Phones.Contains(3));
+
+        var planPhone = queryPhone.GetPlan();
+
+        Action act = () => db.Checkpoint();
+
+        act.Should().NotThrow();
+    }
 }

--- a/LiteDB.Tests/Issues/Issue2471_Test.cs
+++ b/LiteDB.Tests/Issues/Issue2471_Test.cs
@@ -1,0 +1,49 @@
+﻿using FluentAssertions;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace LiteDB.Tests.Issues;
+
+public class Issue2471_Test
+{
+    [Fact]
+    public void TestFragmentDB_FindByIDException()
+    {
+        using var db = new LiteDatabase(":memory:");
+        var collection = db.GetCollection<object>("fragtest");
+
+        var fragment = new object { };
+        var id = collection.Insert(fragment);
+
+        id.Should().BeGreaterThan(0);
+
+        var frag2 = collection.FindById(id);
+        frag2.Should().NotBeNull();
+
+        Action act = () => db.Checkpoint();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void MultipleReadCleansUpTransaction()
+    {
+        using var database = new LiteDatabase(":memory:");
+
+        var collection = database.GetCollection("test");
+        collection.Insert(new BsonDocument { ["_id"] = 1 });
+
+        for (int i = 0; i < 500; i++)
+        {
+            collection.FindById(1);
+        }
+    }
+}

--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -28,6 +28,7 @@
     <SignAssembly Condition="'$(OS)'=='Windows_NT'">true</SignAssembly>
     <AssemblyOriginatorKeyFile Condition="'$(Configuration)' == 'Release'">LiteDB.snk</AssemblyOriginatorKeyFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   
   <!--

--- a/LiteDB/Utils/Extensions/EnumerableExtensions.cs
+++ b/LiteDB/Utils/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LiteDB.Utils.Extensions
+{
+    internal static class EnumerableExtensions
+    {
+        // calls method on dispose
+        public static IEnumerable<T> OnDispose<T>(this IEnumerable<T> source, Action onDispose)
+        {
+            try
+            {
+                foreach (var item in source)
+                {
+                    yield return item;
+                }
+            }
+            finally
+            {
+                onDispose();
+            }
+        }
+    }
+}

--- a/LiteDB/Utils/Extensions/EnumerableExtensions.cs
+++ b/LiteDB/Utils/Extensions/EnumerableExtensions.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LiteDB.Utils.Extensions
 {

--- a/LiteDB/Utils/Extensions/StopWatchExtensions.cs
+++ b/LiteDB/Utils/Extensions/StopWatchExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace LiteDB.Utils.Extensions
+{
+    public static class StopWatchExtensions
+    {
+        // Start the stopwatch and returns an IDisposable that will stop the stopwatch when disposed
+        public static IDisposable StartDisposable(this Stopwatch stopwatch)
+        {
+            stopwatch.Start();
+            return new DisposableAction(stopwatch.Stop);
+        }
+
+        private class DisposableAction : IDisposable
+        {
+            private readonly Action _action;
+
+            public DisposableAction(Action action)
+            {
+                _action = action;
+            }
+
+            public void Dispose()
+            {
+                _action();
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes #2471, https://github.com/mbdavid/LiteDB/issues/2435, https://github.com/mbdavid/LiteDB/issues/2483

Problem was, that the enumerator did not release the readlock when doing FindById. When the Checkpoint then tried to aquire a writelock, the semaphore threw an exception, because there was still a readlock pending.

