### PR TITLE
Added missing modulo operator to BsonValue

### DIFF
--- a/LiteDB.Tests/Expressions/Expressions_Exec_Tests.cs
+++ b/LiteDB.Tests/Expressions/Expressions_Exec_Tests.cs
@@ -104,6 +104,13 @@ namespace LiteDB.Tests.Expressions
                 return BsonExpression.Create(s, args).ExecuteScalar(doc);
             }
 
+            // Arithmetic operators
+            doc = new BsonDocument();
+            S("6 + 3").ExpectValue(9);
+            S("6 * 3").ExpectValue(18);
+            S("6 % 3").ExpectValue(0);
+            S("6 / 3").ExpectValue(2);
+
             // Operators order
             doc = J("{ a: 1, b: 2, c: 3 }");
 

--- a/LiteDB.Tests/Expressions/Expressions_Exec_Tests.cs
+++ b/LiteDB.Tests/Expressions/Expressions_Exec_Tests.cs
@@ -106,10 +106,16 @@ namespace LiteDB.Tests.Expressions
 
             // Arithmetic operators
             doc = new BsonDocument();
+            // Int
             S("6 + 3").ExpectValue(9);
             S("6 * 3").ExpectValue(18);
             S("6 % 3").ExpectValue(0);
             S("6 / 3").ExpectValue(2);
+            // Double
+            S("6.0 + 3.0").ExpectValue(9);
+            S("6.0 * 3.0").ExpectValue(18);
+            S("6.0 % 3.0").ExpectValue(0);
+            S("6.0 / 3.0").ExpectValue(2);
 
             // Operators order
             doc = J("{ a: 1, b: 2, c: 3 }");

--- a/LiteDB/Document/BsonValue.cs
+++ b/LiteDB/Document/BsonValue.cs
@@ -500,6 +500,17 @@ namespace LiteDB
             return left.AsDouble / right.AsDouble;
         }
 
+        // %
+        public static BsonValue operator %(BsonValue left, BsonValue right)
+        {
+            if (!left.IsNumber || !right.IsNumber) return BsonValue.Null;
+            if (left.IsInt32 && right.IsInt32) return left.AsInt32 % right.AsInt32;
+            if (left.IsInt64 && right.IsInt64) return left.AsInt64 % right.AsInt64;
+            if (left.IsDecimal && right.IsDecimal) return left.AsDecimal % right.AsDecimal;
+
+            return left.AsDouble % right.AsDouble;
+        }
+
         public override string ToString()
         {
             return JsonSerializer.Serialize(this);


### PR DESCRIPTION
BsonExpressionOperators assumes that you can use the modulo operator % on two BsonValue objects as seen in BsonExpressionOperators.cs:98:
```c#
/// <summary>
/// Mod two number values
/// </summary>
public static BsonValue MOD(BsonValue left, BsonValue right)
{
    if (left.IsNumber && right.IsNumber)
    {
        return left % right;
    }

    return BsonValue.Null;
}
``` 
This pull request implements this operator overload similar to the other arithmetic operator overloads.

Without this change this expression `Select 1.0 % 2.0;` would result in `Specified cast is not valid.`