### PR TITLE
Changing the DisposableAction to reduce allocations

### DIFF
--- a/LiteDB.Benchmarks/Benchmarks/Constants.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Constants.cs
@@ -10,6 +10,8 @@ namespace LiteDB.Benchmarks.Benchmarks
             internal const string QUERIES = nameof(QUERIES);
             internal const string INSERTION = nameof(INSERTION);
             internal const string DELETION = nameof(DELETION);
+
+            internal const string GENERAL = nameof(GENERAL);
         }
     }
 }

--- a/LiteDB.Benchmarks/Benchmarks/GeneralMethods/StopwatchExtensionsBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/GeneralMethods/StopwatchExtensionsBenchmark.cs
@@ -3,6 +3,7 @@ using BenchmarkDotNet.Jobs;
 using LiteDB.Utils.Extensions;
 using System;
 using System.Diagnostics;
+using System.Linq;
 
 namespace LiteDB.Benchmarks.Benchmarks.GeneralMethods
 {
@@ -18,6 +19,25 @@ namespace LiteDB.Benchmarks.Benchmarks.GeneralMethods
 		public StopWatchExtensions.DisposableAction ReturningNewDisposableAction()
 		{
 			return stopwatch.StartDisposable();
+		}
+
+		[Benchmark]
+		public int Sum()
+		{
+			var watchDisposable = stopwatch.StartDisposable();
+			int sum = 0;
+			try
+			{
+				foreach (var i in Enumerable.Range(0, 100))
+				{
+					sum += i;
+				}
+			}
+			finally
+			{
+				watchDisposable.Dispose();
+			}
+			return sum;
 		}
 	}
 }

--- a/LiteDB.Benchmarks/Benchmarks/GeneralMethods/StopwatchExtensionsBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/GeneralMethods/StopwatchExtensionsBenchmark.cs
@@ -1,0 +1,39 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using LiteDB.Utils.Extensions;
+using System;
+using System.Diagnostics;
+
+namespace LiteDB.Benchmarks.Benchmarks.GeneralMethods
+{
+	[MemoryDiagnoser]
+	[SimpleJob(RuntimeMoniker.Net472, baseline: true)]
+	[SimpleJob(RuntimeMoniker.Net60)]
+	public class StopwatchExtensionsBenchmark
+	{
+
+		Stopwatch stopwatch = new Stopwatch();
+		Action a = () => { };
+		[Benchmark]
+		public StopWatchExtensions.DisposableAction ReturningNewDisposableAction()
+		{
+			return stopwatch.StartDisposable();
+		}
+
+
+		//[Benchmark]
+		//public IDisposable ReturningasIDisposableAction()
+		//{
+		//	return stopwatch.StartDisposable();
+		//}
+
+		//[Benchmark]
+		//public async Task<int> ConsumingTheDisposable()
+		//{
+		//	using var test = stopwatch.StartDisposable();
+		//	await Task.Yield();
+
+		//	return 42;
+		//}
+	}
+}

--- a/LiteDB.Benchmarks/Benchmarks/GeneralMethods/StopwatchExtensionsBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/GeneralMethods/StopwatchExtensionsBenchmark.cs
@@ -11,29 +11,13 @@ namespace LiteDB.Benchmarks.Benchmarks.GeneralMethods
 	[SimpleJob(RuntimeMoniker.Net60)]
 	public class StopwatchExtensionsBenchmark
 	{
-
 		Stopwatch stopwatch = new Stopwatch();
 		Action a = () => { };
+
 		[Benchmark]
 		public StopWatchExtensions.DisposableAction ReturningNewDisposableAction()
 		{
 			return stopwatch.StartDisposable();
 		}
-
-
-		//[Benchmark]
-		//public IDisposable ReturningasIDisposableAction()
-		//{
-		//	return stopwatch.StartDisposable();
-		//}
-
-		//[Benchmark]
-		//public async Task<int> ConsumingTheDisposable()
-		//{
-		//	using var test = stopwatch.StartDisposable();
-		//	await Task.Yield();
-
-		//	return 42;
-		//}
 	}
 }

