### PR TITLE
Fix/improve build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,12 @@ jobs:
         run: dotnet build LiteDB.sln --configuration Release --no-restore /p:DefineConstants=TESTING
 
       - name: Test
-        timeout-minutes: 5
-        run: dotnet test LiteDB.sln --configuration Release --no-build --verbosity normal --settings tests.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" /p:DefineConstants=TESTING
+        timeout-minutes: 3
+        run: dotnet test LiteDB.sln --configuration Release --no-build --verbosity normal --settings tests.ci.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" /p:DefineConstants=TESTING
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: "**/*TestResults*.trx"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
       - name: Check out repository
@@ -24,9 +27,24 @@ jobs:
       - name: Build
         run: dotnet build LiteDB.sln --configuration Release --no-restore /p:DefineConstants=TESTING
 
-      - name: Test
-        timeout-minutes: 5
-        run: dotnet test LiteDB.sln --configuration Release --no-build --verbosity normal --settings tests.ci.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" --blame-hang-timeout 2m /p:DefineConstants=TESTING
+      - name: Test (with hang diagnostics)
+        timeout-minutes: 8
+        env:
+          VSTEST_TESTHOST_HANG_DUMP_TYPE: full
+          VSTEST_TESTHOST_HANG_DUMP_FOLDER: ${{ github.workspace }}/hangdumps
+          DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+          DOTNET_NOLOGO: 1
+        run: >-
+          dotnet test LiteDB.sln
+          --configuration Release
+          --no-build
+          --verbosity normal
+          --settings tests.ci.runsettings
+          --logger "trx;LogFileName=TestResults.trx"
+          --logger "console;verbosity=detailed"
+          --blame-hang --blame-hang-timeout 00:02:00
+          --diag "TestHost.diag.log;tracelevel=verbose"
+          /p:DefineConstants=TESTING
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
@@ -34,3 +52,13 @@ jobs:
         with:
           name: test-results
           path: "**/*TestResults*.trx"
+
+      - name: Upload hang dumps (if any)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: hangdumps
+          path: |
+            hangdumps
+            **/TestResults/**/*.dmp
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Test
         timeout-minutes: 5
-        run: dotnet test LiteDB.sln --configuration Release --no-build --verbosity normal --settings tests.ci.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" /p:DefineConstants=TESTING
+        run: dotnet test LiteDB.sln --configuration Release --no-build --verbosity normal --settings tests.ci.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" --blame-hang-timeout 2m /p:DefineConstants=TESTING
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: dotnet build LiteDB.sln --configuration Release --no-restore /p:DefineConstants=TESTING
 
       - name: Test
-        timeout-minutes: 3
+        timeout-minutes: 5
         run: dotnet test LiteDB.sln --configuration Release --no-build --verbosity normal --settings tests.ci.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" /p:DefineConstants=TESTING
 
       - name: Upload test results

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -39,11 +39,15 @@ jobs:
         run: dotnet test LiteDB.sln --configuration Release --verbosity normal --settings tests.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" /p:DefineConstants=TESTING
 
       - name: Build
-        run: dotnet build LiteDB.sln --configuration Release --no-restore
+        run: dotnet build LiteDB.sln --configuration Release --no-restore \
+          -p:Version=${{ steps.version.outputs.package_version }} \
+          -p:PackageVersion=${{ steps.version.outputs.package_version }}
 
       - name: Pack
         run: |
-          dotnet pack LiteDB/LiteDB.csproj --configuration Release --no-build -o artifacts -p:PackageVersion=${{ steps.version.outputs.package_version }} -p:Version=${{ steps.version.outputs.package_version }}
+          dotnet pack LiteDB/LiteDB.csproj --configuration Release --no-build -o artifacts \
+           -p:PackageVersion=${{ steps.version.outputs.package_version }} \
+           -p:Version=${{ steps.version.outputs.package_version }}
 
       - name: Publish GitHub prerelease
         uses: softprops/action-gh-release@v2
