### PR TITLE
Fix rollback handling for safepoint-flushed pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
         run: dotnet restore LiteDB.sln
 
       - name: Build
-        run: dotnet build LiteDB.sln --configuration Release --no-restore
+        run: dotnet build LiteDB.sln --configuration Release --no-restore /p:DefineConstants=TESTING
 
       - name: Test
         timeout-minutes: 5
-        run: dotnet test LiteDB.sln --configuration Release --no-build --verbosity normal --settings tests.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed"
+        run: dotnet test LiteDB.sln --configuration Release --no-build --verbosity normal --settings tests.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" /p:DefineConstants=TESTING

--- a/ConsoleApp1/Program.cs
+++ b/ConsoleApp1/Program.cs
@@ -27,7 +27,7 @@ try
 {
     using (var db = new LiteEngine(settings))
     {
-#if DEBUG
+#if DEBUG || TESTING
         db.SimulateDiskWriteFail = (page) =>
         {
             var p = new BasePage(page);

--- a/LiteDB.RollbackRepro/LiteDB.RollbackRepro.csproj
+++ b/LiteDB.RollbackRepro/LiteDB.RollbackRepro.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="LiteDB" Version="5.0.20" />
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.RollbackRepro/LiteDB.RollbackRepro.csproj
+++ b/LiteDB.RollbackRepro/LiteDB.RollbackRepro.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LiteDB" Version="5.0.20" />
+  
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj" />
   </ItemGroup>
 
 </Project>

--- a/LiteDB.RollbackRepro/Program.cs
+++ b/LiteDB.RollbackRepro/Program.cs
@@ -9,6 +9,10 @@ using LiteDB;
 
 namespace LiteDB.RollbackRepro;
 
+/// <summary>
+/// Repro of #2586
+/// To repro after the patch, set ``<PackageReference Include="LiteDB" Version="5.0.20" />``
+/// </summary>
 internal static class Program
 {
     private const int HolderTransactionCount = 99;
@@ -230,8 +234,13 @@ internal static class Program
             }
 
             db.Rollback();
+  
+            var color = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Green;
             Console.WriteLine("Rollback returned without throwing — the bug did not reproduce.");
-            throw;
+            Console.ForegroundColor = color;
+            // throw;
+            return;
         }
         finally
         {
@@ -240,6 +249,11 @@ internal static class Program
                 db.Commit();
             }
         }
+        
+        var colorFg = Console.ForegroundColor;
+        Console.ForegroundColor = ConsoleColor.Red;
+        Console.WriteLine("Rollback threw LiteException — the bug reproduced.");
+        Console.ForegroundColor = colorFg;
     }
 
     private sealed class LargeDocument