--- a/LiteDB.Benchmarks/Benchmarks/GeneralMethods/StopwatchExtensionsBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/GeneralMethods/StopwatchExtensionsBenchmark.cs
@@ -1,43 +1,128 @@
 ﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
+
 using LiteDB.Utils.Extensions;
+
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
-namespace LiteDB.Benchmarks.Benchmarks.GeneralMethods
+namespace LiteDB.Benchmarks.Benchmarks.GeneralMethods;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net472, baseline: true)]
+[SimpleJob(RuntimeMoniker.Net60)]
+[BenchmarkCategory(Constants.Categories.GENERAL)]
+public class StopwatchExtensionsBenchmark
 {
-	[MemoryDiagnoser]
-	[SimpleJob(RuntimeMoniker.Net472, baseline: true)]
-	[SimpleJob(RuntimeMoniker.Net60)]
-	public class StopwatchExtensionsBenchmark
-	{
-		Stopwatch stopwatch = new Stopwatch();
-		Action a = () => { };
+    private Stopwatch stopwatch = new Stopwatch();
+    private Action a = () => { };
 
-		[Benchmark]
-		public StopWatchExtensions.DisposableAction ReturningNewDisposableAction()
-		{
-			return stopwatch.StartDisposable();
-		}
+    [Benchmark]
+    public StopWatchExtensions.DisposableAction ReturningNewDisposableAction()
+    {
+        return stopwatch.StartDisposable();
+    }
 
-		[Benchmark]
-		public int Sum()
-		{
-			var watchDisposable = stopwatch.StartDisposable();
-			int sum = 0;
-			try
-			{
-				foreach (var i in Enumerable.Range(0, 100))
-				{
-					sum += i;
-				}
-			}
-			finally
-			{
-				watchDisposable.Dispose();
-			}
-			return sum;
-		}
-	}
+    [Benchmark]
+    public int Sum()
+    {
+        var watchDisposable = stopwatch.StartDisposable();
+        int sum = 0;
+        try
+        {
+            foreach (var i in Enumerable.Range(0, 100))
+            {
+                sum += i;
+            }
+        }
+        finally
+        {
+            watchDisposable.Dispose();
+        }
+        return sum;
+    }
+
+    [Benchmark]
+    public int Struct_SumWithRangeHavingSw()
+    {
+        int sum = 0;
+        foreach (var i in Struct_Range(0, 100))
+        {
+            sum += i;
+        }
+        return sum;
+    }
+
+    private static IEnumerable<int> Struct_Range(int start, int count)
+    {
+        var sw = new Stopwatch();
+
+        using var _ = sw.StartDisposable();
+        for (int i = 0; i < count; i++)
+        {
+            sw.Stop();
+            yield return start + i;
+            sw.Start();
+        }
+    }
+
+    [Benchmark]
+    public int Class_SumWithRangeHavingSw()
+    {
+        int sum = 0;
+        foreach (var i in Class_Range(0, 100))
+        {
+            sum += i;
+        }
+        return sum;
+    }
+
+    private static IEnumerable<int> Class_Range(int start, int count)
+    {
+        var sw = new Stopwatch();
+
+        using var _ = StopWatchExtensionsOld.StartDisposableOld(sw);
+        for (int i = 0; i < count; i++)
+        {
+            sw.Stop();
+            yield return start + i;
+            sw.Start();
+        }
+    }
+
+    internal static class StopWatchExtensionsOld
+    {
+        /// <summary>
+        /// Start the stopwatch and returns an IDisposable that will stop the stopwatch when disposed
+        /// </summary>
+        /// <param name="stopwatch"><see cref="Stopwatch"/> instance that will be used to measure time.</param>
+        /// <returns></returns>
+        public static DisposableAction StartDisposableOld(Stopwatch stopwatch)
+        {
+            stopwatch.Start();
+            return new DisposableAction(stopwatch.Stop);
+        }
+
+        /// <summary>
+        /// This struct isn't mean to be instantiated by users, so its ctor is internal.
+        /// If you want to use an instance of it call <see cref="StartDisposable(Stopwatch)"/> method.
+        /// </summary>
+        public class DisposableAction : IDisposable
+        {
+            private readonly Action _action;
+
+            internal DisposableAction(Action action)
+            {
+                _action = action;
+            }
+
+            public void Dispose()
+            {
+                _action();
+            }
+        }
+    }
 }