@@ -53,8 +57,10 @@ jobs:
           generate_release_notes: true
           prerelease: true
           files: artifacts/*.nupkg
+          target_commitish: ${{ github.sha }}   # or 'dev'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 
       - name: Retrieve secrets from Bitwarden
         uses: bitwarden/sm-action@v2

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -22,14 +22,12 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
-      - name: Set version with padded build number
+      - name: Set prerelease version
         id: version
         run: |
-          # Pad the run number with leading zeros (4 digits)
-          PADDED_BUILD_NUMBER=$(printf "%04d" ${{ github.run_number }})
-          PACKAGE_VERSION="6.0.0-prerelease.${PADDED_BUILD_NUMBER}"
-          echo "package_version=${PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Version set to $PACKAGE_VERSION"
+          # Use SemVer-compliant prerelease without leading zeros
+          echo "package_version=6.0.0-prerelease.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "Version set to 6.0.0-prerelease.${{ github.run_number }}"
 
       - name: Restore
         run: dotnet restore LiteDB.sln
@@ -62,10 +60,9 @@ jobs:
           generate_release_notes: true
           prerelease: true
           files: artifacts/*.nupkg
-          target_commitish: ${{ github.sha }}   # or 'dev'
+          target_commitish: ${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 
       - name: Retrieve secrets from Bitwarden
         if: success()
@@ -80,5 +77,4 @@ jobs:
         if: success()
         run: |
           dotnet nuget push "artifacts/*.nupkg" --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
-
 

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
       - name: Check out repository
@@ -32,9 +35,23 @@ jobs:
       - name: Restore
         run: dotnet restore LiteDB.sln
 
-      - name: Test
-        timeout-minutes: 3
-        run: dotnet test LiteDB.sln --configuration Release --verbosity normal --settings tests.ci.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" --blame-hang-timeout 2m /p:DefineConstants=TESTING
+      - name: Test (with hang diagnostics)
+        timeout-minutes: 8
+        env:
+          VSTEST_TESTHOST_HANG_DUMP_TYPE: full
+          VSTEST_TESTHOST_HANG_DUMP_FOLDER: ${{ github.workspace }}/hangdumps
+          DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+          DOTNET_NOLOGO: 1
+        run: >-
+          dotnet test LiteDB.sln
+          --configuration Release
+          --verbosity normal
+          --settings tests.ci.runsettings
+          --logger "trx;LogFileName=TestResults.trx"
+          --logger "console;verbosity=detailed"
+          --blame-hang --blame-hang-timeout 00:02:00
+          --diag "TestHost.diag.log;tracelevel=verbose"
+          /p:DefineConstants=TESTING
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
@@ -42,6 +59,16 @@ jobs:
         with:
           name: test-results
           path: "**/*TestResults*.trx"
+      
+      - name: Upload hang dumps (if any)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: hangdumps
+          path: |
+            hangdumps
+            **/TestResults/**/*.dmp
+          if-no-files-found: ignore
 
       - name: Build
         if: success()

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Test
         timeout-minutes: 3
-        run: dotnet test LiteDB.sln --configuration Release --verbosity normal --settings tests.ci.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" /p:DefineConstants=TESTING
+        run: dotnet test LiteDB.sln --configuration Release --verbosity normal --settings tests.ci.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" --blame-hang-timeout 2m /p:DefineConstants=TESTING
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -39,7 +39,7 @@ jobs:
         run: dotnet test LiteDB.sln --configuration Release --verbosity normal --settings tests.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" /p:DefineConstants=TESTING
 
       - name: Build
-        run: dotnet build LiteDB.sln --configuration Release --no-restore \
+        run: dotnet build LiteDB/LiteDB.csproj --configuration Release --no-restore \
           -p:Version=${{ steps.version.outputs.package_version }} \
           -p:PackageVersion=${{ steps.version.outputs.package_version }}
 

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -47,16 +47,11 @@ jobs:
 
       - name: Build
         if: success()
-        run: dotnet build LiteDB/LiteDB.csproj --configuration Release --no-restore \
-          -p:Version=${{ steps.version.outputs.package_version }} \
-          -p:PackageVersion=${{ steps.version.outputs.package_version }}
+        run: dotnet build LiteDB/LiteDB.csproj --configuration Release --no-restore -p:Version=${{ steps.version.outputs.package_version }} -p:PackageVersion=${{ steps.version.outputs.package_version }}
 
       - name: Pack
         if: success()
-        run: |
-          dotnet pack LiteDB/LiteDB.csproj --configuration Release --no-build -o artifacts \
-           -p:PackageVersion=${{ steps.version.outputs.package_version }} \
-           -p:Version=${{ steps.version.outputs.package_version }}
+        run: dotnet pack LiteDB/LiteDB.csproj --configuration Release --no-build -o artifacts -p:PackageVersion=${{ steps.version.outputs.package_version }} -p:Version=${{ steps.version.outputs.package_version }}
 
       - name: Publish GitHub prerelease
         if: success()

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -47,11 +47,11 @@ jobs:
 
       - name: Build
         if: success()
