### PR TITLE
Fix race condition in #2536

### DIFF
--- a/LiteDB/Client/Mapper/BsonMapper.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.cs
@@ -235,16 +235,14 @@ namespace LiteDB
         {
             //TODO: needs check if Type if BsonDocument? Returns empty EntityMapper?
 
-            if (!_entities.TryGetValue(type, out EntityMapper mapper))
+            lock (_entities)
             {
-                lock (_entities)
+                if (!_entities.TryGetValue(type, out EntityMapper mapper))
                 {
-                    if (!_entities.TryGetValue(type, out mapper))
-                        return this.BuildAddEntityMapper(type);
+                    return this.BuildAddEntityMapper(type);
                 }
+                return mapper;
             }
-
-            return mapper;
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes a race condition in BsonMapper (#2536), caused by a fix to a different issue in #2493.

It seems like the current approach of checking the dictionary twice is deliberate, likely for performance reasons. That said, I don't believe reading from a dictionary that may be in the process of being updated is actually safe to begin with.

If this is unacceptable perf-wise I believe the locking must be swapped with a proper read-write lock.