### PR TITLE
Serialize shared Demo database tests and stabilize rebuild crash regression test

### DIFF
--- a/LiteDB.Tests/Engine/Rebuild_Crash_Tests.cs
+++ b/LiteDB.Tests/Engine/Rebuild_Crash_Tests.cs
@@ -3,6 +3,7 @@ using LiteDB.Engine;
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;
@@ -51,20 +52,31 @@ namespace LiteDB.Tests.Engine
                         ["lorem"] = new string((char)('a' + (i % 26)), 800)
                     }).ToArray();
 
+                    var faultInjected = 0;
+
                     try
                     {
                         using (var db = new LiteEngine(settings))
                         {
+                            var writeHits = 0;
+
                             db.SimulateDiskWriteFail = (page) =>
                             {
                                 var p = new BasePage(page);
 
-                                if (p.PageID == 28)
+                                if (p.PageType == PageType.Data && p.ColID == 1)
                                 {
-                                    p.ColID.Should().Be(1);
-                                    p.PageType.Should().Be(PageType.Data);
+                                    var hit = Interlocked.Increment(ref writeHits);
 
-                                    page.Write((uint)123123123, 8192 - 4);
+                                    if (hit == 10)
+                                    {
+                                        p.PageType.Should().Be(PageType.Data);
+                                        p.ColID.Should().Be(1);
+
+                                        page.Write((uint)123123123, 8192 - 4);
+
+                                        Interlocked.Exchange(ref faultInjected, 1);
+                                    }
                                 }
                             };
 
@@ -86,6 +98,8 @@ namespace LiteDB.Tests.Engine
                     }
                     catch (Exception ex)
                     {
+                        faultInjected.Should().Be(1, "the simulated disk write fault should have triggered");
+
                         Assert.True(ex is LiteException lex && lex.ErrorCode == 999);
                     }
 

--- a/LiteDB.Tests/Engine/Recursion_Tests.cs
+++ b/LiteDB.Tests/Engine/Recursion_Tests.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace LiteDB.Tests.Engine;
 
+[Collection("SharedDemoDatabase")]
 public class Recursion_Tests
 {
     [Fact]

--- a/LiteDB.Tests/Issues/Issue2534_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2534_Tests.cs
@@ -2,6 +2,7 @@
 
 namespace LiteDB.Tests.Issues;
 
+[Collection("SharedDemoDatabase")]
 public class Issue2534_Tests
 {
     [Fact]

--- a/LiteDB.Tests/Shared/SharedDemoDatabaseCollection.cs
+++ b/LiteDB.Tests/Shared/SharedDemoDatabaseCollection.cs
@@ -1,0 +1,43 @@
+namespace LiteDB.Tests;
+
+using System;
+using System.IO;
+using Xunit;
+
+[CollectionDefinition("SharedDemoDatabase", DisableParallelization = true)]
+public sealed class SharedDemoDatabaseCollection : ICollectionFixture<SharedDemoDatabaseFixture>
+{
+}
+
+public sealed class SharedDemoDatabaseFixture : IDisposable
+{
+    private readonly string _filename;
+
+    public SharedDemoDatabaseFixture()
+    {
+        _filename = Path.GetFullPath("Demo.db");
+        TryDeleteFile();
+    }
+
+    public void Dispose()
+    {
+        TryDeleteFile();
+    }
+
+    private void TryDeleteFile()
+    {
+        try
+        {
+            if (File.Exists(_filename))
+            {
+                File.Delete(_filename);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- mark the Issue2534 and recursion test classes as part of a shared collection so they no longer execute in parallel against Demo.db
- add a collection fixture that disables parallelization for the shared Demo database and cleans up the on-disk file between runs
- trigger the simulated disk write failure in `Rebuild_Crash_IO_Write_Error` deterministically on the 10th data page write for collection 1 and assert the injection happened before validating the rebuild results

## Testing
- dotnet test LiteDB.sln --settings tests.runsettings --no-restore (x10)


------
https://chatgpt.com/codex/tasks/task_e_68d316fcc2c4832aa04baa3cd06fdb53