-        run: dotnet build LiteDB/LiteDB.csproj --configuration Release --no-restore -p:Version=${{ steps.version.outputs.package_version }} -p:PackageVersion=${{ steps.version.outputs.package_version }}
+        run: dotnet build LiteDB/LiteDB.csproj --configuration Release --no-restore -p:Version=${{ steps.version.outputs.package_version }} -p:PackageVersion=${{ steps.version.outputs.package_version }} -p:MinVerSkip=true
 
       - name: Pack
         if: success()
-        run: dotnet pack LiteDB/LiteDB.csproj --configuration Release --no-build -o artifacts -p:PackageVersion=${{ steps.version.outputs.package_version }} -p:Version=${{ steps.version.outputs.package_version }}
+        run: dotnet pack LiteDB/LiteDB.csproj --configuration Release --no-build -o artifacts -p:PackageVersion=${{ steps.version.outputs.package_version }} -p:Version=${{ steps.version.outputs.package_version }} -p:MinVerSkip=true
 
       - name: Publish GitHub prerelease
         if: success()

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -35,21 +35,31 @@ jobs:
         run: dotnet restore LiteDB.sln
 
       - name: Test
-        timeout-minutes: 5
-        run: dotnet test LiteDB.sln --configuration Release --verbosity normal --settings tests.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" /p:DefineConstants=TESTING
+        timeout-minutes: 3
+        run: dotnet test LiteDB.sln --configuration Release --verbosity normal --settings tests.ci.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" /p:DefineConstants=TESTING
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: "**/*TestResults*.trx"
 
       - name: Build
+        if: success()
         run: dotnet build LiteDB/LiteDB.csproj --configuration Release --no-restore \
           -p:Version=${{ steps.version.outputs.package_version }} \
           -p:PackageVersion=${{ steps.version.outputs.package_version }}
 
       - name: Pack
+        if: success()
         run: |
           dotnet pack LiteDB/LiteDB.csproj --configuration Release --no-build -o artifacts \
            -p:PackageVersion=${{ steps.version.outputs.package_version }} \
            -p:Version=${{ steps.version.outputs.package_version }}
 
       - name: Publish GitHub prerelease
+        if: success()
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version.outputs.package_version }}
@@ -63,6 +73,7 @@ jobs:
 
 
       - name: Retrieve secrets from Bitwarden
+        if: success()
         uses: bitwarden/sm-action@v2
         with:
           access_token: ${{ secrets.BW_ACCESS_TOKEN }}
@@ -71,6 +82,7 @@ jobs:
             265b2fb6-2cf0-4859-9bc8-b24c00ab4378 > NUGET_API_KEY
 
       - name: Push package to NuGet
+        if: success()
         run: |
           dotnet nuget push "artifacts/*.nupkg" --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
 

--- a/LiteDB.Stress/Test/TestExecution.cs
+++ b/LiteDB.Stress/Test/TestExecution.cs
@@ -47,7 +47,10 @@ namespace LiteDB.Stress
             this.CreateThreads();
 
             // start report thread
-            var t = new Thread(() => this.ReportThread());
+            var t = new Thread(() => this.ReportThread())
+            {
+                IsBackground = true
+            };
             t.Name = "REPORT";
             t.Start();
         }
@@ -100,7 +103,10 @@ namespace LiteDB.Stress
                             info.Counter++;
                             info.LastRun = DateTime.Now;
                         }