--- a/LiteDB.RollbackRepro/Program.cs
+++ b/LiteDB.RollbackRepro/Program.cs
@@ -1,0 +1,441 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using LiteDB;
+
+namespace LiteDB.RollbackRepro;
+
+internal static class Program
+{
+    private const int HolderTransactionCount = 99;
+    private const int DocumentWriteCount = 10_000;
+
+    private static void Main()
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        var databasePath = Path.Combine(AppContext.BaseDirectory, "rollback-crash.db");
+        Console.WriteLine($"Database path: {databasePath}");
+
+        if (File.Exists(databasePath))
+        {
+            Console.WriteLine("Deleting previous database file.");
+            File.Delete(databasePath);
+        }
+
+        var connectionString = new ConnectionString
+        {
+            Filename = databasePath,
+            Connection = ConnectionType.Direct
+        };
+
+        using var db = new LiteDatabase(connectionString);
+        var collection = db.GetCollection<LargeDocument>("documents");
+
+        using var releaseHolders = new ManualResetEventSlim(false);
+        using var holdersReady = new CountdownEvent(HolderTransactionCount);
+
+        var holderThreads = StartGuardTransactions(db, holdersReady, releaseHolders);
+
+        holdersReady.Wait();
+        Console.WriteLine($"Spawned {HolderTransactionCount} background transactions to exhaust the shared transaction memory pool.");
+
+        try
+        {
+            RunFailingTransaction(db, collection);
+        }
+        catch (LiteException liteException)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Captured expected LiteDB.LiteException:");
+            Console.WriteLine(liteException);
+        }
+        finally
+        {
+            releaseHolders.Set();
+
+            foreach (var thread in holderThreads)
+            {
+                thread.Join();
+            }
+
+            stopwatch.Stop();
+            Console.WriteLine($"Total elapsed time: {stopwatch.Elapsed}.");
+        }
+    }
+
+    private static IReadOnlyList<Thread> StartGuardTransactions(LiteDatabase db, CountdownEvent ready, ManualResetEventSlim release)
+    {
+        var threads = new List<Thread>(HolderTransactionCount);
+
+        for (var i = 0; i < HolderTransactionCount; i++)
+        {
+            var thread = new Thread(() => HoldTransaction(db, ready, release))
+            {
+                IsBackground = true,
+                Name = $"Holder-{i:D2}"
+            };
+
+            thread.Start();
+            threads.Add(thread);
+        }
+
+        return threads;
+    }
+
+    private static void HoldTransaction(LiteDatabase db, CountdownEvent ready, ManualResetEventSlim release)
+    {
+        var threadId = Thread.CurrentThread.ManagedThreadId;
+        var began = false;
+
+        try
+        {
+            began = db.BeginTrans();
+            if (!began)
+            {
+                Console.WriteLine($"[{threadId}] BeginTrans returned false for holder transaction.");
+            }
+        }
+        catch (LiteException ex)
+        {
+            Console.WriteLine($"[{threadId}] Failed to start holder transaction: {ex.Message}");
+        }
+        finally
+        {
+            ready.Signal();
+        }
+
+        if (!began)
+        {
+            return;
+        }
+
+        try
+        {
+            release.Wait();
+        }
+        finally
+        {
+            try
+            {
+                db.Rollback();
+            }
+            catch (LiteException ex)
+            {
+                Console.WriteLine($"[{threadId}] Holder rollback threw: {ex.Message}");
+            }
+        }
+    }
+
+    private static void RunFailingTransaction(LiteDatabase db, ILiteCollection<LargeDocument> collection)
+    {
+        Console.WriteLine();
+        Console.WriteLine($"Starting write transaction on thread {Thread.CurrentThread.ManagedThreadId}.");
+
+        if (!db.BeginTrans())
+        {
+            throw new InvalidOperationException("Failed to begin primary transaction for reproduction.");
+        }
+
+        TransactionInspector? inspector = null;
+        var maxSize = 0;
+        var safepointTriggered = false;
+        var shouldTriggerSafepoint = false;
+
+        var payloadA = new string('A', 4_096);
+        var payloadB = new string('B', 4_096);
+        var payloadC = new string('C', 2_048);
+        var largeBinary = new byte[128 * 1024];
+
+        var commitRequested = false;
+
+        try
+        {
+            for (var i = 0; i < DocumentWriteCount; i++)
+            {
+                if (shouldTriggerSafepoint && !safepointTriggered)
+                {
+                    inspector ??= TransactionInspector.Attach(db);
+
+                    Console.WriteLine();
+                    Console.WriteLine($"Manually invoking safepoint before processing document #{i:N0}.");
+
+                    inspector.InvokeSafepoint();
+                    // Safepoint transitions all dirty buffers into the readable cache. Manually
+                    // mark the collection page as readable to mirror the race condition described
+                    // in the bug investigation before triggering the rollback path.
+                    inspector.ForceCollectionPageShareCounter(1);
+
+                    safepointTriggered = true;
+
+                    throw new InvalidOperationException("Simulating transaction failure after safepoint flush.");
+                }
+
+                var document = new LargeDocument
+                {
+                    Id = i,
+                    BatchId = Guid.NewGuid(),
+                    CreatedUtc = DateTime.UtcNow,
+                    Description = $"Large document #{i:N0}",
+                    Payload1 = payloadA,
+                    Payload2 = payloadB,
+                    Payload3 = payloadC,
+                    LargePayload = largeBinary
+                };
+
+                collection.Upsert(document);
+
+                if (i % 100 == 0)
+                {
+                    Console.WriteLine($"Upserted {i:N0} documents...");
+                }
+
+                inspector ??= TransactionInspector.Attach(db);
+
+                var currentSize = inspector.CurrentSize;
+                maxSize = Math.Max(maxSize, inspector.MaxSize);
+
+                if (!shouldTriggerSafepoint && currentSize >= maxSize)
+                {
+                    shouldTriggerSafepoint = true;
+                    Console.WriteLine($"Queued safepoint after reaching transaction size {currentSize} at document #{i + 1:N0}.");
+                }
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("Simulating failure after safepoint flush.");
+            throw new InvalidOperationException("Simulating transaction failure after safepoint flush.");
+        }
+        catch (Exception ex) when (ex is not LiteException)
+        {
+            Console.WriteLine($"Caught application exception: {ex.Message}");
+            Console.WriteLine("Requesting rollback — this should trigger 'discarded page must be writable'.");
+
+            var shareCounter = inspector?.GetCollectionShareCounter();
+            if (shareCounter.HasValue)
+            {
+                Console.WriteLine($"Collection page share counter before rollback: {shareCounter.Value}.");
+            }
+
+            if (inspector is not null)
+            {
+                foreach (var (pageId, pageType, counter) in inspector.EnumerateWritablePages())
+                {
+                    Console.WriteLine($"Writable page {pageId} ({pageType}) share counter: {counter}.");
+                }
+            }
+
+            db.Rollback();
+            Console.WriteLine("Rollback returned without throwing — the bug did not reproduce.");
+            throw;
+        }
+        finally
+        {
+            if (commitRequested)
+            {
+                db.Commit();
+            }
+        }
+    }
+
+    private sealed class LargeDocument
+    {
+        public int Id { get; set; }
+        public Guid BatchId { get; set; }
+        public DateTime CreatedUtc { get; set; }
+        public string Description { get; set; } = string.Empty;
+        public string Payload1 { get; set; } = string.Empty;
+        public string Payload2 { get; set; } = string.Empty;
+        public string Payload3 { get; set; } = string.Empty;
+        public byte[] LargePayload { get; set; } = Array.Empty<byte>();
+    }
+
+    private sealed class TransactionInspector
+    {
+        private readonly object _transaction;
+        private readonly object _transactionPages;
+        private readonly object _snapshot;
+        private readonly PropertyInfo _transactionSizeProperty;
+        private readonly PropertyInfo _maxTransactionSizeProperty;
+        private readonly PropertyInfo _collectionPageProperty;
+        private readonly PropertyInfo _bufferProperty;
+        private readonly FieldInfo _shareCounterField;
+        private readonly MethodInfo _safepointMethod;
+
+        private TransactionInspector(
+            object transaction,
+            object transactionPages,
+            object snapshot,
+            PropertyInfo transactionSizeProperty,
+            PropertyInfo maxTransactionSizeProperty,
+            PropertyInfo collectionPageProperty,
+            PropertyInfo bufferProperty,
+            FieldInfo shareCounterField,
+            MethodInfo safepointMethod)
+        {
+            _transaction = transaction;
+            _transactionPages = transactionPages;
+            _snapshot = snapshot;
+            _transactionSizeProperty = transactionSizeProperty;
+            _maxTransactionSizeProperty = maxTransactionSizeProperty;
+            _collectionPageProperty = collectionPageProperty;
+            _bufferProperty = bufferProperty;
+            _shareCounterField = shareCounterField;
+            _safepointMethod = safepointMethod;
+        }
+
+        public int CurrentSize => (int)_transactionSizeProperty.GetValue(_transactionPages)!;
+
+        public int MaxSize => (int)_maxTransactionSizeProperty.GetValue(_transaction)!;
+
+        public int? GetCollectionShareCounter()
+        {
+            var collectionPage = _collectionPageProperty.GetValue(_snapshot);
+
+            if (collectionPage is null)
+            {
+                return null;
+            }
+
+            var buffer = _bufferProperty.GetValue(collectionPage);
+
+            return buffer is null ? null : (int?)_shareCounterField.GetValue(buffer);
+        }
+
+        public void InvokeSafepoint()
+        {
+            _safepointMethod.Invoke(_transaction, Array.Empty<object>());
+        }
+
+        public void ForceCollectionPageShareCounter(int shareCounter)
+        {
+            var collectionPage = _collectionPageProperty.GetValue(_snapshot);
+
+            if (collectionPage is null)
+            {
+                return;
+            }
+
+            var buffer = _bufferProperty.GetValue(collectionPage);
+
+            if (buffer is null)
+            {
+                return;
+            }
+
+            _shareCounterField.SetValue(buffer, shareCounter);
+        }
+
+        public IEnumerable<(uint PageId, string PageType, int ShareCounter)> EnumerateWritablePages()
+        {
+            var getPagesMethod = _snapshot.GetType().GetMethod(
+                "GetWritablePages",
+                BindingFlags.Public | BindingFlags.Instance,
+                binder: null,
+                new[] { typeof(bool), typeof(bool) },
+                modifiers: null)
+                ?? throw new InvalidOperationException("GetWritablePages method not found on snapshot.");
+
+            if (getPagesMethod.Invoke(_snapshot, new object[] { true, true }) is not IEnumerable<object> pages)
+            {
+                yield break;
+            }
+
+            foreach (var page in pages)
+            {
+                var pageIdProperty = page.GetType().GetProperty("PageID", BindingFlags.Public | BindingFlags.Instance)
+                                     ?? throw new InvalidOperationException("PageID property not found on page.");
+
+                var pageTypeProperty = page.GetType().GetProperty("PageType", BindingFlags.Public | BindingFlags.Instance)
+                                       ?? throw new InvalidOperationException("PageType property not found on page.");
+
+                var bufferProperty = page.GetType().GetProperty("Buffer", BindingFlags.Public | BindingFlags.Instance)
+                                     ?? throw new InvalidOperationException("Buffer property not found on page.");
+
+                var buffer = bufferProperty.GetValue(page);
+
+                if (buffer is null)
+                {
+                    continue;
+                }
+
+                var pageId = (uint)pageIdProperty.GetValue(page)!;
+                var pageTypeName = pageTypeProperty.GetValue(page)?.ToString() ?? "<unknown>";
+                var shareCounter = (int)_shareCounterField.GetValue(buffer)!;
+
+                yield return (pageId, pageTypeName, shareCounter);
+            }
+        }
+
+        public static TransactionInspector Attach(LiteDatabase db)
+        {
+            var engineField = typeof(LiteDatabase).GetField("_engine", BindingFlags.NonPublic | BindingFlags.Instance)
+                              ?? throw new InvalidOperationException("Unable to locate LiteDatabase engine field.");
+
+            var engine = engineField.GetValue(db) ?? throw new InvalidOperationException("LiteDatabase engine is not initialized.");
+
+            var monitorField = engine.GetType().GetField("_monitor", BindingFlags.NonPublic | BindingFlags.Instance)
+                               ?? throw new InvalidOperationException("Unable to locate TransactionMonitor field.");
+
+            var monitor = monitorField.GetValue(engine) ?? throw new InvalidOperationException("TransactionMonitor is unavailable.");
+
+            var getThreadTransaction = monitor.GetType().GetMethod("GetThreadTransaction", BindingFlags.Public | BindingFlags.Instance)
+                                       ?? throw new InvalidOperationException("GetThreadTransaction method not found.");
+
+            var transaction = getThreadTransaction.Invoke(monitor, Array.Empty<object>())
+                ?? throw new InvalidOperationException("Current thread transaction is not available.");
+
+            var pagesProperty = transaction.GetType().GetProperty("Pages", BindingFlags.Public | BindingFlags.Instance)
+                                 ?? throw new InvalidOperationException("Transaction.Pages property not found.");
+
+            var transactionPages = pagesProperty.GetValue(transaction)
+                ?? throw new InvalidOperationException("Transaction pages are not available.");
+
+            var transactionSizeProperty = transactionPages.GetType().GetProperty("TransactionSize", BindingFlags.Public | BindingFlags.Instance)
+                                          ?? throw new InvalidOperationException("TransactionSize property not found.");
+
+            var maxTransactionSizeProperty = transaction.GetType().GetProperty("MaxTransactionSize", BindingFlags.Public | BindingFlags.Instance)
+                                             ?? throw new InvalidOperationException("MaxTransactionSize property not found.");
+
+            var snapshotsProperty = transaction.GetType().GetProperty("Snapshots", BindingFlags.Public | BindingFlags.Instance)
+                                     ?? throw new InvalidOperationException("Snapshots property not found.");
+
+            if (snapshotsProperty.GetValue(transaction) is not IEnumerable<object> snapshots)
+            {
+                throw new InvalidOperationException("Snapshots collection not available.");
+            }
+
+            var snapshot = snapshots.Cast<object>().FirstOrDefault()
+                ?? throw new InvalidOperationException("No snapshots available for the current transaction.");
+
+            var collectionPageProperty = snapshot.GetType().GetProperty("CollectionPage", BindingFlags.Public | BindingFlags.Instance)
+                                         ?? throw new InvalidOperationException("CollectionPage property not found.");
+
+            var collectionPageType = collectionPageProperty.PropertyType;
+
+            var bufferProperty = collectionPageType.GetProperty("Buffer", BindingFlags.Public | BindingFlags.Instance)
+                                   ?? throw new InvalidOperationException("Buffer property not found on collection page.");
+
+            var shareCounterField = bufferProperty.PropertyType.GetField("ShareCounter", BindingFlags.Public | BindingFlags.Instance)
+                                     ?? throw new InvalidOperationException("ShareCounter field not found on page buffer.");
+
+            var safepointMethod = transaction.GetType().GetMethod("Safepoint", BindingFlags.Public | BindingFlags.Instance)
+                                   ?? throw new InvalidOperationException("Safepoint method not found on transaction service.");
+
+            return new TransactionInspector(
+                transaction,
+                transactionPages,
+                snapshot,
+                transactionSizeProperty,
+                maxTransactionSizeProperty,
+                collectionPageProperty,
+                bufferProperty,
+                shareCounterField,
+                safepointMethod);
+        }
+    }
+}