--- a/LiteDB.Benchmarks/LiteDB.Benchmarks.csproj
+++ b/LiteDB.Benchmarks/LiteDB.Benchmarks.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+	  <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/LiteDB.Benchmarks/LiteDB.Benchmarks.csproj
+++ b/LiteDB.Benchmarks/LiteDB.Benchmarks.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFrameworks>net472;net6</TargetFrameworks>
-		<LangVersion>8</LangVersion>
+		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/LiteDB.Benchmarks/Program.cs
+++ b/LiteDB.Benchmarks/Program.cs
@@ -8,13 +8,14 @@ using BenchmarkDotNet.Toolchains.CsProj;
 
 namespace LiteDB.Benchmarks
 {
-    class Program
+    internal class Program
     {
-        static void Main(string[] args)
+        private static void Main(string[] args)
         {
             BenchmarkRunner.Run(typeof(Program).Assembly, DefaultConfig.Instance
-                
-                //.With(new BenchmarkDotNet.Filters.AnyCategoriesFilter(new[] {Benchmarks.Constants.Categories.DATA_GEN}))
+
+                //.With(new BenchmarkDotNet.Filters.AnyCategoriesFilter(new[] { Benchmarks.Constants.Categories.GENERAL }))
+                //.AddFilter(new BenchmarkDotNet.Filters.AnyCategoriesFilter([Benchmarks.Constants.Categories.GENERAL]))
                 .AddJob(Job.Default.WithRuntime(CoreRuntime.Core60)
                     .WithJit(Jit.RyuJit)
                     .WithToolchain(CsProjCoreToolchain.NetCoreApp60)

--- a/LiteDB.Benchmarks/Program.cs
+++ b/LiteDB.Benchmarks/Program.cs
@@ -13,17 +13,18 @@ namespace LiteDB.Benchmarks
         static void Main(string[] args)
         {
             BenchmarkRunner.Run(typeof(Program).Assembly, DefaultConfig.Instance
+                
                 //.With(new BenchmarkDotNet.Filters.AnyCategoriesFilter(new[] {Benchmarks.Constants.Categories.DATA_GEN}))
-                .With(Job.Default.With(CoreRuntime.Core31)
-                    .With(Jit.RyuJit)
-                    .With(CsProjCoreToolchain.NetCoreApp31)
+                .AddJob(Job.Default.WithRuntime(CoreRuntime.Core60)
+                    .WithJit(Jit.RyuJit)
+                    .WithToolchain(CsProjCoreToolchain.NetCoreApp60)
                     .WithGcForce(true))
                 /*.With(Job.Default.With(MonoRuntime.Default)
                     .With(Jit.Llvm)
                     .With(new[] {new MonoArgument("--optimize=inline")})
                     .WithGcForce(true))*/
-                .With(MemoryDiagnoser.Default)
-                .With(BenchmarkReportExporter.Default, HtmlExporter.Default, MarkdownExporter.GitHub)
+                .AddDiagnoser(MemoryDiagnoser.Default)
+                .AddExporter(BenchmarkReportExporter.Default, HtmlExporter.Default, MarkdownExporter.GitHub)
                 .KeepBenchmarkFiles());
         }
     }

--- a/LiteDB/Utils/Extensions/StopWatchExtensions.cs
+++ b/LiteDB/Utils/Extensions/StopWatchExtensions.cs
@@ -3,37 +3,37 @@ using System.Diagnostics;
 
 namespace LiteDB.Utils.Extensions
 {
-	public static class StopWatchExtensions
-	{
-		/// <summary>
-		/// Start the stopwatch and returns an IDisposable that will stop the stopwatch when disposed
-		/// </summary>
-		/// <param name="stopwatch"><see cref="Stopwatch"/> instance that will be used to measure time.</param>
-		/// <returns></returns>
-		public static DisposableAction StartDisposable(this Stopwatch stopwatch)
-		{
-			stopwatch.Start();
-			return new DisposableAction(stopwatch.Stop);
-		}
+    public static class StopWatchExtensions
+    {
+        /// <summary>
+        /// Start the stopwatch and returns an IDisposable that will stop the stopwatch when disposed
+        /// </summary>
+        /// <param name="stopwatch"><see cref="Stopwatch"/> instance that will be used to measure time.</param>
+        /// <returns></returns>
+        public static DisposableAction StartDisposable(this Stopwatch stopwatch)
+        {
+            stopwatch.Start();
+            return new DisposableAction(stopwatch.Stop);
+        }
 
-		/// <summary>
-		/// This struct isn't mean to be instantiated by users, so its ctor is internal.
-		/// If you want to use an instance of it call <see cref="StartDisposable(Stopwatch)"/> method.
-		/// </summary>
-		public readonly struct DisposableAction : IDisposable
-		{
-			private readonly Action _action;
+        /// <summary>
+        /// This struct isn't mean to be instantiated by users, so its ctor is internal.
+        /// If you want to use an instance of it call <see cref="StartDisposable(Stopwatch)"/> method.
+        /// </summary>
+        public readonly struct DisposableAction : IDisposable
+        {
+            private readonly Action _action;
 
-			internal DisposableAction(Action action)
-			{
-				_action = action;
-			}
+            internal DisposableAction(Action action)
+            {
+                _action = action;
+            }
 
-			public void Dispose()
-			{
-				_action();
-			}
-		}
-	}
+            public void Dispose()
+            {
+                _action();
+            }
+        }
+    }
 
 }

--- a/LiteDB/Utils/Extensions/StopWatchExtensions.cs
+++ b/LiteDB/Utils/Extensions/StopWatchExtensions.cs
@@ -3,29 +3,37 @@ using System.Diagnostics;
 
 namespace LiteDB.Utils.Extensions
 {
-    public static class StopWatchExtensions
-    {
-        // Start the stopwatch and returns an IDisposable that will stop the stopwatch when disposed
-        public static IDisposable StartDisposable(this Stopwatch stopwatch)
-        {
-            stopwatch.Start();
-            return new DisposableAction(stopwatch.Stop);
-        }
+	public static class StopWatchExtensions
+	{
+		/// <summary>
+		/// Start the stopwatch and returns an IDisposable that will stop the stopwatch when disposed
+		/// </summary>
+		/// <param name="stopwatch"><see cref="Stopwatch"/> instance that will be used to measure time.</param>
+		/// <returns></returns>
+		public static DisposableAction StartDisposable(this Stopwatch stopwatch)
+		{
+			stopwatch.Start();
+			return new DisposableAction(stopwatch.Stop);
+		}
 
-        private class DisposableAction : IDisposable
-        {
-            private readonly Action _action;
+		/// <summary>
+		/// This struct isn't mean to be instantiated by users, so its ctor is internal.
+		/// If you want to use an instance of it call <see cref="StartDisposable(Stopwatch)"/> method.
+		/// </summary>
+		public readonly struct DisposableAction : IDisposable
+		{
+			private readonly Action _action;
 
-            public DisposableAction(Action action)
-            {
-                _action = action;
-            }
+			internal DisposableAction(Action action)
+			{
+				_action = action;
+			}
 
-            public void Dispose()
-            {
-                _action();
-            }
-        }
-    }
+			public void Dispose()
+			{
+				_action();
+			}
+		}
+	}
 
 }


### PR DESCRIPTION
This PR just changes the `DisposableAction` to be a `readonly struct` and the extension method to not return the `IDisposable`  interface, those changes reduce the allocation in by 27%.

- Return `IDisposable` will force the compiler to box the `struct`.
- Making it `struct` will prevent allocations if not needed

Previous:
![image](https://github.com/mbdavid/LiteDB/assets/20712372/eee6e275-7c99-4022-8892-bdcdf978aa63)

Changed:
![image](https://github.com/mbdavid/LiteDB/assets/20712372/9f14de93-3984-456d-bc18-238492a3afab)

