### PR TITLE
Add support for on-the-fly document upgrades

### DIFF
--- a/LiteDB.Tests/Database/DocumentUpgrade_Tests.cs
+++ b/LiteDB.Tests/Database/DocumentUpgrade_Tests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 
 using LiteDB.Engine;
 
@@ -38,10 +38,24 @@ public class DocumentUpgrade_Tests
 
         ms.Position = 0;
 
-        var engine = new LiteEngine(new EngineSettings
+        using var engine = new LiteEngine(new EngineSettings
         {
             DataStream = ms,
-            ReadTransform = ReadTransform
+            ReadTransform = (collectionName, val) =>
+            {
+                if (val is not BsonDocument doc)
+                {
+                    return val;
+                }
+
+                if (doc.TryGetValue("version", out var version) && version.AsInt32 == 1)
+                {
+                    doc["version"] = 2;
+                    doc["age"] = 30;
+                }
+
+                return val;
+            }
         });
 
         using (var db = new LiteDatabase(engine))
@@ -58,19 +72,62 @@ public class DocumentUpgrade_Tests
         }
     }
 
-    private BsonValue ReadTransform(string arg1, BsonValue val)
+    [Fact]
+    public void DocumentUpgrade_BsonMapper_Test()
     {
-        if (!(val is BsonDocument bdoc))
+        var ms = new MemoryStream();
+        using (var db = new LiteDatabase(ms))
         {
-            return val;
+            var col = db.GetCollection("col");
+
+            col.Insert(new BsonDocument { ["version"] = 1, ["_id"] = 1, ["name"] = "John" });
         }
 
-        if (bdoc.TryGetValue("version", out var version) && version.AsInt32 == 1)
+        ms.Position = 0;
+
+        using (var db = new LiteDatabase(ms))
         {
-            bdoc["version"] = 2;
-            bdoc["age"] = 30;
+            var col = db.GetCollection("col");
+
+            col.Count().Should().Be(1);
+
+            var doc = col.FindById(1);
+
+            doc["version"].AsInt32.Should().Be(1);
+            doc["name"].AsString.Should().Be("John");
+            doc["age"].AsInt32.Should().Be(0);
         }
 
-        return val;
+        ms.Position = 0;
+
+        var mapper = new BsonMapper();
+        mapper.OnDeserialization = (sender, type, val) =>
+        {
+            if (val is not BsonDocument doc)
+            {
+                return val;
+            }
+
+            if (doc.TryGetValue("version", out var version) && version.AsInt32 == 1)
+            {
+                doc["version"] = 2;
+                doc["age"] = 30;
+            }
+
+            return doc;
+        };
+
+        using (var db = new LiteDatabase(ms, mapper))
+        {
+            var col = db.GetCollection("col");
+
+            col.Count().Should().Be(1);
+
+            var doc = col.FindById(1);
+
+            doc["version"].AsInt32.Should().Be(2);
+            doc["name"].AsString.Should().Be("John");
+            doc["age"].AsInt32.Should().Be(30);
+        }
     }
 }

