### PR TITLE
Fix #2534

### DIFF
--- a/LiteDB.Tests/Engine/Recursion_Tests.cs
+++ b/LiteDB.Tests/Engine/Recursion_Tests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Xunit;
+
+namespace LiteDB.Tests.Engine;
+
+public class Recursion_Tests {
+    [Fact]
+    public void UpdateInFindAll()
+    {
+        Test(collection =>
+        {
+            foreach (BsonDocument document in collection.FindAll())
+            {
+                collection.Update(document);
+            }
+        });
+    }
+    [Fact]
+    public void InsertDeleteInFindAll()
+    {
+        Test(collection =>
+        {
+            foreach (BsonDocument document in collection.FindAll())
+            {
+                BsonValue id = collection.Insert(new BsonDocument());
+                collection.Delete(id);
+            }
+        });
+    }
+    [Fact]
+    public void QueryInFindAll()
+    {
+        Test(collection =>
+        {
+            foreach (BsonDocument document in collection.FindAll())
+            {
+                collection.Query().Count();
+            }
+        });
+    }
+
+    private void Test(Action<ILiteCollection<BsonDocument>> action)
+    {
+        using LiteDatabase database = new(new ConnectionString()
+        {
+            Filename = "Demo.db",
+            Connection = ConnectionType.Shared,
+        });
+        ILiteCollection<BsonDocument> accounts = database.GetCollection("Recursion");
+        if (accounts.Count() < 3)
+        {
+            accounts.Insert(new BsonDocument());
+            accounts.Insert(new BsonDocument());
+            accounts.Insert(new BsonDocument());
+        }
+        action(accounts);
+    }
+}

--- a/LiteDB.Tests/Engine/Recursion_Tests.cs
+++ b/LiteDB.Tests/Engine/Recursion_Tests.cs
@@ -3,7 +3,8 @@ using Xunit;
 
 namespace LiteDB.Tests.Engine;
 
