### PR TITLE
Replace Mutex name hashing with URI escaping (Fix #2543)

### DIFF
--- a/LiteDB/Client/Shared/SharedEngine.cs
+++ b/LiteDB/Client/Shared/SharedEngine.cs
@@ -21,7 +21,7 @@ namespace LiteDB
         {
             _settings = settings;
 
-            var name = Path.GetFullPath(settings.Filename).ToLower().Sha1();
+            string name = Uri.EscapeDataString(Path.GetFullPath(settings.Filename).ToLowerInvariant());
 
             try
             {

--- a/LiteDB/Utils/Extensions/StringExtensions.cs
+++ b/LiteDB/Utils/Extensions/StringExtensions.cs
@@ -37,24 +37,6 @@ namespace LiteDB
             return true;
         }
 
-        public static string Sha1(this string value)
-        {
-            var data = Encoding.UTF8.GetBytes(value);
-
-            using (var sha = SHA1.Create())
-            {
-                var hashData = sha.ComputeHash(data);
-                var hash = new StringBuilder();
-
-                foreach (var b in hashData)
-                {
-                    hash.Append(b.ToString("X2"));
-                }
-
-                return hash.ToString();
-            }
-        }
-
         /// <summary>
         /// Implement SqlLike in C# string - based on
         /// https://stackoverflow.com/a/8583383/3286260


### PR DESCRIPTION
`Shared` mode uses a named Mutex to avoid multiple processes reading/writing at the same time. LiteDB names the Mutex to contain the absolute file path of the database. But Mutex names have to be valid file paths, so this would cause an invalid file path like:
```
Global\c:\users\user\documents\github\litedb\litedb.tests\bin\debug\net8\demo.db.Mutex
```

So instead, currently it hashes the file path using SHA1 to turn it into the following:
```
Global\0a1ab52c4b3f3d01730f61b59e7891bc029ab372.Mutex
```

However, this is a hacky solution in my opinion. Someone experienced exceptions (#2543) caused when creating SHA1. This PR avoids the need to hash the path by using URL escaping:
```
Global\c%3A%5Cusers%5Cuser%5Cdocuments%5Cgithub%5Clitedb%5Clitedb.tests%5Cbin%5Cdebug%5Cnet8%5Cdemo.db.Mutex
```

Also, I changed it to use `.ToLowerInvariant()` instead of `.ToLower()` because Windows file paths are case insensitive even for non-ASCII characters (e.g. `É` and `é`).

This PR should fix #2543 since it removes hashing.