### PR TITLE
Add grouping materialization support

### DIFF
--- a/LiteDB/Client/Database/LiteGrouping.cs
+++ b/LiteDB/Client/Database/LiteGrouping.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LiteDB
+{
+    internal static class LiteGroupingFieldNames
+    {
+        public const string Key = "key";
+        public const string Items = "items";
+    }
+
+    /// <summary>
+    /// Concrete <see cref="IGrouping{TKey, TElement}"/> implementation used to materialize
+    /// grouping results coming from query execution.
+    /// </summary>
+    internal sealed class LiteGrouping<TKey, TElement> : IGrouping<TKey, TElement>
+    {
+        internal const string KeyField = LiteGroupingFieldNames.Key;
+        internal const string ItemsField = LiteGroupingFieldNames.Items;
+
+        private readonly IReadOnlyList<TElement> _items;
+
+        public LiteGrouping(TKey key, IReadOnlyList<TElement> items)
+        {
+            Key = key;
+            _items = items;
+        }
+
+        public TKey Key { get; }
+
+        public IEnumerator<TElement> GetEnumerator() => _items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    }
+}

--- a/LiteDB/Client/Database/LiteQueryable.cs
+++ b/LiteDB/Client/Database/LiteQueryable.cs
@@ -182,6 +182,8 @@ namespace LiteDB
 
             this.GroupBy(expression);
 
+            _mapper.RegisterGroupingType<K, T>();
+
             return new LiteQueryable<IGrouping<K, T>>(_engine, _mapper, _collection, _query);
         }
 

--- a/LiteDB/Client/Mapper/BsonMapper.Grouping.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Grouping.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LiteDB
+{
+    public partial class BsonMapper
+    {
+        internal void RegisterGroupingType<TKey, TElement>()
+        {
+            var interfaceType = typeof(IGrouping<TKey, TElement>);
+            var concreteType = typeof(LiteGrouping<TKey, TElement>);
+
+            if (_customDeserializer.ContainsKey(interfaceType))
+            {
+                return;
+            }
+
+            BsonValue SerializeGrouping(object value)
+            {
+                var grouping = (IGrouping<TKey, TElement>)value;
+                var items = new BsonArray();
+
+                foreach (var item in grouping)
+                {
+                    items.Add(this.Serialize(typeof(TElement), item));
+                }
+
+                return new BsonDocument
+                {
+                    [LiteGroupingFieldNames.Key] = this.Serialize(typeof(TKey), grouping.Key),
+                    [LiteGroupingFieldNames.Items] = items
+                };
+            }
+
+            object DeserializeGrouping(BsonValue value)
+            {
+                var document = value.AsDocument;
+
+                var key = (TKey)this.Deserialize(typeof(TKey), document[LiteGroupingFieldNames.Key]);
+
+                var itemsArray = document[LiteGroupingFieldNames.Items].AsArray;
+                var items = new List<TElement>(itemsArray.Count);
+
+                foreach (var item in itemsArray)
+                {
+                    items.Add((TElement)this.Deserialize(typeof(TElement), item));
+                }
+
+                return new LiteGrouping<TKey, TElement>(key, items);
+            }
+
+            this.RegisterType(interfaceType, SerializeGrouping, DeserializeGrouping);
+
+            if (!_customDeserializer.ContainsKey(concreteType))
+            {
+                this.RegisterType(concreteType, SerializeGrouping, DeserializeGrouping);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a concrete LiteGrouping implementation and register it with the mapper for grouping queries
- shape GroupBy pipeline output to expose grouping keys and elements when no projection is supplied
- add a regression test covering GroupBy(...).ToList() materialization

## Testing
- dotnet test LiteDB.Tests -f net8.0

------
https://chatgpt.com/codex/tasks/task_e_68d829e232d0832a92f0860ec104b79c