--- a/LiteDB.Tests/Database/DocumentUpgrade_Tests.cs
+++ b/LiteDB.Tests/Database/DocumentUpgrade_Tests.cs
@@ -1,0 +1,76 @@
+﻿using FluentAssertions;
+
+using LiteDB.Engine;
+
+using System.IO;
+
+using Xunit;
+
+namespace LiteDB.Tests.Database;
+
+public class DocumentUpgrade_Tests
+{
+    [Fact]
+    public void DocumentUpgrade_Test()
+    {
+        var ms = new MemoryStream();
+        using (var db = new LiteDatabase(ms))
+        {
+            var col = db.GetCollection("col");
+
+            col.Insert(new BsonDocument { ["version"] = 1, ["_id"] = 1, ["name"] = "John" });
+        }
+
+        ms.Position = 0;
+
+        using (var db = new LiteDatabase(ms))
+        {
+            var col = db.GetCollection("col");
+
+            col.Count().Should().Be(1);
+
+            var doc = col.FindById(1);
+
+            doc["version"].AsInt32.Should().Be(1);
+            doc["name"].AsString.Should().Be("John");
+            doc["age"].AsInt32.Should().Be(0);
+        }
+
+        ms.Position = 0;
+
+        var engine = new LiteEngine(new EngineSettings
+        {
+            DataStream = ms,
+            ReadTransform = ReadTransform
+        });
+
+        using (var db = new LiteDatabase(engine))
+        {
+            var col = db.GetCollection("col");
+
+            col.Count().Should().Be(1);
+
+            var doc = col.FindById(1);
+
+            doc["version"].AsInt32.Should().Be(2);
+            doc["name"].AsString.Should().Be("John");
+            doc["age"].AsInt32.Should().Be(30);
+        }
+    }
+
+    private BsonValue ReadTransform(string arg1, BsonValue val)
+    {
+        if (!(val is BsonDocument bdoc))
+        {
+            return val;
+        }
+
+        if (bdoc.TryGetValue("version", out var version) && version.AsInt32 == 1)
+        {
+            bdoc["version"] = 2;
+            bdoc["age"] = 30;
+        }
+
+        return val;
+    }
+}