-                    });
+                    })
+                    {
+                        IsBackground = true
+                    };
 
                     _threads[thread.ManagedThreadId] = new ThreadInfo
                     {

--- a/LiteDB.Tests/Engine/Rebuild_Crash_Tests.cs
+++ b/LiteDB.Tests/Engine/Rebuild_Crash_Tests.cs
@@ -3,12 +3,11 @@ using LiteDB.Engine;
 using System;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 
 using Xunit;
 using Xunit.Abstractions;
 
-#if DEBUG || TESTING
+#if DEBUG
 namespace LiteDB.Tests.Engine
 {
     public class Rebuild_Crash_Tests
@@ -20,16 +19,13 @@ namespace LiteDB.Tests.Engine
             _output = output;
         }
 
-        [Fact(Timeout = 30000)]
-        public async Task Rebuild_Crash_IO_Write_Error()
+        [Fact]
+        public void Rebuild_Crash_IO_Write_Error()
         {
-            var testName = nameof(Rebuild_Crash_IO_Write_Error);
-
-            _output.WriteLine($"starting {testName}");
-
+            _output.WriteLine("Running Rebuild_Crash_IO_Write_Error");
             try
             {
-                var N = 1000;
+                var N = 1_000;
 
                 using (var file = new TempFile())
                 {
@@ -40,15 +36,13 @@ namespace LiteDB.Tests.Engine
                         Password = "46jLz5QWd5fI3m4LiL2r"
                     };
 
-                    var initial = new DateTime(2024, 1, 1);
-
                     var data = Enumerable.Range(1, N).Select(i => new BsonDocument
                     {
                         ["_id"] = i,
-                        ["name"] = $"user-{i:D4}",
-                        ["age"] = 18 + (i % 60),
-                        ["created"] = initial.AddDays(i),
-                        ["lorem"] = new string((char)('a' + (i % 26)), 800)
+                        ["name"] = Faker.Fullname(),
+                        ["age"] = Faker.Age(),
+                        ["created"] = Faker.Birthday(),
+                        ["lorem"] = Faker.Lorem(5, 25)
                     }).ToArray();
 
                     try
@@ -103,12 +97,10 @@ namespace LiteDB.Tests.Engine
 
                     }
                 }
-
-                await Task.CompletedTask;
             }
             finally
             {
-                _output.WriteLine($"{testName} completed");
+                _output.WriteLine("Finished running Rebuild_Crash_IO_Write_Error");
             }
         }
     }

--- a/LiteDB.Tests/Engine/Rebuild_Crash_Tests.cs
+++ b/LiteDB.Tests/Engine/Rebuild_Crash_Tests.cs
@@ -3,6 +3,7 @@ using LiteDB.Engine;
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;
@@ -51,20 +52,31 @@ namespace LiteDB.Tests.Engine
                         ["lorem"] = new string((char)('a' + (i % 26)), 800)
                     }).ToArray();
 
+                    var faultInjected = 0;
+
                     try
                     {
                         using (var db = new LiteEngine(settings))
                         {
+                            var writeHits = 0;
+
                             db.SimulateDiskWriteFail = (page) =>
                             {
                                 var p = new BasePage(page);
 
-                                if (p.PageID == 28)
+                                if (p.PageType == PageType.Data && p.ColID == 1)
                                 {
-                                    p.ColID.Should().Be(1);
-                                    p.PageType.Should().Be(PageType.Data);
+                                    var hit = Interlocked.Increment(ref writeHits);
 
-                                    page.Write((uint)123123123, 8192 - 4);
+                                    if (hit == 10)
+                                    {
+                                        p.PageType.Should().Be(PageType.Data);
+                                        p.ColID.Should().Be(1);
+
+                                        page.Write((uint)123123123, 8192 - 4);
+
+                                        Interlocked.Exchange(ref faultInjected, 1);
+                                    }
                                 }
                             };
 
@@ -86,6 +98,8 @@ namespace LiteDB.Tests.Engine
                     }
                     catch (Exception ex)
                     {
+                        faultInjected.Should().Be(1, "the simulated disk write fault should have triggered");
+
                         Assert.True(ex is LiteException lex && lex.ErrorCode == 999);
                     }
 

--- a/LiteDB.Tests/Engine/Recursion_Tests.cs
+++ b/LiteDB.Tests/Engine/Recursion_Tests.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace LiteDB.Tests.Engine;
 
+[Collection("SharedDemoDatabase")]
 public class Recursion_Tests
 {
     [Fact]

--- a/LiteDB.Tests/Engine/Transactions_Tests.cs
+++ b/LiteDB.Tests/Engine/Transactions_Tests.cs
@@ -370,7 +370,10 @@ namespace LiteDB.Tests.Engine
                     blockingStream.ShouldBlock = true;
                     db.Checkpoint();
                     db.Dispose();
-                });
+                })
+                {
+                    IsBackground = true
+                };
                 lockerThread.Start();
                 blockingStream.Blocked.WaitOne(200).Should().BeTrue();
                 Assert.Throws<LiteException>(() => db.GetCollection<Person>().Insert(new Person())).Message.Should().Contain("timeout");

--- a/LiteDB.Tests/Issues/Issue2534_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2534_Tests.cs
@@ -2,6 +2,7 @@
 
 namespace LiteDB.Tests.Issues;
 
