### PR TITLE
Update target frameworks.

### DIFF
--- a/LiteDB.Benchmarks/LiteDB.Benchmarks.csproj
+++ b/LiteDB.Benchmarks/LiteDB.Benchmarks.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/LiteDB.Tests/LiteDB.Tests.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.console" Version="2.9.2">

--- a/LiteDB/Client/Shared/SharedEngine.cs
+++ b/LiteDB/Client/Shared/SharedEngine.cs
@@ -3,10 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
-#if NETFRAMEWORK
-using System.Security.AccessControl;
-using System.Security.Principal;
-#endif
 
 namespace LiteDB
 {
@@ -25,17 +21,7 @@ namespace LiteDB
 
             try
             {
-#if NETFRAMEWORK
-                var allowEveryoneRule = new MutexAccessRule(new SecurityIdentifier(WellKnownSidType.WorldSid, null),
-                           MutexRights.FullControl, AccessControlType.Allow);
-
-                var securitySettings = new MutexSecurity();
-                securitySettings.AddAccessRule(allowEveryoneRule);
-
-                _mutex = new Mutex(false, "Global\\" + name + ".Mutex", out _, securitySettings);
-#else
                 _mutex = new Mutex(false, "Global\\" + name + ".Mutex");
-#endif
             }
             catch (NotSupportedException ex)
             {

--- a/LiteDB/Document/ObjectId.cs
+++ b/LiteDB/Document/ObjectId.cs
@@ -275,13 +275,7 @@ namespace LiteDB
         // static constructor
         static ObjectId()
         {
-            _machine = (GetMachineHash() +
-#if HAVE_APP_DOMAIN
-                AppDomain.CurrentDomain.Id
-#else
-                10000 // Magic number
-#endif   
-                ) & 0x00ffffff;
+            _machine = (GetMachineHash() + AppDomain.CurrentDomain.Id) & 0x00ffffff;
             _increment = (new Random()).Next();
 
             try
@@ -294,24 +288,14 @@ namespace LiteDB
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static int GetCurrentProcessId()
         {
-#if HAVE_PROCESS
             return Process.GetCurrentProcess().Id;
-#else
-            return (new Random()).Next(0, 5000); // Any same number for this process
-#endif
         }
 
         private static int GetMachineHash()
         {
-            var hostName =
-#if HAVE_ENVIRONMENT
-                Environment.MachineName; // use instead of Dns.HostName so it will work offline
-#else
-                "SOMENAME";
-#endif
+            var hostName = Environment.MachineName; // use instead of Dns.HostName so it will work offline
             return 0x00ffffff & hostName.GetHashCode(); // use first 3 bytes of hash
         }
 

--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -30,41 +30,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  
-  <!--
-  == All variables ==
-  HAVE_APP_DOMAIN
-  HAVE_PROCESS
-  HAVE_ENVIRONMENT
-  HAVE_SHA1_MANAGED
-  -->
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
-    <DefineConstants>HAVE_SHA1_MANAGED;HAVE_APP_DOMAIN;HAVE_PROCESS;HAVE_ENVIRONMENT</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>HAVE_SHA1_MANAGED</DefineConstants>
-  </PropertyGroup>
 
   <!-- Begin References -->
   <ItemGroup>
     <None Include="..\LICENSE" Pack="true" PackagePath="" />
     <None Include="..\icon_64x64.png" Pack="true" PackagePath="\" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <Reference Include="System" />
-    <Reference Include="System.Runtime" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -68,7 +68,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Buffers" Version="4.6.0" />
   </ItemGroup>
   
   <!-- End References -->

--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net4.5;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <AssemblyVersion>5.0.21</AssemblyVersion>
     <FileVersion>5.0.21</FileVersion>
     <VersionPrefix>5.0.21</VersionPrefix>


### PR DESCRIPTION
This pull request replaces support for `.NET 4.5` and `.NET Standard 1.3` with support for `.NET Standard 2.0`, `.NET Standard 2.1`, `.NET 8.0` and `.NET 9.0`.

The justification is that `.NET 4.5` and `.NET Standard 1.3` are very old. `.NET 4.5` has been [end-of-life](https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-framework) for 8 years (since 2016/01/12), and the only frameworks supported by `.NET Standard 1.3` that aren't supported by `.NET Standard 2.0` have also been dead for a long time.

They are so old in fact that `System.Buffers` (a dependency of LiteDB) has released an update not supported by `.NET Standard 1.3`.

While `.NET Standard 2.1` only supports `.NET`, `.NET Standard 2.0` supports all supported versions of `.NET Framework`, so there should be almost no one left out.

With the removal of `.NET 4.5` and `.NET Standard 1.3`, I've been able to remove several instances of conditional compilation. In the future, LiteDB will have a larger range of APIs to work with.

Additionally, supporting `.NET 8.0` and `.NET 9.0` should give performance boosts when using those versions.

This pull request has created a number of warnings in LiteDB due to various APIs becoming obsolete. I think the team should look at each case individually and look to replace the APIs with newer alternatives.