-public class Recursion_Tests {
+public class Recursion_Tests
+{
     [Fact]
     public void UpdateInFindAll()
     {
@@ -46,7 +47,9 @@ public class Recursion_Tests {
             Filename = "Demo.db",
             Connection = ConnectionType.Shared,
         });
+
         ILiteCollection<BsonDocument> accounts = database.GetCollection("Recursion");
+
         if (accounts.Count() < 3)
         {
             accounts.Insert(new BsonDocument());

--- a/LiteDB.Tests/Issues/Issue2534_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2534_Tests.cs
@@ -2,21 +2,26 @@
 
 namespace LiteDB.Tests.Issues;
 
-public class Issue2534_Tests {
+public class Issue2534_Tests
+{
     [Fact]
-    public void Test() {
+    public void Test() 
+    {
         using LiteDatabase database = new(new ConnectionString()
         {
             Filename = "Demo.db",
             Connection = ConnectionType.Shared,
         });
+
         ILiteCollection<BsonDocument> accounts = database.GetCollection("Issue2534");
+
         if (accounts.Count() < 3)
         {
             accounts.Insert(new BsonDocument());
             accounts.Insert(new BsonDocument());
             accounts.Insert(new BsonDocument());
         }
+
         foreach (BsonDocument document in accounts.FindAll())
         {
             accounts.Update(document);

--- a/LiteDB.Tests/Issues/Issue2534_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2534_Tests.cs
@@ -1,0 +1,25 @@
+﻿using Xunit;
+
+namespace LiteDB.Tests.Issues;
+
+public class Issue2534_Tests {
+    [Fact]
+    public void Test() {
+        using LiteDatabase database = new(new ConnectionString()
+        {
+            Filename = "Demo.db",
+            Connection = ConnectionType.Shared,
+        });
+        ILiteCollection<BsonDocument> accounts = database.GetCollection("Accounts");
+        if (accounts.Count() < 3)
+        {
+            accounts.Insert(new BsonDocument());
+            accounts.Insert(new BsonDocument());
+            accounts.Insert(new BsonDocument());
+        }
+        foreach (BsonDocument document in accounts.FindAll())
+        {
+            accounts.Update(document);
+        }
+    }
+}

--- a/LiteDB.Tests/Issues/Issue2534_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2534_Tests.cs
@@ -10,7 +10,7 @@ public class Issue2534_Tests {
             Filename = "Demo.db",
             Connection = ConnectionType.Shared,
         });
-        ILiteCollection<BsonDocument> accounts = database.GetCollection("Accounts");
+        ILiteCollection<BsonDocument> accounts = database.GetCollection("Issue2534");
         if (accounts.Count() < 3)
         {
             accounts.Insert(new BsonDocument());

--- a/LiteDB.Tests/LiteDB.Tests.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.csproj
@@ -29,15 +29,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.2">
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.reporters" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.reporters" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/LiteDB/Client/Shared/SharedEngine.cs
+++ b/LiteDB/Client/Shared/SharedEngine.cs
@@ -82,7 +82,7 @@ namespace LiteDB
         private void CloseDatabase()
         {
             // Don't dispose the engine while a transaction is running.
-            if (!this._transactionRunning && _engine != null)
+            if (!_transactionRunning && _engine != null)
             {
                 // If no transaction pending, dispose the engine.
                 _engine.Dispose();
@@ -97,17 +97,17 @@ namespace LiteDB
 
         public bool BeginTrans()
         {
-            this.OpenDatabase();
+            OpenDatabase();
 
             try
             {
-                this._transactionRunning = _engine.BeginTrans();
+                _transactionRunning = _engine.BeginTrans();
 
-                return this._transactionRunning;
+                return _transactionRunning;
             }
             catch
             {
-                this.CloseDatabase();
+                CloseDatabase();
                 throw;
             }
         }
@@ -122,8 +122,8 @@ namespace LiteDB
             }
             finally
             {
-                this._transactionRunning = false;
-                this.CloseDatabase();
+                _transactionRunning = false;
+                CloseDatabase();
             }
         }
 
@@ -137,8 +137,8 @@ namespace LiteDB
             }
             finally
             {
-                this._transactionRunning = false;
-                this.CloseDatabase();
+                _transactionRunning = false;
+                CloseDatabase();
             }
         }
 
@@ -148,7 +148,7 @@ namespace LiteDB
 
         public IBsonDataReader Query(string collection, Query query)
         {
-            bool opened = this.OpenDatabase();
+            bool opened = OpenDatabase();
 
             var reader = _engine.Query(collection, query);
 
@@ -156,7 +156,7 @@ namespace LiteDB
             {
                 if (opened)
                 {
-                    this.CloseDatabase();
+                    CloseDatabase();
                 }
             });
         }
@@ -239,13 +239,13 @@ namespace LiteDB
 
         public void Dispose()
         {
-            this.Dispose(true);
+            Dispose(true);
             GC.SuppressFinalize(this);
         }
 
         ~SharedEngine()
         {
-            this.Dispose(false);
+            Dispose(false);
         }
 
         protected virtual void Dispose(bool disposing)
@@ -261,8 +261,9 @@ namespace LiteDB
             }
         }
 
-        private T QueryDatabase<T>(Func<T> Query) {
-            bool opened = this.OpenDatabase();
+        private T QueryDatabase<T>(Func<T> Query)
+        {
+            bool opened = OpenDatabase();
             try
             {
                 return Query();
@@ -271,7 +272,7 @@ namespace LiteDB
             {
                 if (opened)
                 {
-                    this.CloseDatabase();
+                    CloseDatabase();
                 }
             }
         }


### PR DESCRIPTION
This fixes issue #2534 where updating a collection during an iteration fails in shared mode.

Previously, functions like `Collection.Update()` would always open and close the database, causing a dispose error when recursion was used. Now, it only closes the database if it was responsible for opening it.

I'm not sure that this is the best way to solve the problem. It might be a good idea to open a transaction whenever iterating a collection instead. I would have expected this issue to be more impactful.