### PR TITLE
Handle multi-order sort comparisons in containers

### DIFF
--- a/LiteDB/Engine/Sort/SortService.cs
+++ b/LiteDB/Engine/Sort/SortService.cs
@@ -92,9 +92,7 @@ namespace LiteDB.Engine
                 var container = new SortContainer(_pragmas.Collation, _containerSize, _orders);
 
                 // insert segmented items inside a container - reuse same buffer slice
-                var order = _orders.Length == 1 ? _orders[0] : Query.Ascending;
-
-                container.Insert(containerItems, order, _buffer);
+                container.Insert(containerItems, _buffer);
 
                 _containers.Add(container);
 


### PR DESCRIPTION
## Summary
- use a dedicated comparer in `SortContainer` so chunk sorting honors per-segment order sequences
- update `SortService` to pass container items without translating multi-field orders to a single scalar flag

## Testing
- dotnet test LiteDB.sln --settings tests.runsettings

------
https://chatgpt.com/codex/tasks/task_e_68cfec80b420832aa67496a2cd401b3b