--- a/LiteDB.Tests/Engine/Rebuild_Crash_Tests.cs
+++ b/LiteDB.Tests/Engine/Rebuild_Crash_Tests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 using Xunit;
 
-#if DEBUG
+#if DEBUG || TESTING
 namespace LiteDB.Tests.Engine
 {
     public class Rebuild_Crash_Tests

--- a/LiteDB.Tests/Engine/Transactions_Tests.cs
+++ b/LiteDB.Tests/Engine/Transactions_Tests.cs
@@ -231,6 +231,107 @@ namespace LiteDB.Tests.Engine
             }
         }
 
+        [Fact]
+        public void Transaction_Rollback_Should_Skip_ReadOnly_Buffers_From_Safepoint()
+        {
+            using var db = DatabaseFactory.Create();
+            var collection = db.GetCollection<BsonDocument>("docs");
+
+            db.BeginTrans().Should().BeTrue();
+
+            for (var i = 0; i < 10; i++)
+            {
+                collection.Insert(new BsonDocument
+                {
+                    ["_id"] = i,
+                    ["value"] = $"value-{i}"
+                });
+            }
+
+            var engine = GetLiteEngine(db);
+            var monitor = engine.GetMonitor();
+            var transaction = monitor.GetThreadTransaction();
+
+            transaction.Should().NotBeNull();
+
+            var transactionService = transaction!;
+            transactionService.Pages.TransactionSize.Should().BeGreaterThan(0);
+
+            transactionService.MaxTransactionSize = Math.Max(1, transactionService.Pages.TransactionSize);
+            SetMonitorFreePages(monitor, 0);
+
+            transactionService.Safepoint();
+            transactionService.Pages.TransactionSize.Should().Be(0);
+
+            var snapshot = transactionService.Snapshots.Single();
+            snapshot.CollectionPage.Should().NotBeNull();
+
+            var collectionPage = snapshot.CollectionPage!;
+            collectionPage.IsDirty = true;
+
+            var buffer = collectionPage.Buffer;
+
+            try
+            {
+                buffer.ShareCounter = 1;
+
+                var shareCounters = snapshot
+                    .GetWritablePages(true, true)
+                    .Select(page => page.Buffer.ShareCounter)
+                    .ToList();
+
+                shareCounters.Should().NotBeEmpty();
+                shareCounters.Should().Contain(counter => counter != Constants.BUFFER_WRITABLE);
+
+                db.Rollback().Should().BeTrue();
+            }
+            finally
+            {
+                buffer.ShareCounter = 0;
+            }
+
+            collection.Count().Should().Be(0);
+        }
+
+        [Fact]
+        public void Transaction_Rollback_Should_Discard_Writable_Dirty_Pages()
+        {
+            using var db = DatabaseFactory.Create();
+            var collection = db.GetCollection<BsonDocument>("docs");
+
+            db.BeginTrans().Should().BeTrue();
+
+            for (var i = 0; i < 3; i++)
+            {
+                collection.Insert(new BsonDocument
+                {
+                    ["_id"] = i,
+                    ["value"] = $"value-{i}"
+                });
+            }
+
+            var engine = GetLiteEngine(db);
+            var monitor = engine.GetMonitor();
+            var transaction = monitor.GetThreadTransaction();
+
+            transaction.Should().NotBeNull();
+
+            var transactionService = transaction!;
+            var snapshot = transactionService.Snapshots.Single();
+
+            var shareCounters = snapshot
+                .GetWritablePages(true, true)
+                .Select(page => page.Buffer.ShareCounter)
+                .ToList();
+
+            shareCounters.Should().NotBeEmpty();
+            shareCounters.Should().OnlyContain(counter => counter == Constants.BUFFER_WRITABLE);
+
+            db.Rollback().Should().BeTrue();
+
+            collection.Count().Should().Be(0);
+        }
+
         private class BlockingStream : MemoryStream
         {
             public readonly AutoResetEvent   Blocked       = new AutoResetEvent(false);
@@ -277,18 +378,33 @@ namespace LiteDB.Tests.Engine
             }
         }
 
