### PR TITLE
Fixes concurrent access issues using a concurrent dictionary

### DIFF
--- a/LiteDB/Client/Database/LiteCollection.cs
+++ b/LiteDB/Client/Database/LiteCollection.cs
@@ -47,6 +47,8 @@ namespace LiteDB
             else
             {
                 _entity = mapper.GetEntityMapper(typeof(T));
+                _entity.WaitForInitialization();
+                
                 _id = _entity.Id;
 
                 if (_id != null && _id.AutoId)

--- a/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
@@ -213,6 +213,7 @@ namespace LiteDB
                 }
 
                 var entity = this.GetEntityMapper(type);
+                entity.WaitForInitialization();
 
                 // initialize CreateInstance
                 if (entity.CreateInstance == null)

--- a/LiteDB/Client/Mapper/BsonMapper.GetEntityMapper.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.GetEntityMapper.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+
+namespace LiteDB;
+
+public partial class BsonMapper
+{
+    /// <summary>
+    /// Mapping cache between Class/BsonDocument
+    /// </summary>
+    private readonly ConcurrentDictionary<Type, EntityMapper> _entities = new();
+
+    /// <summary>
+    /// Get property mapper between typed .NET class and BsonDocument - Cache results
+    /// </summary>
+    internal EntityMapper GetEntityMapper(Type type)
+    {
+        if (_entities.TryGetValue(type, out EntityMapper mapper))
+        {
+            return mapper;
+        }
+
+        using var cts = new CancellationTokenSource();
+        mapper = new EntityMapper(type, cts.Token);
+        if (_entities.TryAdd(type, mapper))
+        {
+            this.BuildEntityMapper(mapper);
+        }
+        cts.Cancel();
+        cts.Dispose();
+
+        return mapper;
+    }
+
+    /// <summary>
+    /// Use this method to override how your class can be, by default, mapped from entity to Bson document.
+    /// Returns an EntityMapper from each requested Type
+    /// </summary>
+    protected void BuildEntityMapper(EntityMapper mapper)
+    {
+        var idAttr = typeof(BsonIdAttribute);
+        var ignoreAttr = typeof(BsonIgnoreAttribute);
+        var fieldAttr = typeof(BsonFieldAttribute);
+        var dbrefAttr = typeof(BsonRefAttribute);
+
+        var members = this.GetTypeMembers(mapper.ForType);
+        var id = this.GetIdMember(members);
+
+        foreach (var memberInfo in members)
+        {
+            // checks [BsonIgnore]
+            if (CustomAttributeExtensions.IsDefined(memberInfo, ignoreAttr, true)) continue;
+
+            // checks field name conversion
+            var name = this.ResolveFieldName(memberInfo.Name);
+
+            // check if property has [BsonField]
+            var field = (BsonFieldAttribute)CustomAttributeExtensions.GetCustomAttributes(memberInfo, fieldAttr, true)
+                .FirstOrDefault();
+
+            // check if property has [BsonField] with a custom field name
+            if (field != null && field.Name != null)
+            {
+                name = field.Name;
+            }
+
+            // checks if memberInfo is id field
+            if (memberInfo == id)
+            {
+                name = "_id";
+            }
+
+            // create getter/setter function
+            var getter = Reflection.CreateGenericGetter(mapper.ForType, memberInfo);
+            var setter = Reflection.CreateGenericSetter(mapper.ForType, memberInfo);
+
+            // check if property has [BsonId] to get with was setted AutoId = true
+            var autoId = (BsonIdAttribute)CustomAttributeExtensions.GetCustomAttributes(memberInfo, idAttr, true)
+                .FirstOrDefault();
+
+            // get data type
+            var dataType = memberInfo is PropertyInfo
+                ? (memberInfo as PropertyInfo).PropertyType
+                : (memberInfo as FieldInfo).FieldType;
+
+            // check if datatype is list/array
+            var isEnumerable = Reflection.IsEnumerable(dataType);
+
+            // create a property mapper
+            var member = new MemberMapper
+            {
+                AutoId = autoId == null ? true : autoId.AutoId,
+                FieldName = name,
+                MemberName = memberInfo.Name,
+                DataType = dataType,
+                IsEnumerable = isEnumerable,
+                UnderlyingType = isEnumerable ? Reflection.GetListItemType(dataType) : dataType,
+                Getter = getter,
+                Setter = setter
+            };
+
+            // check if property has [BsonRef]
+            var dbRef = (BsonRefAttribute)CustomAttributeExtensions.GetCustomAttributes(memberInfo, dbrefAttr, false)
+                .FirstOrDefault();
+
+            if (dbRef != null && memberInfo is PropertyInfo)
+            {
+                BsonMapper.RegisterDbRef(this, member, _typeNameBinder,
+                    dbRef.Collection ?? this.ResolveCollectionName((memberInfo as PropertyInfo).PropertyType));
+            }
+
+            // support callback to user modify member mapper
+            this.ResolveMember?.Invoke(mapper.ForType, memberInfo, member);
+
+            // test if has name and there is no duplicate field
+            // when member is not ignore
+            if (member.FieldName != null &&
+                mapper.Members.Any(x => x.FieldName.Equals(name, StringComparison.OrdinalIgnoreCase)) == false &&
+                !member.IsIgnore)
+            {
+                mapper.Members.Add(member);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets MemberInfo that refers to Id from a document object.
+    /// </summary>
+    protected virtual MemberInfo GetIdMember(IEnumerable<MemberInfo> members)
+    {
+        return Reflection.SelectMember(members,
+            x => CustomAttributeExtensions.IsDefined(x, typeof(BsonIdAttribute), true),
+            x => x.Name.Equals("Id", StringComparison.OrdinalIgnoreCase),
+            x => x.Name.Equals(x.DeclaringType.Name + "Id", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Returns all member that will be have mapper between POCO class to document
+    /// </summary>
+    protected virtual IEnumerable<MemberInfo> GetTypeMembers(Type type)
+    {
+        var members = new List<MemberInfo>();
+
+        var flags = this.IncludeNonPublic
+            ? (BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            : (BindingFlags.Public | BindingFlags.Instance);
+
+        members.AddRange(type.GetProperties(flags)
+            .Where(x => x.CanRead && x.GetIndexParameters().Length == 0)
+            .Select(x => x as MemberInfo));
+
+        if (this.IncludeFields)
+        {
+            members.AddRange(type.GetFields(flags).Where(x => !x.Name.EndsWith("k__BackingField") && x.IsStatic == false)
+                .Select(x => x as MemberInfo));
+        }
+
+        return members;
+    }
+
+    /// <summary>
+    /// Get best construtor to use to initialize this entity.
+    /// - Look if contains [BsonCtor] attribute
+    /// - Look for parameterless ctor
+    /// - Look for first contructor with parameter and use BsonDocument to send RawValue
+    /// </summary>
+    protected virtual CreateObject GetTypeCtor(EntityMapper mapper)
+    {
+        Type type = mapper.ForType;
+        List<CreateObject> Mappings = new List<CreateObject>();
+        bool returnZeroParamNull = false;
+        foreach (ConstructorInfo ctor in type.GetConstructors())
+        {
+            ParameterInfo[] pars = ctor.GetParameters();
+            // For 0 parameters, we can let the Reflection.CreateInstance handle it, unless they've specified a [BsonCtor] attribute on a different constructor.
+            if (pars.Length == 0)
+            {
+                returnZeroParamNull = true;
+                continue;
+            }
+
+            KeyValuePair<string, Type>[] paramMap = new KeyValuePair<string, Type>[pars.Length];
+            int i;
+            for (i = 0; i < pars.Length; i++)
+            {
+                ParameterInfo par = pars[i];
+                MemberMapper mi = null;
+                foreach (MemberMapper member in mapper.Members)
+                {
+                    if (member.MemberName.ToLower() == par.Name.ToLower() && member.DataType == par.ParameterType)
+                    {
+                        mi = member;
+                        break;
+                    }
+                }
+
+                if (mi == null)
+                {
+                    break;
+                }
+
+                paramMap[i] = new KeyValuePair<string, Type>(mi.FieldName, mi.DataType);
+            }
+
+            if (i < pars.Length)
+            {
+                continue;
+            }
+
+            CreateObject toAdd = (BsonDocument value) =>
+                Activator.CreateInstance(type, paramMap.Select(x =>
+                    this.Deserialize(x.Value, value[x.Key])).ToArray());
+            if (ctor.GetCustomAttribute<BsonCtorAttribute>() != null)
+            {
+                return toAdd;
+            }
+            else
+            {
+                Mappings.Add(toAdd);
+            }
+        }
+
+        if (returnZeroParamNull)
+        {
+            return null;
+        }
+
+        return Mappings.FirstOrDefault();
+    }
+}

--- a/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
@@ -181,6 +181,7 @@ namespace LiteDB
             var t = obj.GetType();
             var doc = new BsonDocument();
             var entity = this.GetEntityMapper(t);
+            entity.WaitForInitialization();
 
             // adding _type only where property Type is not same as object instance type
             if (type != t)

--- a/LiteDB/Client/Mapper/BsonMapper.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.cs
@@ -25,17 +25,6 @@ namespace LiteDB
     public partial class BsonMapper
     {
         #region Properties
-
-        /// <summary>
-        /// Mapping cache between Class/BsonDocument
-        /// </summary>
-        private readonly Dictionary<Type, EntityMapper> _entities = new Dictionary<Type, EntityMapper>();
-        
-        /// <summary>
-        /// Unfinished mapping cache between Class/BsonDocument
-        /// </summary>
-        private readonly Dictionary<Type, EntityMapper> _buildEntities = new Dictionary<Type, EntityMapper>();
-        
         /// <summary>
         /// Map serializer/deserialize for custom types
         /// </summary>
@@ -231,227 +220,6 @@ namespace LiteDB
 
         #endregion
 
-        #region GetEntityMapper
-        
-        
-
-        /// <summary>
-        /// Get property mapper between typed .NET class and BsonDocument - Cache results
-        /// </summary>
-        internal EntityMapper GetEntityMapper(Type type)
-        {
-            //TODO: needs check if Type if BsonDocument? Returns empty EntityMapper?
-
-            if (_entities.TryGetValue(type, out EntityMapper mapper))
-            {
-                return mapper;
-            }
-
-            lock (_entities)
-            {
-                if (_entities.TryGetValue(type, out mapper))
-                {
-                    return mapper;
-                }
-
-                if(_buildEntities.TryGetValue(type, out EntityMapper buildMapper))
-                {
-                    return buildMapper;
-                }
-                        
-                var newMapper = new EntityMapper(type);
-                _buildEntities[type] = newMapper;
-                this.BuildEntityMapper(newMapper);
-                _entities[type] = newMapper;
-                        
-                _buildEntities.Remove(type);
-                return newMapper;
-            }
-
-            return mapper;
-        }
-
-        /// <summary>
-        /// Use this method to override how your class can be, by default, mapped from entity to Bson document.
-        /// Returns an EntityMapper from each requested Type
-        /// </summary>
-        protected void BuildEntityMapper(EntityMapper mapper)
-        {
-            // var mapper = new EntityMapper(type);
-            // _entities[type] = mapper;//direct add into entities, to solove the DBRef [ GetEntityMapper > BuildAddEntityMapper > RegisterDbRef > RegisterDbRefItem > GetEntityMapper ] Loop call recursion,we stoped at here and GetEntityMapper's _entities.TryGetValue
-
-            var idAttr = typeof(BsonIdAttribute);
-            var ignoreAttr = typeof(BsonIgnoreAttribute);
-            var fieldAttr = typeof(BsonFieldAttribute);
-            var dbrefAttr = typeof(BsonRefAttribute);
-
-            var members = this.GetTypeMembers(mapper.ForType);
-            var id = this.GetIdMember(members);
-
-            foreach (var memberInfo in members)
-            {
-                // checks [BsonIgnore]
-                if (CustomAttributeExtensions.IsDefined(memberInfo, ignoreAttr, true)) continue;
-
-                // checks field name conversion
-                var name = this.ResolveFieldName(memberInfo.Name);
-
-                // check if property has [BsonField]
-                var field = (BsonFieldAttribute)CustomAttributeExtensions.GetCustomAttributes(memberInfo, fieldAttr, true).FirstOrDefault();
-
-                // check if property has [BsonField] with a custom field name
-                if (field != null && field.Name != null)
-                {
-                    name = field.Name;
-                }
-
-                // checks if memberInfo is id field
-                if (memberInfo == id)
-                {
-                    name = "_id";
-                }
-
-                // create getter/setter function
-                var getter = Reflection.CreateGenericGetter(mapper.ForType, memberInfo);
-                var setter = Reflection.CreateGenericSetter(mapper.ForType, memberInfo);
-
-                // check if property has [BsonId] to get with was setted AutoId = true
-                var autoId = (BsonIdAttribute)CustomAttributeExtensions.GetCustomAttributes(memberInfo, idAttr, true).FirstOrDefault();
-
-                // get data type
-                var dataType = memberInfo is PropertyInfo ?
-                    (memberInfo as PropertyInfo).PropertyType :
-                    (memberInfo as FieldInfo).FieldType;
-
-                // check if datatype is list/array
-                var isEnumerable = Reflection.IsEnumerable(dataType);
-
-                // create a property mapper
-                var member = new MemberMapper
-                {
-                    AutoId = autoId == null ? true : autoId.AutoId,
-                    FieldName = name,
-                    MemberName = memberInfo.Name,
-                    DataType = dataType,
-                    IsEnumerable = isEnumerable,
-                    UnderlyingType = isEnumerable ? Reflection.GetListItemType(dataType) : dataType,
-                    Getter = getter,
-                    Setter = setter
-                };
-
-                // check if property has [BsonRef]
-                var dbRef = (BsonRefAttribute)CustomAttributeExtensions.GetCustomAttributes(memberInfo, dbrefAttr, false).FirstOrDefault();
-
-                if (dbRef != null && memberInfo is PropertyInfo)
-                {
-                    BsonMapper.RegisterDbRef(this, member, _typeNameBinder, dbRef.Collection ?? this.ResolveCollectionName((memberInfo as PropertyInfo).PropertyType));
-                }
-
-                // support callback to user modify member mapper
-                this.ResolveMember?.Invoke(mapper.ForType, memberInfo, member);
-
-                // test if has name and there is no duplicate field
-                // when member is not ignore
-                if (member.FieldName != null && mapper.Members.Any(x => x.FieldName.Equals(name, StringComparison.OrdinalIgnoreCase)) == false && !member.IsIgnore)
-                {
-                    mapper.Members.Add(member);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets MemberInfo that refers to Id from a document object.
-        /// </summary>
-        protected virtual MemberInfo GetIdMember(IEnumerable<MemberInfo> members)
-        {
-            return Reflection.SelectMember(members,
-                x => CustomAttributeExtensions.IsDefined(x, typeof(BsonIdAttribute), true),
-                x => x.Name.Equals("Id", StringComparison.OrdinalIgnoreCase),
-                x => x.Name.Equals(x.DeclaringType.Name + "Id", StringComparison.OrdinalIgnoreCase));
-        }
-
-        /// <summary>
-        /// Returns all member that will be have mapper between POCO class to document
-        /// </summary>
-        protected virtual IEnumerable<MemberInfo> GetTypeMembers(Type type)
-        {
-            var members = new List<MemberInfo>();
-
-            var flags = this.IncludeNonPublic ?
-                (BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance) :
-                (BindingFlags.Public | BindingFlags.Instance);
-
-            members.AddRange(type.GetProperties(flags)
-                .Where(x => x.CanRead && x.GetIndexParameters().Length == 0)
-                .Select(x => x as MemberInfo));
-
-            if (this.IncludeFields)
-            {
-                members.AddRange(type.GetFields(flags).Where(x => !x.Name.EndsWith("k__BackingField") && x.IsStatic == false).Select(x => x as MemberInfo));
-            }
-
-            return members;
-        }
-
-        /// <summary>
-        /// Get best construtor to use to initialize this entity.
-        /// - Look if contains [BsonCtor] attribute
-        /// - Look for parameterless ctor
-        /// - Look for first contructor with parameter and use BsonDocument to send RawValue
-        /// </summary>
-        protected virtual CreateObject GetTypeCtor(EntityMapper mapper)
-        {
-            Type type = mapper.ForType;
-            List<CreateObject> Mappings = new List<CreateObject>();
-            bool returnZeroParamNull = false;
-            foreach (ConstructorInfo ctor in type.GetConstructors())
-            {
-                ParameterInfo[] pars = ctor.GetParameters();
-                // For 0 parameters, we can let the Reflection.CreateInstance handle it, unless they've specified a [BsonCtor] attribute on a different constructor.
-                if (pars.Length == 0)
-                {
-                    returnZeroParamNull = true;
-                    continue;
-                }
-                KeyValuePair<string, Type>[] paramMap = new KeyValuePair<string, Type>[pars.Length];
-                int i;
-                for (i = 0; i < pars.Length; i++)
-                {
-                    ParameterInfo par = pars[i];
-                    MemberMapper  mi  = null;
-                    foreach (MemberMapper member in mapper.Members)
-                    {
-                        if (member.MemberName.ToLower() == par.Name.ToLower() && member.DataType == par.ParameterType)
-                        {
-                            mi = member;
-                            break;
-                        }
-                    }
-                    if (mi == null) {break;}
-                    paramMap[i] = new KeyValuePair<string, Type>(mi.FieldName, mi.DataType);
-                }
-                if (i < pars.Length) { continue;}
-                CreateObject toAdd = (BsonDocument value) =>
-                Activator.CreateInstance(type, paramMap.Select(x =>
-                this.Deserialize(x.Value, value[x.Key])).ToArray());
-                if (ctor.GetCustomAttribute<BsonCtorAttribute>() != null)
-                {
-                    return toAdd;
-                }
-                else
-                {
-                    Mappings.Add(toAdd);
-                }
-            }
-            if (returnZeroParamNull)
-            {
-                return null;
-            }
-            return Mappings.FirstOrDefault();
-        }
-
-        #endregion
-
         #region Register DbRef
 
         /// <summary>
@@ -478,12 +246,13 @@ namespace LiteDB
         {
             // get entity
             var entity = mapper.GetEntityMapper(member.DataType);
-
+            
             member.Serialize = (obj, m) =>
             {
                 // supports null values when "SerializeNullValues = true"
                 if (obj == null) return BsonValue.Null;
-
+                entity.WaitForInitialization();
+                
                 var idField = entity.Id;
 
                 // #768 if using DbRef with interface with no ID mapped
@@ -551,7 +320,8 @@ namespace LiteDB
             {
                 // supports null values when "SerializeNullValues = true"
                 if (list == null) return BsonValue.Null;
-
+                entity.WaitForInitialization();
+                
                 var result = new BsonArray();
                 var idField = entity.Id;
 

--- a/LiteDB/Client/Mapper/EntityBuilder.cs
+++ b/LiteDB/Client/Mapper/EntityBuilder.cs
@@ -30,6 +30,7 @@ namespace LiteDB
         {
             return this.GetMember(member, (p) =>
             {
+                _entity.WaitForInitialization();
                 _entity.Members.Remove(p);
             });
         }
@@ -54,9 +55,11 @@ namespace LiteDB
         {
             return this.GetMember(member, (p) =>
             {
+                _entity.WaitForInitialization();
+                
                 // if contains another _id, remove-it
                 var oldId = _entity.Members.FirstOrDefault(x => x.FieldName == "_id");
-
+        
                 if (oldId != null)
                 {
                     oldId.FieldName = _mapper.ResolveFieldName(oldId.MemberName);
@@ -73,6 +76,7 @@ namespace LiteDB
         /// </summary>
         public EntityBuilder<T> Ctor(Func<BsonDocument, T> createInstance)
         {
+            _entity.WaitForInitialization();
             _entity.CreateInstance = v => createInstance(v);
 
             return this;
@@ -95,7 +99,8 @@ namespace LiteDB
         private EntityBuilder<T> GetMember<TK, K>(Expression<Func<TK, K>> member, Action<MemberMapper> action)
         {
             if (member == null) throw new ArgumentNullException(nameof(member));
-
+            _entity.WaitForInitialization();
+            
             var memb = _entity.GetMember(member);
 
             if (memb == null)

--- a/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
+++ b/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
@@ -619,6 +619,7 @@ namespace LiteDB
 
             // get class entity from mapper
             var entity = _mapper.GetEntityMapper(member.DeclaringType);
+            entity.WaitForInitialization();
 
             // get mapped field from entity
             var field = entity.Members.FirstOrDefault(x => x.MemberName == name);

--- a/LiteDB/Utils/LiteException.cs
+++ b/LiteDB/Utils/LiteException.cs
@@ -57,6 +57,7 @@ namespace LiteDB
         public const int NOT_ENCRYPTED = 216;
         public const int INVALID_PASSWORD = 217;
         public const int ILLEGAL_DESERIALIZATION_TYPE = 218;
+        public const int ENTITY_INITIALIZATION_FAILED = 219;
 
         public const int INVALID_DATAFILE_STATE = 999;
 


### PR DESCRIPTION
Hopefully fixes https://github.com/mbdavid/LiteDB/issues/2563

Can't really verify. I let it run for an hour and it shows no issues so far. 
The stresstest shows the exception with the latest release but doesn't with the current master so noone guarantees the issue is _**really**_ fixed.

Changes:
- Using concurrent dictionary for storing ``EntityMapper``s
- Adding an uninitialized ``EntityMapper`` to the dictionary and initializing it after the fact, after it has been added. On all serializations/deserializations, we wait until the initialization has been finished.




@vonzshik