+[Collection("SharedDemoDatabase")]
 public class Issue2534_Tests
 {
     [Fact]

--- a/LiteDB.Tests/Shared/SharedDemoDatabaseCollection.cs
+++ b/LiteDB.Tests/Shared/SharedDemoDatabaseCollection.cs
@@ -1,0 +1,43 @@
+namespace LiteDB.Tests;
+
+using System;
+using System.IO;
+using Xunit;
+
+[CollectionDefinition("SharedDemoDatabase", DisableParallelization = true)]
+public sealed class SharedDemoDatabaseCollection : ICollectionFixture<SharedDemoDatabaseFixture>
+{
+}
+
+public sealed class SharedDemoDatabaseFixture : IDisposable
+{
+    private readonly string _filename;
+
+    public SharedDemoDatabaseFixture()
+    {
+        _filename = Path.GetFullPath("Demo.db");
+        TryDeleteFile();
+    }
+
+    public void Dispose()
+    {
+        TryDeleteFile();
+    }
+
+    private void TryDeleteFile()
+    {
+        try
+        {
+            if (File.Exists(_filename))
+            {
+                File.Delete(_filename);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/tests.ci.runsettings
+++ b/tests.ci.runsettings
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- Increase timeouts for CI environment -->
+    <TestSessionTimeout>600000</TestSessionTimeout> <!-- 10 minutes -->
+    <TestCaseTimeout>60000</TestCaseTimeout>        <!-- 60 seconds per test -->
+    
+    <!-- Optimize for CI -->
+    <MaxCpuCount>1</MaxCpuCount>                    <!-- Single-threaded to avoid resource contention -->
+    <DisableParallelization>true</DisableParallelization>
+  </RunConfiguration>
+  
+  <!-- CI-specific test filters -->
+  <MSTest>
+    <DeploymentEnabled>false</DeploymentEnabled>
+  </MSTest>
+</RunSettings>

--- a/tests.ci.runsettings
+++ b/tests.ci.runsettings
@@ -2,7 +2,8 @@
 <RunSettings>
   <RunConfiguration>
     <!-- Increase timeouts for CI environment -->
-    <TestSessionTimeout>600000</TestSessionTimeout> <!-- 10 minutes -->
+    <!-- <TestSessionTimeout>600000</TestSessionTimeout> 10 minutes -->
+    <TestSessionTimeout>180000</TestSessionTimeout> <!-- 3 minutes -->
     <TestCaseTimeout>60000</TestCaseTimeout>        <!-- 60 seconds per test -->
     
     <!-- Optimize for CI -->


### PR DESCRIPTION
This pull request updates the CI and prerelease workflows to improve reliability and consistency of test execution, artifact management, and versioning. The most notable changes include switching to a CI-optimized test settings file, reducing test timeouts, uploading test results as artifacts, and refining the prerelease versioning scheme.

**CI and Test Execution Improvements:**

* Introduced a new `tests.ci.runsettings` file for CI runs, which increases timeouts, disables parallelization, and optimizes test configuration for resource-constrained environments. (`tests.ci.runsettings`)
* Updated both `.github/workflows/ci.yml` and `.github/workflows/publish-prerelease.yml` to use the new CI-specific test settings file and reduced the test timeout from 5 to 3 minutes for quicker feedback. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL28-R36) [[2]](diffhunk://#diff-8f8c899da6a5ae0e74d849c8bcdf04b40dd721e2a312df07156a5ba2a9ee5abbL25-R68)

**Artifact Management:**

* Added a step to upload test results (`TestResults.trx` files) as build artifacts in both workflows, ensuring test output is always available for review. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL28-R36) [[2]](diffhunk://#diff-8f8c899da6a5ae0e74d849c8bcdf04b40dd721e2a312df07156a5ba2a9ee5abbL25-R68)

**Versioning and Build Process Updates:**

* Changed prerelease versioning to use a SemVer-compliant format without padded zeros, improving compatibility and clarity.
* Updated build and pack steps to use the correct project file, pass version parameters, and ensure these steps only run on successful tests.

**Release and Deployment Safeguards:**

* Added explicit `if: success()` conditions to build, pack, release, secret retrieval, and NuGet publish steps in the prerelease workflow, preventing downstream actions if earlier steps fail. [[1]](diffhunk://#diff-8f8c899da6a5ae0e74d849c8bcdf04b40dd721e2a312df07156a5ba2a9ee5abbL25-R68) [[2]](diffhunk://#diff-8f8c899da6a5ae0e74d849c8bcdf04b40dd721e2a312df07156a5ba2a9ee5abbR77-L71)