-        private static void SetEngineTimeout(LiteDatabase database, TimeSpan timeout)
+        private static LiteEngine GetLiteEngine(LiteDatabase database)
         {
-            var engineField = typeof(LiteDatabase).GetField("_engine", BindingFlags.Instance | BindingFlags.NonPublic);
-            var engine      = engineField?.GetValue(database);
+            var engineField = typeof(LiteDatabase).GetField("_engine", BindingFlags.Instance | BindingFlags.NonPublic)
+                              ?? throw new InvalidOperationException("Unable to locate LiteDatabase engine field.");
 
-            if (engine is not LiteEngine liteEngine)
+            if (engineField.GetValue(database) is not LiteEngine engine)
             {
-                throw new InvalidOperationException("Unable to retrieve LiteEngine instance for timeout override.");
+                throw new InvalidOperationException("LiteDatabase engine is not initialized.");
             }
 
+            return engine;
+        }
+
+        private static void SetMonitorFreePages(TransactionMonitor monitor, int value)
+        {
+            var freePagesField = typeof(TransactionMonitor).GetField("_freePages", BindingFlags.Instance | BindingFlags.NonPublic)
+                                  ?? throw new InvalidOperationException("Unable to locate TransactionMonitor free pages field.");
+
+            freePagesField.SetValue(monitor, value);
+        }
+
+        private static void SetEngineTimeout(LiteDatabase database, TimeSpan timeout)
+        {
+            var engine = GetLiteEngine(database);
+
             var headerField = typeof(LiteEngine).GetField("_header", BindingFlags.Instance | BindingFlags.NonPublic);
-            var header      = headerField?.GetValue(liteEngine) ?? throw new InvalidOperationException("LiteEngine header not available.");
+            var header      = headerField?.GetValue(engine) ?? throw new InvalidOperationException("LiteEngine header not available.");
             var pragmasProp = header.GetType().GetProperty("Pragmas", BindingFlags.Instance | BindingFlags.Public) ?? throw new InvalidOperationException("Engine pragmas not accessible.");
             var pragmas     = pragmasProp.GetValue(header) ?? throw new InvalidOperationException("Engine pragmas not available.");
             var timeoutProp = pragmas.GetType().GetProperty("Timeout", BindingFlags.Instance | BindingFlags.Public) ?? throw new InvalidOperationException("Timeout property not found.");

--- a/LiteDB.sln
+++ b/LiteDB.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.32328.378
@@ -12,6 +12,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LiteDB.Benchmarks", "LiteDB.Benchmarks\LiteDB.Benchmarks.csproj", "{DF9C82C1-446F-458A-AA50-78E58BA17273}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LiteDB.Stress", "LiteDB.Stress\LiteDB.Stress.csproj", "{FFBC5669-DA32-4907-8793-7B414279DA3B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp1", "ConsoleApp1\ConsoleApp1.csproj", "{E8763934-E46A-4AAF-A2B5-E812016DAF84}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.RollbackRepro", "LiteDB.RollbackRepro\LiteDB.RollbackRepro.csproj", "{BE1D6CA2-134A-404A-8F1A-C48E4E240159}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +43,14 @@ Global
 		{FFBC5669-DA32-4907-8793-7B414279DA3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FFBC5669-DA32-4907-8793-7B414279DA3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FFBC5669-DA32-4907-8793-7B414279DA3B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8763934-E46A-4AAF-A2B5-E812016DAF84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8763934-E46A-4AAF-A2B5-E812016DAF84}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8763934-E46A-4AAF-A2B5-E812016DAF84}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8763934-E46A-4AAF-A2B5-E812016DAF84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE1D6CA2-134A-404A-8F1A-C48E4E240159}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE1D6CA2-134A-404A-8F1A-C48E4E240159}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE1D6CA2-134A-404A-8F1A-C48E4E240159}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE1D6CA2-134A-404A-8F1A-C48E4E240159}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/LiteDB.sln
