### PR TITLE
Make all internal Task SyncContext agnostic

### DIFF
--- a/LiteDB/Engine/Disk/DiskWriterQueue.cs
+++ b/LiteDB/Engine/Disk/DiskWriterQueue.cs
@@ -81,7 +81,7 @@ namespace LiteDB.Engine
                 {
                     if (_queue.TryDequeue(out var page))
                     {
-                        await WritePageToStream(page).ConfigureAwait(false);
+                        await WritePageToStream(page);
                     }
                     else
                     {
@@ -93,8 +93,9 @@ namespace LiteDB.Engine
 
                         if (_shouldClose) return;
 
-                        await _stream.FlushToDiskAsync().ConfigureAwait(false);
-                        await _queueHasItems.WaitAsync().ConfigureAwait(false);
+                        // We don't want to cancel this flush.
+                        await _stream.FlushAsync();
+                        await _queueHasItems.WaitAsync();
                     }
                 }
             }
@@ -119,7 +120,7 @@ namespace LiteDB.Engine
 #endif
 
             // We don't want to cancel this write.
-            await _stream.WriteAsync(page.Array, page.Offset, PAGE_SIZE).ConfigureAwait(false);
+            await _stream.WriteAsync(page.Array, page.Offset, PAGE_SIZE);
 
             // release page here (no page use after this)
             page.Release();

--- a/LiteDB/Utils/Extensions/StreamExtensions.cs
+++ b/LiteDB/Utils/Extensions/StreamExtensions.cs
@@ -2,8 +2,6 @@
 
 namespace LiteDB
 {
-    using System.Threading.Tasks;
-
     internal static class StreamExtensions
     {
         /// <summary>
@@ -19,20 +17,6 @@ namespace LiteDB
             {
                 stream.Flush();
             }
-        }
-
-        public static async Task FlushToDiskAsync(this Stream stream)
-        {
-            // We don't need to cancel flush operation here.
-            // From FileStream sources:
-            // ================================================================================================
-            // Unlike Flush(), FlushAsync() always flushes to disk. This is intentional.
-            // Legend is that we chose not to flush the OS file buffers in Flush() in fear of
-            // perf problems with frequent, long running FlushFileBuffers() calls. But we don't
-            // have that problem with FlushAsync() because we will call FlushFileBuffers() in the background.
-            // ================================================================================================
-            // Hence no casting and bool flag here.
-            await stream.FlushAsync().ConfigureAwait(false);
         }
     }
 }

--- a/LiteDB/Utils/Extensions/StreamExtensions.cs
+++ b/LiteDB/Utils/Extensions/StreamExtensions.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.IO;
-using static LiteDB.Constants;
+﻿using System.IO;
 
 namespace LiteDB
 {
+    using System.Threading.Tasks;
+
     internal static class StreamExtensions
     {
         /// <summary>
@@ -19,6 +19,20 @@ namespace LiteDB
             {
                 stream.Flush();
             }
+        }
+
+        public static async Task FlushToDiskAsync(this Stream stream)
+        {
+            // We don't need to cancel flush operation here.
+            // From FileStream sources:
+            // ================================================================================================
+            // Unlike Flush(), FlushAsync() always flushes to disk. This is intentional.
+            // Legend is that we chose not to flush the OS file buffers in Flush() in fear of
+            // perf problems with frequent, long running FlushFileBuffers() calls. But we don't
+            // have that problem with FlushAsync() because we will call FlushFileBuffers() in the background.
+            // ================================================================================================
+            // Hence no casting and bool flag here.
+            await stream.FlushAsync().ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
This PR addresses #2505

In fact, the only place in LiteDB where we're firing up a new task is in DiskWriterQueue.

Also, changed write/flush methods to async ones.