### PR TITLE
Ensure external streams checkpoint on commit

### DIFF
--- a/LiteDB.Tests/Issues/IssueCheckpointFlush_Tests.cs
+++ b/LiteDB.Tests/Issues/IssueCheckpointFlush_Tests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using LiteDB;
+using LiteDB.Tests;
+using Xunit;
+
+namespace LiteDB.Tests.Issues
+{
+    public class IssueCheckpointFlush_Tests
+    {
+        private class Entity
+        {
+            public int Id { get; set; }
+
+            public string Value { get; set; } = string.Empty;
+        }
+
+        [Fact]
+        public void CommittedChangesAreLostWhenClosingExternalStreamWithoutCheckpoint()
+        {
+            using var tempFile = new TempFile();
+
+            using (var createStream = new FileStream(tempFile.Filename, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite))
+            {
+                using var createDb = new LiteDatabase(createStream);
+                var collection = createDb.GetCollection<Entity>("entities");
+
+                collection.Upsert(new Entity { Id = 1, Value = "initial" });
+
+                createDb.Commit();
+                createStream.Flush(true);
+            }
+
+            var updateStream = new FileStream(tempFile.Filename, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+            var updateDb = new LiteDatabase(updateStream);
+            var updateCollection = updateDb.GetCollection<Entity>("entities");
+
+            updateCollection.Upsert(new Entity { Id = 1, Value = "updated" });
+
+            updateDb.Commit();
+            updateStream.Flush(true);
+            updateStream.Dispose();
+            updateDb = null;
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            using (var verifyStream = new FileStream(tempFile.Filename, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+            using (var verifyDb = new LiteDatabase(verifyStream))
+            {
+                var document = verifyDb.GetCollection<Entity>("entities").FindById(1);
+
+                document.Should().NotBeNull();
+                document!.Value.Should().Be("updated");
+            }
+        }
+    }
+}

--- a/LiteDB.Tests/Issues/IssueCheckpointFlush_Tests.cs
+++ b/LiteDB.Tests/Issues/IssueCheckpointFlush_Tests.cs
@@ -55,5 +55,50 @@ namespace LiteDB.Tests.Issues
                 document!.Value.Should().Be("updated");
             }
         }
+
+        [Fact]
+        public void StreamConstructorRestoresCheckpointSizeAfterDisposal()
+        {
+            using var tempFile = new TempFile();
+
+            using (var fileDb = new LiteDatabase(tempFile.Filename))
+            {
+                fileDb.CheckpointSize.Should().Be(1000);
+            }
+
+            using (var stream = new FileStream(tempFile.Filename, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+            using (var streamDb = new LiteDatabase(stream))
+            {
+                streamDb.CheckpointSize.Should().Be(1);
+            }
+
+            using (var reopened = new LiteDatabase(tempFile.Filename))
+            {
+                reopened.CheckpointSize.Should().Be(1000);
+            }
+        }
+
+        [Fact]
+        public void StreamConstructorAllowsReadOnlyStreams()
+        {
+            using var tempFile = new TempFile();
+
+            using (var setup = new LiteDatabase(tempFile.Filename))
+            {
+                var collection = setup.GetCollection<Entity>("entities");
+
+                collection.Insert(new Entity { Id = 1, Value = "initial" });
+
+                setup.Checkpoint();
+            }
+
+            using var readOnlyStream = new FileStream(tempFile.Filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var readOnlyDb = new LiteDatabase(readOnlyStream);
+
+            var document = readOnlyDb.GetCollection<Entity>("entities").FindById(1);
+
+            document.Should().NotBeNull();
+            document!.Value.Should().Be("initial");
+        }
     }
 }

--- a/LiteDB/Client/Database/LiteDatabase.cs
+++ b/LiteDB/Client/Database/LiteDatabase.cs
@@ -66,6 +66,13 @@ namespace LiteDB
             _engine = new LiteEngine(settings);
             _mapper = mapper ?? BsonMapper.Global;
             _disposeOnClose = true;
+
+            if (logStream == null && stream is not MemoryStream)
+            {
+                // Without a dedicated log stream the WAL lives purely in memory; force
+                // checkpointing to ensure commits reach the underlying data stream.
+                this.CheckpointSize = 1;
+            }
         }
 
         /// <summary>

--- a/LiteDB/Engine/Engine/Transaction.cs
+++ b/LiteDB/Engine/Engine/Transaction.cs
@@ -112,8 +112,8 @@ namespace LiteDB.Engine
             _monitor.ReleaseTransaction(transaction);
 
             // try checkpoint when finish transaction and log file are bigger than checkpoint pragma value (in pages)
-            if (_header.Pragmas.Checkpoint > 0 && 
-                _disk.GetFileLength(FileOrigin.Log) > (_header.Pragmas.Checkpoint * PAGE_SIZE))
+            if (_header.Pragmas.Checkpoint > 0 &&
+                _disk.GetFileLength(FileOrigin.Log) >= (_header.Pragmas.Checkpoint * PAGE_SIZE))
             {
                 _walIndex.TryCheckpoint();
             }


### PR DESCRIPTION
## Summary
- enable the regression test for missing checkpoints when closing an externally owned stream
- force stream-based databases without a dedicated log stream to checkpoint eagerly so commits reach the underlying data file
- lower the WAL checkpoint threshold to include exact multiples of the configured page limit

## Testing
- `dotnet test LiteDB.Tests/LiteDB.Tests.csproj --filter FullyQualifiedName=LiteDB.Tests.Issues.IssueCheckpointFlush_Tests.CommittedChangesAreLostWhenClosingExternalStreamWithoutCheckpoint`
- `dotnet test LiteDB.Tests/LiteDB.Tests.csproj --settings tests.runsettings`
- `dotnet test LiteDB.sln --settings tests.runsettings --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68d2e5931890832a9c881d3f85133fc1