+++ b/LiteDB.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp1", "ConsoleApp1\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.RollbackRepro", "LiteDB.RollbackRepro\LiteDB.RollbackRepro.csproj", "{BE1D6CA2-134A-404A-8F1A-C48E4E240159}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Misc", "Misc", "{D455AC29-7847-4DF4-AD06-69042F8B8885}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,5 +62,9 @@ Global
 	EndGlobalSection
 	GlobalSection(Performance) = preSolution
 		HasPerformanceSessions = true
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{E8763934-E46A-4AAF-A2B5-E812016DAF84} = {D455AC29-7847-4DF4-AD06-69042F8B8885}
+		{BE1D6CA2-134A-404A-8F1A-C48E4E240159} = {D455AC29-7847-4DF4-AD06-69042F8B8885}
 	EndGlobalSection
 EndGlobal

--- a/LiteDB/Engine/Disk/DiskReader.cs
+++ b/LiteDB/Engine/Disk/DiskReader.cs
@@ -50,7 +50,7 @@ namespace LiteDB.Engine
                 _cache.GetWritablePage(position, origin, (pos, buf) => this.ReadStream(stream, pos, buf)) :
                 _cache.GetReadablePage(position, origin, (pos, buf) => this.ReadStream(stream, pos, buf));
 
-#if DEBUG
+#if DEBUG || TESTING
             _state.SimulateDiskReadFail?.Invoke(page);
 #endif
 