--- a/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
@@ -9,6 +9,24 @@ namespace LiteDB
 {
     public partial class BsonMapper
     {
+        #region Deserialization Hooks
+
+        /// <summary>
+        /// Delegate for deserialization callback.
+        /// </summary>
+        /// <param name="sender">The BsonMapper instance that triggered the deserialization.</param>
+        /// <param name="target">The target type for deserialization.</param>
+        /// <param name="value">The BsonValue to be deserialized.</param>
+        /// <returns>The deserialized BsonValue.</returns>
+        public delegate BsonValue DeserializationCallback(BsonMapper sender, Type target, BsonValue value);
+
+        /// <summary>
+        /// Gets called before deserialization of a value
+        /// </summary>
+        public DeserializationCallback? OnDeserialization { get; set; }
+
+        #endregion Deserialization Hooks
+
         #region Basic direct .NET convert types
 
         // direct bson types
@@ -78,6 +96,15 @@ namespace LiteDB
         /// </summary>
         public object Deserialize(Type type, BsonValue value)
         {
+            if (OnDeserialization is not null)
+            {
+                var result = OnDeserialization(this, type, value);
+                if (result is not null)
+                {
+                    value = result;
+                }
+            }
+
             // null value - null returns
             if (value.IsNull) return null;
 

--- a/LiteDB/Client/Structures/ConnectionString.cs
+++ b/LiteDB/Client/Structures/ConnectionString.cs
@@ -1,4 +1,4 @@
-﻿using LiteDB.Engine;
+using LiteDB.Engine;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -107,7 +107,7 @@ namespace LiteDB
         /// <summary>
         /// Create ILiteEngine instance according string connection parameters. For now, only Local/Shared are supported
         /// </summary>
-        internal ILiteEngine CreateEngine()
+        internal ILiteEngine CreateEngine(Action<EngineSettings> engineSettingsAction = null)
         {
             var settings = new EngineSettings
             {
@@ -119,6 +119,8 @@ namespace LiteDB
                 Upgrade = this.Upgrade,
                 AutoRebuild = this.AutoRebuild,
             };
+
+            engineSettingsAction?.Invoke(settings);
 
             // create engine implementation as Connection Type
             if (this.Connection == ConnectionType.Direct)

--- a/LiteDB/Document/DataReader/BsonDataReader.cs
+++ b/LiteDB/Document/DataReader/BsonDataReader.cs
@@ -1,4 +1,4 @@
-﻿using LiteDB.Engine;
+using LiteDB.Engine;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -56,10 +56,10 @@ namespace LiteDB
                 if (_source.MoveNext())
                 {
                     _hasValues = _isFirst = true;
-                    _current = _source.Current;
+                    _current = _state.ReadTransform(_collection, _source.Current);
                 }
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 _state.Handle(ex);
                 throw;
@@ -102,10 +102,10 @@ namespace LiteDB
                     try
                     {
                         var read = _source.MoveNext(); // can throw any error here
-                        _current = _source.Current;
+                        _current = _state.ReadTransform(_collection, _source.Current);
                         return read;
                     }
-                    catch(Exception ex)
+                    catch (Exception ex)
                     {
                         _state.Handle(ex);
                         throw ex;
@@ -117,7 +117,7 @@ namespace LiteDB
                 }
             }
         }
-        
+
         public BsonValue this[string field]
         {
             get

--- a/LiteDB/Engine/EngineSettings.cs
+++ b/LiteDB/Engine/EngineSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
+
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -65,6 +66,11 @@ namespace LiteDB.Engine
         /// If detect it's a older version (v4) do upgrade in datafile to new v5. A backup file will be keeped in same directory
         /// </summary>
         public bool Upgrade { get; set; } = false;
+
+        /// <summary>
+        /// Is used to transform a <see cref="BsonValue"/> from the database on read. This can be used to upgrade data from older versions.
+        /// </summary>
+        public Func<string, BsonValue, BsonValue> ReadTransform { get; set; }
 
         /// <summary>
         /// Create new IStreamFactory for datafile

--- a/LiteDB/Engine/EngineState.cs
+++ b/LiteDB/Engine/EngineState.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -8,7 +8,6 @@ using System.Text;
 using System.Threading.Tasks;
 
 using static LiteDB.Constants;
-
 
 namespace LiteDB.Engine
 {
@@ -25,7 +24,7 @@ namespace LiteDB.Engine
 #endif
 
         public EngineState(LiteEngine engine, EngineSettings settings)
-        { 
+        {
             _engine = engine;
             _settings = settings;
         }
@@ -39,7 +38,7 @@ namespace LiteDB.Engine
         {
             LOG(ex.Message, "ERROR");
 
-            if (ex is IOException || 
+            if (ex is IOException ||
                 (ex is LiteException lex && lex.ErrorCode == LiteException.INVALID_DATAFILE_STATE))
             {
                 _exception = ex;
@@ -50,6 +49,13 @@ namespace LiteDB.Engine
             }
 
             return true;
+        }
+
+        public BsonValue ReadTransform(string collection, BsonValue value)
+        {
+            if (_settings?.ReadTransform is null) return value;
+
+            return _settings.ReadTransform(collection, value);
         }
     }
 }

--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -28,6 +28,7 @@
     <SignAssembly Condition="'$(OS)'=='Windows_NT'">true</SignAssembly>
     <AssemblyOriginatorKeyFile Condition="'$(Configuration)' == 'Release'">LiteDB.snk</AssemblyOriginatorKeyFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+	<LangVersion>9.0</LangVersion>
   </PropertyGroup>
   
   <!--

--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -28,7 +28,7 @@
     <SignAssembly Condition="'$(OS)'=='Windows_NT'">true</SignAssembly>
     <AssemblyOriginatorKeyFile Condition="'$(Configuration)' == 'Release'">LiteDB.snk</AssemblyOriginatorKeyFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	<LangVersion>9.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   
   <!--

--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -28,7 +28,7 @@
     <SignAssembly Condition="'$(OS)'=='Windows_NT'">true</SignAssembly>
     <AssemblyOriginatorKeyFile Condition="'$(Configuration)' == 'Release'">LiteDB.snk</AssemblyOriginatorKeyFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>9.0</LangVersion>
+	<LangVersion>latest</LangVersion>
   </PropertyGroup>
   
   <!--


### PR DESCRIPTION
This change would allow me to improve my library (https://github.com/JKamsker/LiteDb.Migration) significantly. The documents would then only be upgrades on load and not all at once.