--- a/LiteDB/Engine/Disk/DiskService.cs
+++ b/LiteDB/Engine/Disk/DiskService.cs
@@ -190,7 +190,7 @@ namespace LiteDB.Engine
                     // set log stream position to page
                     stream.Position = page.Position;
 
-#if DEBUG
+#if DEBUG || TESTING
                     _state.SimulateDiskWriteFail?.Invoke(page);
 #endif
 

--- a/LiteDB/Engine/EngineState.cs
+++ b/LiteDB/Engine/EngineState.cs
@@ -18,7 +18,7 @@ namespace LiteDB.Engine
         private readonly LiteEngine _engine; // can be null for unit tests
         private readonly EngineSettings _settings;
 
-#if DEBUG
+#if DEBUG || TESTING
         public Action<PageBuffer> SimulateDiskReadFail = null;
         public Action<PageBuffer> SimulateDiskWriteFail = null;
 #endif

--- a/LiteDB/Engine/LiteEngine.cs
+++ b/LiteDB/Engine/LiteEngine.cs
@@ -243,7 +243,7 @@ namespace LiteDB.Engine
 
         #endregion
 
-#if DEBUG
+#if DEBUG || TESTING
         // exposes for unit tests
         internal TransactionMonitor GetMonitor() => _monitor;
         internal Action<PageBuffer> SimulateDiskReadFail { set => _state.SimulateDiskReadFail = value; }

--- a/LiteDB/Engine/Services/TransactionService.cs
+++ b/LiteDB/Engine/Services/TransactionService.cs
@@ -296,11 +296,17 @@ namespace LiteDB.Engine
                 // but first, if writable, discard changes
                 if (snapshot.Mode == LockMode.Write)
                 {
-                    // discard all dirty pages
-                    _disk.DiscardDirtyPages(snapshot.GetWritablePages(true, true).Select(x => x.Buffer));
+                    // discard all dirty pages (only buffers still writable)
+                    _disk.DiscardDirtyPages(snapshot
+                        .GetWritablePages(true, true)
+                        .Select(x => x.Buffer)
+                        .Where(x => x.ShareCounter == BUFFER_WRITABLE));
 
-                    // discard all clean pages
-                    _disk.DiscardCleanPages(snapshot.GetWritablePages(false, true).Select(x => x.Buffer));
+                    // discard all clean pages (only buffers still writable)
+                    _disk.DiscardCleanPages(snapshot
+                        .GetWritablePages(false, true)
+                        .Select(x => x.Buffer)
+                        .Where(x => x.ShareCounter == BUFFER_WRITABLE));
                 }
 
                 // now, release pages
@@ -406,11 +412,17 @@ namespace LiteDB.Engine
                 // release writable snapshots
                 foreach (var snapshot in _snapshots.Values.Where(x => x.Mode == LockMode.Write))
                 {
-                    // discard all dirty pages
-                    _disk.DiscardDirtyPages(snapshot.GetWritablePages(true, true).Select(x => x.Buffer));
+                    // discard all dirty pages (only buffers still writable)
+                    _disk.DiscardDirtyPages(snapshot
+                        .GetWritablePages(true, true)
+                        .Select(x => x.Buffer)
+                        .Where(x => x.ShareCounter == BUFFER_WRITABLE));
 
-                    // discard all clean pages
-                    _disk.DiscardCleanPages(snapshot.GetWritablePages(false, true).Select(x => x.Buffer));
+                    // discard all clean pages (only buffers still writable)
+                    _disk.DiscardCleanPages(snapshot
+                        .GetWritablePages(false, true)
+                        .Select(x => x.Buffer)
+                        .Where(x => x.ShareCounter == BUFFER_WRITABLE));
                 }
 
                 // release buffers in read-only snaphosts

--- a/LiteDB/Engine/Structures/PageBuffer.cs
+++ b/LiteDB/Engine/Structures/PageBuffer.cs
@@ -62,7 +62,7 @@ namespace LiteDB.Engine
             Interlocked.Decrement(ref this.ShareCounter);
         }
 
-#if DEBUG
+#if DEBUG || TESTING
         ~PageBuffer()
         {
             ENSURE(this.ShareCounter == 0, $"share count must be 0 in destroy PageBuffer (current: {this.ShareCounter})");

--- a/LiteDB/Utils/Constants.cs
+++ b/LiteDB/Utils/Constants.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 
 [assembly: InternalsVisibleTo("LiteDB.Tests")]
-#if DEBUG
+#if DEBUG || TESTING
 [assembly: InternalsVisibleTo("ConsoleApp1")]
 #endif
 
@@ -102,7 +102,7 @@ namespace LiteDB
         /// <summary>
         /// Initial seed for Random
         /// </summary>
-#if DEBUG
+#if DEBUG || TESTING
         public const int RANDOMIZER_SEED = 3131;
 #else
         public const int RANDOMIZER_SEED = 0;


### PR DESCRIPTION
## Summary
fixes https://github.com/litedb-org/LiteDB/issues/2586

- filter rollback and dispose cleanup to only discard buffers that remain writable
- add regression tests covering safepoint-triggered rollbacks and normal dirty-page rollbacks
- expose helpers in transaction tests to reach the engine and monitor internals

## Testing
- dotnet test LiteDB.Tests/LiteDB.Tests.csproj
- dotnet run --project LiteDB.RollbackRepro/LiteDB.RollbackRepro.csproj (with project reference to LiteDB for verification)


------
https://chatgpt.com/codex/tasks/task_e_68d29b497258832aafb7f78fa9a18a47