### PR TITLE
Add spatial indexing and geometry primitives

### DIFF
--- a/LiteDB.Tests/Spatial/SpatialTests.cs
+++ b/LiteDB.Tests/Spatial/SpatialTests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LiteDB;
+using LiteDB.Spatial;
+using Xunit;
+using SpatialApi = LiteDB.Spatial.Spatial;
+
+namespace LiteDB.Tests.Geo
+{
+    public class SpatialTests
+    {
+        [Fact]
+        public void Near_Returns_Ordered_Within_Radius()
+        {
+            using var db = new LiteDatabase(":memory:");
+            var col = db.GetCollection<Place>("p");
+
+            SpatialApi.EnsurePointIndex(col, x => x.Location);
+
+            var center = new GeoPoint(48.2082, 16.3738);
+
+            var a = new Place { Name = "A", Location = new GeoPoint(48.215, 16.355) };
+            var b = new Place { Name = "B", Location = new GeoPoint(48.185, 16.380) };
+            var c = new Place { Name = "C", Location = new GeoPoint(48.300, 16.450) };
+
+            col.Insert(new[] { a, b, c });
+
+            var result = SpatialApi.Near(col, x => x.Location, center, 5000).ToList();
+
+            Assert.Equal(new[] { "A", "B" }, result.Select(x => x.Name).ToArray());
+        }
+
+        [Fact]
+        public void BoundingBox_Crosses_Antimeridian()
+        {
+            using var db = new LiteDatabase(":memory:");
+            var col = db.GetCollection<Place>("p");
+
+            SpatialApi.EnsurePointIndex(col, x => x.Location);
+
+            col.Insert(new Place { Name = "W", Location = new GeoPoint(0, -179.5) });
+            col.Insert(new Place { Name = "E", Location = new GeoPoint(0, 179.5) });
+
+            var result = SpatialApi.WithinBoundingBox(col, x => x.Location, -10, 170, 10, -170).ToList();
+
+            Assert.Contains(result, p => p.Name == "W");
+            Assert.Contains(result, p => p.Name == "E");
+        }
+
+        [Theory]
+        [InlineData(89.9, 0, 89.9, 90)]
+        [InlineData(-89.9, 0, -89.9, -90)]
+        public void GreatCircle_Is_Stable_Near_Poles(double lat1, double lon1, double lat2, double lon2)
+        {
+            var d = GeoMath.DistanceMeters(new GeoPoint(lat1, lon1), new GeoPoint(lat2, lon2));
+            Assert.InRange(d, 0, 20000);
+        }
+
+        [Fact]
+        public void GeoJson_RoundTrip_Point()
+        {
+            var p = new GeoPoint(48.2082, 16.3738);
+            var json = GeoJson.Serialize(p);
+            var back = GeoJson.Deserialize<GeoPoint>(json);
+
+            Assert.Equal(p.Lat, back.Lat, 10);
+            Assert.Equal(p.Lon, back.Lon, 10);
+        }
+
+        [Fact]
+        public void Within_Polygon_Excludes_Hole()
+        {
+            using var db = new LiteDatabase(":memory:");
+            var col = db.GetCollection<Place>("p");
+
+            SpatialApi.EnsureShapeIndex(col, x => x.Location);
+
+            var outer = new[]
+            {
+                new GeoPoint(48.25, 16.30),
+                new GeoPoint(48.25, 16.45),
+                new GeoPoint(48.15, 16.45),
+                new GeoPoint(48.15, 16.30),
+                new GeoPoint(48.25, 16.30),
+            };
+
+            var hole = new[]
+            {
+                new GeoPoint(48.22, 16.36),
+                new GeoPoint(48.22, 16.39),
+                new GeoPoint(48.18, 16.39),
+                new GeoPoint(48.18, 16.36),
+                new GeoPoint(48.22, 16.36),
+            };
+
+            var poly = new GeoPolygon(outer, new[] { hole });
+
+            var insideOutsideHole = new Place { Name = "Edge", Location = new GeoPoint(48.20, 16.37) };
+            var outside = new Place { Name = "Outside", Location = new GeoPoint(48.30, 16.50) };
+
+            col.Insert(new[] { insideOutsideHole, outside });
+
+            var result = SpatialApi.Within(col, x => x.Location, poly).ToList();
+
+            Assert.DoesNotContain(result, p => p.Name == "Edge");
+            Assert.DoesNotContain(result, p => p.Name == "Outside");
+        }
+
+        [Fact]
+        public void GeoHash_Recomputes_On_Update()
+        {
+            using var db = new LiteDatabase(":memory:");
+            var col = db.GetCollection<Place>("p");
+
+            SpatialApi.EnsurePointIndex(col, x => x.Location);
+
+            var pl = new Place { Name = "P", Location = new GeoPoint(48.2, 16.37) };
+            col.Insert(pl);
+
+            var h1 = col.FindOne(x => x.Name == "P")._gh;
+
+            pl.Location = new GeoPoint(48.21, 16.38);
+            col.Update(pl);
+
+            var h2 = col.FindById(pl.Id)._gh;
+
+            Assert.NotEqual(h1, h2);
+        }
+
+        [Theory]
+        [InlineData(91, 0)]
+        [InlineData(-91, 0)]
+        [InlineData(0, 181)]
+        [InlineData(0, -181)]
+        public void Invalid_Coordinates_Throw(double lat, double lon)
+        {
+            using var db = new LiteDatabase(":memory:");
+            var col = db.GetCollection<Place>("p");
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                col.Insert(new Place { Name = "X", Location = new GeoPoint(lat, lon) }));
+        }
+
+        [Fact]
+        public void Intersects_Line_Touches_Polygon_Edge()
+        {
+            using var db = new LiteDatabase(":memory:");
+            var roads = db.GetCollection<Road>("roads");
+
+            SpatialApi.EnsureShapeIndex(roads, r => r.Path);
+
+            var line = new GeoLineString(new[]
+            {
+                new GeoPoint(0.5, -1),
+                new GeoPoint(0.5, 2)
+            });
+
+            var polygon = new GeoPolygon(new[]
+            {
+                new GeoPoint(0, 0),
+                new GeoPoint(0, 1),
+                new GeoPoint(1, 1),
+                new GeoPoint(1, 0),
+                new GeoPoint(0, 0)
+            });
+
+            roads.Insert(new Road { Name = "Main", Path = line });
+
+            var hits = SpatialApi.Intersects(roads, r => r.Path, polygon).ToList();
+
+            Assert.NotEmpty(hits);
+        }
+
+        private sealed class Place
+        {
+            public ObjectId Id { get; set; }
+
+            public string Name { get; set; }
+
+            public GeoPoint Location { get; set; }
+
+            public long _gh { get; set; }
+
+            public double[] _mbb { get; set; }
+        }
+
+        private sealed class Road
+        {
+            public ObjectId Id { get; set; }
+
+            public string Name { get; set; }
+
+            public GeoLineString Path { get; set; }
+
+            public double[] _mbb { get; set; }
+        }
+    }
+}

--- a/LiteDB/Client/Database/Collections/Insert.cs
+++ b/LiteDB/Client/Database/Collections/Insert.cs
@@ -16,6 +16,7 @@ namespace LiteDB
 
             var doc = _mapper.ToDocument(entity);
             var removed = this.RemoveDocId(doc);
+            this.ApplyWriteTransforms(entity, doc);
 
             _engine.Insert(_collection, new[] { doc }, _autoId);
 
@@ -39,6 +40,7 @@ namespace LiteDB
             if (id == null || id.IsNull) throw new ArgumentNullException(nameof(id));
 
             var doc = _mapper.ToDocument(entity);
+            this.ApplyWriteTransforms(entity, doc);
 
             doc["_id"] = id;
 
@@ -75,6 +77,7 @@ namespace LiteDB
             {
                 var doc = _mapper.ToDocument(document);
                 var removed = this.RemoveDocId(doc);
+                this.ApplyWriteTransforms(document, doc);
 
                 yield return doc;
 

--- a/LiteDB/Client/Database/Collections/Update.cs
+++ b/LiteDB/Client/Database/Collections/Update.cs
@@ -17,6 +17,7 @@ namespace LiteDB
 
             // get BsonDocument from object
             var doc = _mapper.ToDocument(entity);
+            this.ApplyWriteTransforms(entity, doc);
 
             return _engine.Update(_collection, new BsonDocument[] { doc }) > 0;
         }
@@ -31,6 +32,7 @@ namespace LiteDB
 
             // get BsonDocument from object
             var doc = _mapper.ToDocument(entity);
+            this.ApplyWriteTransforms(entity, doc);
 
             // set document _id using id parameter
             doc["_id"] = id;
@@ -45,7 +47,12 @@ namespace LiteDB
         {
             if (entities == null) throw new ArgumentNullException(nameof(entities));
 
-            return _engine.Update(_collection, entities.Select(x => _mapper.ToDocument(x)));
+            return _engine.Update(_collection, entities.Select(x =>
+            {
+                var doc = _mapper.ToDocument(x);
+                this.ApplyWriteTransforms(x, doc);
+                return doc;
+            }));
         }
 
         /// <summary>

--- a/LiteDB/Client/Database/Collections/Upsert.cs
+++ b/LiteDB/Client/Database/Collections/Upsert.cs
@@ -37,6 +37,7 @@ namespace LiteDB
 
             // get BsonDocument from object
             var doc = _mapper.ToDocument(entity);
+            this.ApplyWriteTransforms(entity, doc);
 
             // set document _id using id parameter
             doc["_id"] = id;

--- a/LiteDB/Client/Database/Collections/WriteTransforms.cs
+++ b/LiteDB/Client/Database/Collections/WriteTransforms.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using static LiteDB.Constants;
+
+namespace LiteDB
+{
+    public sealed partial class LiteCollection<T>
+    {
+        private readonly List<Action<T, BsonDocument>> _writeTransforms = new List<Action<T, BsonDocument>>();
+
+        internal void RegisterWriteTransform(Action<T, BsonDocument> transform)
+        {
+            if (transform == null)
+            {
+                throw new ArgumentNullException(nameof(transform));
+            }
+
+            lock (_writeTransforms)
+            {
+                _writeTransforms.Add(transform);
+            }
+        }
+
+        private void ApplyWriteTransforms(T entity, BsonDocument document)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            Action<T, BsonDocument>[] transforms;
+
+            lock (_writeTransforms)
+            {
+                if (_writeTransforms.Count == 0)
+                {
+                    return;
+                }
+
+                transforms = _writeTransforms.ToArray();
+            }
+
+            foreach (var transform in transforms)
+            {
+                transform(entity, document);
+            }
+        }
+    }
+}

--- a/LiteDB/Spatial/GeoBoundingBox.cs
+++ b/LiteDB/Spatial/GeoBoundingBox.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LiteDB.Spatial
+{
+    internal readonly struct GeoBoundingBox
+    {
+        public double MinLat { get; }
+
+        public double MinLon { get; }
+
+        public double MaxLat { get; }
+
+        public double MaxLon { get; }
+
+        public GeoBoundingBox(double minLat, double minLon, double maxLat, double maxLon)
+        {
+            MinLat = minLat;
+            MinLon = minLon;
+            MaxLat = maxLat;
+            MaxLon = maxLon;
+        }
+
+        public static GeoBoundingBox FromPoints(IEnumerable<GeoPoint> points)
+        {
+            if (points == null)
+            {
+                throw new ArgumentNullException(nameof(points));
+            }
+
+            var enumerable = points.ToList();
+
+            if (enumerable.Count == 0)
+            {
+                throw new ArgumentException("Bounding box requires at least one point", nameof(points));
+            }
+
+            var minLat = enumerable.Min(p => p.Lat);
+            var maxLat = enumerable.Max(p => p.Lat);
+
+            var lons = enumerable.Select(p => p.Lon).ToList();
+            var minLon = lons.Min();
+            var maxLon = lons.Max();
+
+            return new GeoBoundingBox(minLat, minLon, maxLat, maxLon);
+        }
+
+        public double[] ToArray()
+        {
+            return new[] { MinLat, MinLon, MaxLat, MaxLon };
+        }
+
+        public bool Contains(GeoPoint point)
+        {
+            return point.Lat >= MinLat && point.Lat <= MaxLat && IsLongitudeWithin(point.Lon);
+        }
+
+        public bool Intersects(GeoBoundingBox other)
+        {
+            return !(other.MinLat > MaxLat || other.MaxLat < MinLat) && LongitudesOverlap(other);
+        }
+
+        private bool LongitudesOverlap(GeoBoundingBox other)
+        {
+            var lonRange = new LongitudeRange(MinLon, MaxLon);
+            var otherRange = new LongitudeRange(other.MinLon, other.MaxLon);
+            return lonRange.Intersects(otherRange);
+        }
+
+        private bool IsLongitudeWithin(double lon)
+        {
+            var lonRange = new LongitudeRange(MinLon, MaxLon);
+            return lonRange.Contains(lon);
+        }
+    }
+}

--- a/LiteDB/Spatial/GeoJson.cs
+++ b/LiteDB/Spatial/GeoJson.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LiteDB;
+
+namespace LiteDB.Spatial
+{
+    public static class GeoJson
+    {
+        public static string Serialize(GeoShape shape)
+        {
+            if (shape == null)
+            {
+                throw new ArgumentNullException(nameof(shape));
+            }
+
+            var bson = ToBson(shape);
+            return JsonSerializer.Serialize(bson, false);
+        }
+
+        public static T Deserialize<T>(string json)
+            where T : GeoShape
+        {
+            var shape = Deserialize(json);
+
+            if (shape is T typed)
+            {
+                return typed;
+            }
+
+            throw new ArgumentException($"GeoJSON represents {shape.GetType().Name} which cannot be cast to {typeof(T).Name}");
+        }
+
+        public static GeoShape Deserialize(string json)
+        {
+            if (json == null)
+            {
+                throw new ArgumentNullException(nameof(json));
+            }
+
+            var bson = JsonSerializer.Deserialize(json);
+
+            if (!bson.IsDocument)
+            {
+                throw new ArgumentException("GeoJSON payload must be a JSON object", nameof(json));
+            }
+
+            return FromBson(bson.AsDocument);
+        }
+
+        internal static BsonValue ToBson(GeoShape shape)
+        {
+            return shape switch
+            {
+                GeoPoint point => new BsonDocument
+                {
+                    ["type"] = "Point",
+                    ["coordinates"] = new BsonArray { point.Lon, point.Lat }
+                },
+                GeoLineString line => new BsonDocument
+                {
+                    ["type"] = "LineString",
+                    ["coordinates"] = new BsonArray(line.Points.Select(p => new BsonArray { p.Lon, p.Lat }))
+                },
+                GeoPolygon polygon => new BsonDocument
+                {
+                    ["type"] = "Polygon",
+                    ["coordinates"] = BuildPolygonCoordinates(polygon)
+                },
+                _ => throw new ArgumentException($"Unsupported geometry type {shape.GetType().Name}")
+            };
+        }
+
+        internal static GeoShape FromBson(BsonDocument document)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            if (!document.TryGetValue("type", out var typeValue) || !typeValue.IsString)
+            {
+                throw new ArgumentException("GeoJSON requires a string 'type' property");
+            }
+
+            var type = typeValue.AsString;
+
+            switch (type)
+            {
+                case "Point":
+                    return ParsePoint(document);
+                case "LineString":
+                    return ParseLineString(document);
+                case "Polygon":
+                    return ParsePolygon(document);
+                default:
+                    throw new ArgumentException($"Unsupported GeoJSON geometry type '{type}'");
+            }
+        }
+
+        private static BsonArray BuildPolygonCoordinates(GeoPolygon polygon)
+        {
+            var rings = new List<BsonArray>
+            {
+                new BsonArray(polygon.Outer.Select(p => new BsonArray { p.Lon, p.Lat }))
+            };
+
+            foreach (var hole in polygon.Holes)
+            {
+                rings.Add(new BsonArray(hole.Select(p => new BsonArray { p.Lon, p.Lat })));
+            }
+
+            return new BsonArray(rings);
+        }
+
+        private static GeoPoint ParsePoint(BsonDocument document)
+        {
+            var coordinates = ReadCoordinateArray(document);
+            return new GeoPoint(coordinates.lat, coordinates.lon);
+        }
+
+        private static GeoLineString ParseLineString(BsonDocument document)
+        {
+            var array = EnsureArray(document, "coordinates");
+
+            var points = array.Select(value => ToPoint(value)).ToList();
+
+            return new GeoLineString(points);
+        }
+
+        private static GeoPolygon ParsePolygon(BsonDocument document)
+        {
+            var array = EnsureArray(document, "coordinates");
+
+            if (array.Count == 0)
+            {
+                throw new ArgumentException("Polygon must have at least one ring");
+            }
+
+            var rings = array.Select(ToRing).ToList();
+
+            var outer = rings[0];
+            var holes = rings.Skip(1).Select(r => (IReadOnlyList<GeoPoint>)r).ToList();
+
+            return new GeoPolygon(outer, holes);
+        }
+
+        private static (double lon, double lat) ReadCoordinateArray(BsonDocument document)
+        {
+            var array = EnsureArray(document, "coordinates");
+
+            if (array.Count < 2)
+            {
+                throw new ArgumentException("Coordinate array must have at least two elements");
+            }
+
+            return (array[0].AsDouble, array[1].AsDouble);
+        }
+
+        private static List<GeoPoint> ToRing(BsonValue value)
+        {
+            if (!value.IsArray)
+            {
+                throw new ArgumentException("Ring must be an array of positions");
+            }
+
+            return value.AsArray.Select(ToPoint).ToList();
+        }
+
+        private static GeoPoint ToPoint(BsonValue value)
+        {
+            if (!value.IsArray)
+            {
+                throw new ArgumentException("Point must be an array");
+            }
+
+            var coords = value.AsArray;
+
+            if (coords.Count < 2)
+            {
+                throw new ArgumentException("Point array must contain longitude and latitude");
+            }
+
+            return new GeoPoint(coords[1].AsDouble, coords[0].AsDouble);
+        }
+
+        private static BsonArray EnsureArray(BsonDocument document, string key)
+        {
+            if (!document.TryGetValue(key, out var value) || !value.IsArray)
+            {
+                throw new ArgumentException($"GeoJSON requires '{key}' to be an array");
+            }
+
+            return value.AsArray;
+        }
+    }
+}

--- a/LiteDB/Spatial/GeoMath.cs
+++ b/LiteDB/Spatial/GeoMath.cs
@@ -1,0 +1,80 @@
+using System;
+
+namespace LiteDB.Spatial
+{
+    internal static class GeoMath
+    {
+        public const double EarthRadiusMeters = 6_371_000d;
+
+        public static double DegreesToRadians(double degrees)
+        {
+            return degrees * Math.PI / 180d;
+        }
+
+        public static double ClampLatitude(double latitude)
+        {
+            return Math.Max(-90d, Math.Min(90d, latitude));
+        }
+
+        public static double NormalizeLongitude(double longitude)
+        {
+            var lon = longitude % 360d;
+
+            if (lon < -180d)
+            {
+                lon += 360d;
+            }
+            else if (lon >= 180d)
+            {
+                lon -= 360d;
+            }
+
+            return lon;
+        }
+
+        public static double DistanceMeters(GeoPoint a, GeoPoint b)
+        {
+            if (a == null)
+            {
+                throw new ArgumentNullException(nameof(a));
+            }
+
+            if (b == null)
+            {
+                throw new ArgumentNullException(nameof(b));
+            }
+
+            var lat1 = DegreesToRadians(a.Lat);
+            var lat2 = DegreesToRadians(b.Lat);
+            var dLat = DegreesToRadians(b.Lat - a.Lat);
+            var dLon = DegreesToRadians(DeltaLongitude(a.Lon, b.Lon));
+
+            var sinLat = Math.Sin(dLat / 2d);
+            var sinLon = Math.Sin(dLon / 2d);
+
+            var aTerm = sinLat * sinLat + Math.Cos(lat1) * Math.Cos(lat2) * sinLon * sinLon;
+
+            aTerm = Math.Min(1d, Math.Max(0d, aTerm));
+
+            var c = 2d * Math.Asin(Math.Sqrt(aTerm));
+
+            return EarthRadiusMeters * c;
+        }
+
+        private static double DeltaLongitude(double lon1, double lon2)
+        {
+            var diff = NormalizeLongitude(lon2) - NormalizeLongitude(lon1);
+
+            if (diff > 180d)
+            {
+                diff -= 360d;
+            }
+            else if (diff < -180d)
+            {
+                diff += 360d;
+            }
+
+            return diff;
+        }
+    }
+}

--- a/LiteDB/Spatial/GeoShape.cs
+++ b/LiteDB/Spatial/GeoShape.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace LiteDB.Spatial
+{
+    public abstract record GeoShape
+    {
+        internal abstract GeoBoundingBox GetBoundingBox();
+    }
+
+    public sealed record GeoPoint : GeoShape
+    {
+        private const double Epsilon = 1e-9;
+
+        public double Lat { get; }
+
+        public double Lon { get; }
+
+        public GeoPoint(double lat, double lon)
+        {
+            GeoValidation.EnsureValidCoordinate(lat, lon);
+
+            Lat = GeoMath.ClampLatitude(lat);
+            Lon = GeoMath.NormalizeLongitude(lon);
+        }
+
+        internal override GeoBoundingBox GetBoundingBox()
+        {
+            return new GeoBoundingBox(Lat, Lon, Lat, Lon);
+        }
+
+        public GeoPoint Normalize()
+        {
+            return new GeoPoint(Lat, Lon);
+        }
+
+        public override string ToString()
+        {
+            return $"({Lat:F6}, {Lon:F6})";
+        }
+    }
+
+    public sealed record GeoLineString : GeoShape
+    {
+        public IReadOnlyList<GeoPoint> Points { get; }
+
+        public GeoLineString(IReadOnlyList<GeoPoint> points)
+        {
+            if (points == null)
+            {
+                throw new ArgumentNullException(nameof(points));
+            }
+
+            if (points.Count < 2)
+            {
+                throw new ArgumentException("LineString requires at least two points", nameof(points));
+            }
+
+            Points = new ReadOnlyCollection<GeoPoint>(points.Select(p => p ?? throw new ArgumentNullException(nameof(points), "LineString points cannot contain null"))
+                .Select(p => p.Normalize()).ToList());
+        }
+
+        internal override GeoBoundingBox GetBoundingBox()
+        {
+            return GeoBoundingBox.FromPoints(Points);
+        }
+    }
+
+    public sealed record GeoPolygon : GeoShape
+    {
+        public IReadOnlyList<GeoPoint> Outer { get; }
+
+        public IReadOnlyList<IReadOnlyList<GeoPoint>> Holes { get; }
+
+        public GeoPolygon(IReadOnlyList<GeoPoint> outer, IReadOnlyList<IReadOnlyList<GeoPoint>> holes = null)
+        {
+            if (outer == null)
+            {
+                throw new ArgumentNullException(nameof(outer));
+            }
+
+            if (outer.Count < 4)
+            {
+                throw new ArgumentException("Polygon outer ring must contain at least four points including closure", nameof(outer));
+            }
+
+            var normalizedOuter = NormalizeRing(outer, nameof(outer));
+
+            Outer = new ReadOnlyCollection<GeoPoint>(normalizedOuter);
+
+            if (holes == null)
+            {
+                Holes = Array.Empty<IReadOnlyList<GeoPoint>>();
+            }
+            else
+            {
+                var normalizedHoles = holes.Select((hole, index) =>
+                {
+                    var points = NormalizeRing(hole, $"holes[{index}]");
+                    return (IReadOnlyList<GeoPoint>)new ReadOnlyCollection<GeoPoint>(points);
+                }).ToList();
+
+                Holes = new ReadOnlyCollection<IReadOnlyList<GeoPoint>>(normalizedHoles);
+            }
+
+            foreach (var hole in Holes)
+            {
+                if (!Geometry.IsRingInside(Outer, hole))
+                {
+                    throw new ArgumentException("Polygon hole must lie within the outer ring", nameof(holes));
+                }
+
+                foreach (var other in Holes)
+                {
+                    if (!ReferenceEquals(hole, other) && Geometry.RingsOverlap(hole, other))
+                    {
+                        throw new ArgumentException("Polygon holes must not overlap", nameof(holes));
+                    }
+                }
+            }
+        }
+
+        internal override GeoBoundingBox GetBoundingBox()
+        {
+            return GeoBoundingBox.FromPoints(Outer);
+        }
+
+        private static List<GeoPoint> NormalizeRing(IReadOnlyList<GeoPoint> ring, string argumentName)
+        {
+            if (ring == null)
+            {
+                throw new ArgumentNullException(argumentName);
+            }
+
+            if (ring.Count < 4)
+            {
+                throw new ArgumentException("Polygon rings must contain at least four points including closure", argumentName);
+            }
+
+            var normalized = ring.Select(p => p ?? throw new ArgumentNullException(argumentName, "Polygon ring point cannot be null"))
+                .Select(p => p.Normalize()).ToList();
+
+            if (!Geometry.IsRingClosed(normalized))
+            {
+                throw new ArgumentException("Polygon rings must be closed (first point equals last point)", argumentName);
+            }
+
+            if (Geometry.HasSelfIntersection(normalized))
+            {
+                throw new ArgumentException("Polygon rings must not self-intersect", argumentName);
+            }
+
+            return normalized;
+        }
+    }
+}

--- a/LiteDB/Spatial/GeoValidation.cs
+++ b/LiteDB/Spatial/GeoValidation.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace LiteDB.Spatial
+{
+    internal static class GeoValidation
+    {
+        private const double LatitudeMin = -90d;
+
+        private const double LatitudeMax = 90d;
+
+        private const double LongitudeMin = -180d;
+
+        private const double LongitudeMax = 180d;
+
+        public static void EnsureValidCoordinate(double lat, double lon)
+        {
+            if (lat < LatitudeMin || lat > LatitudeMax)
+            {
+                throw new ArgumentOutOfRangeException(nameof(lat), $"Latitude must be between {LatitudeMin} and {LatitudeMax}");
+            }
+
+            if (lon < LongitudeMin || lon > LongitudeMax)
+            {
+                throw new ArgumentOutOfRangeException(nameof(lon), $"Longitude must be between {LongitudeMin} and {LongitudeMax}");
+            }
+        }
+    }
+}

--- a/LiteDB/Spatial/Geometry.cs
+++ b/LiteDB/Spatial/Geometry.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LiteDB.Spatial
+{
+    internal static class Geometry
+    {
+        private const double Epsilon = 1e-9;
+
+        public static bool ContainsPoint(GeoPolygon polygon, GeoPoint point)
+        {
+            if (polygon == null)
+            {
+                throw new ArgumentNullException(nameof(polygon));
+            }
+
+            if (point == null)
+            {
+                throw new ArgumentNullException(nameof(point));
+            }
+
+            if (!IsPointInRing(polygon.Outer, point))
+            {
+                return false;
+            }
+
+            foreach (var hole in polygon.Holes)
+            {
+                if (IsPointInRing(hole, point))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public static bool Intersects(GeoLineString line, GeoPolygon polygon)
+        {
+            if (line == null)
+            {
+                throw new ArgumentNullException(nameof(line));
+            }
+
+            if (polygon == null)
+            {
+                throw new ArgumentNullException(nameof(polygon));
+            }
+
+            for (var i = 0; i < line.Points.Count - 1; i++)
+            {
+                var segmentStart = line.Points[i];
+                var segmentEnd = line.Points[i + 1];
+
+                if (ContainsPoint(polygon, segmentStart) || ContainsPoint(polygon, segmentEnd))
+                {
+                    return true;
+                }
+
+                if (IntersectsRing(segmentStart, segmentEnd, polygon.Outer))
+                {
+                    return true;
+                }
+
+                foreach (var hole in polygon.Holes)
+                {
+                    if (IntersectsRing(segmentStart, segmentEnd, hole))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public static bool Intersects(GeoPolygon a, GeoPolygon b)
+        {
+            if (a == null)
+            {
+                throw new ArgumentNullException(nameof(a));
+            }
+
+            if (b == null)
+            {
+                throw new ArgumentNullException(nameof(b));
+            }
+
+            if (!a.GetBoundingBox().Intersects(b.GetBoundingBox()))
+            {
+                return false;
+            }
+
+            if (a.Outer.Any(p => ContainsPoint(b, p)) || b.Outer.Any(p => ContainsPoint(a, p)))
+            {
+                return true;
+            }
+
+            return RingsIntersect(a.Outer, b.Outer);
+        }
+
+        public static bool RingsOverlap(IReadOnlyList<GeoPoint> a, IReadOnlyList<GeoPoint> b)
+        {
+            return RingsIntersect(a, b) || a.Any(p => IsPointInRing(b, p)) || b.Any(p => IsPointInRing(a, p));
+        }
+
+        public static bool HasSelfIntersection(IReadOnlyList<GeoPoint> ring)
+        {
+            for (var i = 0; i < ring.Count - 1; i++)
+            {
+                for (var j = i + 1; j < ring.Count - 1; j++)
+                {
+                    if (Math.Abs(i - j) <= 1)
+                    {
+                        continue;
+                    }
+
+                    if (i == 0 && j == ring.Count - 2)
+                    {
+                        continue;
+                    }
+
+                    if (SharesEndpoint(ring[i], ring[i + 1], ring[j], ring[j + 1]))
+                    {
+                        continue;
+                    }
+
+                    if (SegmentsIntersect(ring[i], ring[i + 1], ring[j], ring[j + 1]))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public static bool IsRingClosed(IReadOnlyList<GeoPoint> ring)
+        {
+            if (ring.Count < 4)
+            {
+                return false;
+            }
+
+            var first = ring[0];
+            var last = ring[ring.Count - 1];
+
+            return Math.Abs(first.Lat - last.Lat) < Epsilon && Math.Abs(first.Lon - last.Lon) < Epsilon;
+        }
+
+        public static bool IsRingInside(IReadOnlyList<GeoPoint> outer, IReadOnlyList<GeoPoint> inner)
+        {
+            return inner.All(p => IsPointInRing(outer, p));
+        }
+
+        private static bool IsPointInRing(IReadOnlyList<GeoPoint> ring, GeoPoint point)
+        {
+            var inside = false;
+
+            for (int i = 0, j = ring.Count - 1; i < ring.Count; j = i++)
+            {
+                var pi = ring[i];
+                var pj = ring[j];
+
+                var intersects = ((pi.Lat > point.Lat) != (pj.Lat > point.Lat)) &&
+                    (point.Lon < (pj.Lon - pi.Lon) * (point.Lat - pi.Lat) / (pj.Lat - pi.Lat + double.Epsilon) + pi.Lon);
+
+                if (intersects)
+                {
+                    inside = !inside;
+                }
+            }
+
+            return inside;
+        }
+
+        private static bool IntersectsRing(GeoPoint a, GeoPoint b, IReadOnlyList<GeoPoint> ring)
+        {
+            for (var i = 0; i < ring.Count - 1; i++)
+            {
+                if (SegmentsIntersect(a, b, ring[i], ring[i + 1]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool RingsIntersect(IReadOnlyList<GeoPoint> a, IReadOnlyList<GeoPoint> b)
+        {
+            for (var i = 0; i < a.Count - 1; i++)
+            {
+                for (var j = 0; j < b.Count - 1; j++)
+                {
+                    if (SegmentsIntersect(a[i], a[i + 1], b[j], b[j + 1]))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        internal static bool SegmentsIntersect(GeoPoint a1, GeoPoint a2, GeoPoint b1, GeoPoint b2)
+        {
+            var d1 = Direction(a1, a2, b1);
+            var d2 = Direction(a1, a2, b2);
+            var d3 = Direction(b1, b2, a1);
+            var d4 = Direction(b1, b2, a2);
+
+            if (((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) &&
+                ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0)))
+            {
+                return true;
+            }
+
+            if (Math.Abs(d1) < Epsilon && OnSegment(a1, a2, b1)) return true;
+            if (Math.Abs(d2) < Epsilon && OnSegment(a1, a2, b2)) return true;
+            if (Math.Abs(d3) < Epsilon && OnSegment(b1, b2, a1)) return true;
+            if (Math.Abs(d4) < Epsilon && OnSegment(b1, b2, a2)) return true;
+
+            return false;
+        }
+
+        private static double Direction(GeoPoint a, GeoPoint b, GeoPoint c)
+        {
+            return (b.Lon - a.Lon) * (c.Lat - a.Lat) - (b.Lat - a.Lat) * (c.Lon - a.Lon);
+        }
+
+        private static bool SharesEndpoint(GeoPoint a1, GeoPoint a2, GeoPoint b1, GeoPoint b2)
+        {
+            return (IsSamePoint(a1, b1) || IsSamePoint(a1, b2) || IsSamePoint(a2, b1) || IsSamePoint(a2, b2));
+        }
+
+        private static bool IsSamePoint(GeoPoint a, GeoPoint b)
+        {
+            return Math.Abs(a.Lat - b.Lat) < Epsilon && Math.Abs(a.Lon - b.Lon) < Epsilon;
+        }
+
+        private static bool OnSegment(GeoPoint a, GeoPoint b, GeoPoint c)
+        {
+            return c.Lat >= Math.Min(a.Lat, b.Lat) - Epsilon &&
+                   c.Lat <= Math.Max(a.Lat, b.Lat) + Epsilon &&
+                   c.Lon >= Math.Min(a.Lon, b.Lon) - Epsilon &&
+                   c.Lon <= Math.Max(a.Lon, b.Lon) + Epsilon;
+        }
+    }
+}

--- a/LiteDB/Spatial/LongitudeRange.cs
+++ b/LiteDB/Spatial/LongitudeRange.cs
@@ -1,0 +1,69 @@
+using System;
+
+namespace LiteDB.Spatial
+{
+    internal readonly struct LongitudeRange
+    {
+        private readonly double _start;
+
+        private readonly double _end;
+
+        private readonly bool _wraps;
+
+        public LongitudeRange(double start, double end)
+        {
+            _start = GeoMath.NormalizeLongitude(start);
+            _end = GeoMath.NormalizeLongitude(end);
+            _wraps = _start > _end;
+        }
+
+        public bool Contains(double lon)
+        {
+            lon = GeoMath.NormalizeLongitude(lon);
+
+            if (!_wraps)
+            {
+                return lon >= _start && lon <= _end;
+            }
+
+            return lon >= _start || lon <= _end;
+        }
+
+        public bool Intersects(LongitudeRange other)
+        {
+            if (!_wraps && !other._wraps)
+            {
+                return !(_start > other._end || other._start > _end);
+            }
+
+            for (var i = 0; i < 2; i++)
+            {
+                var aStart = i == 0 ? _start : -180d;
+                var aEnd = i == 0 ? (_wraps ? 180d : _end) : _end;
+
+                if (aStart > aEnd)
+                {
+                    continue;
+                }
+
+                for (var j = 0; j < 2; j++)
+                {
+                    var bStart = j == 0 ? other._start : -180d;
+                    var bEnd = j == 0 ? (other._wraps ? 180d : other._end) : other._end;
+
+                    if (bStart > bEnd)
+                    {
+                        continue;
+                    }
+
+                    if (!(aStart > bEnd || bStart > aEnd))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/LiteDB/Spatial/Spatial.cs
+++ b/LiteDB/Spatial/Spatial.cs
@@ -1,0 +1,372 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using LiteDB;
+
+namespace LiteDB.Spatial
+{
+    public static class Spatial
+    {
+        private static readonly object _initLock = new object();
+
+        private static bool _initialized;
+
+        public static SpatialOptions Options { get; set; } = new SpatialOptions();
+
+        public static void EnsurePointIndex<T>(ILiteCollection<T> collection, Expression<Func<T, GeoPoint>> selector, int precisionBits = 52)
+        {
+            EnsureInitialized();
+
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            if (selector == null)
+            {
+                throw new ArgumentNullException(nameof(selector));
+            }
+
+            if (collection is not LiteCollection<T> liteCollection)
+            {
+                throw new ArgumentException("Spatial indexing requires LiteCollection", nameof(collection));
+            }
+
+            var getter = selector.Compile();
+
+            liteCollection.RegisterWriteTransform((entity, document) =>
+            {
+                var point = getter(entity);
+
+                if (point == null)
+                {
+                    document["_gh"] = BsonValue.Null;
+                    document["_mbb"] = BsonValue.Null;
+                    return;
+                }
+
+                var normalized = new GeoPoint(point.Lat, point.Lon);
+                var hash = SpatialIndexing.ComputeMorton(normalized, precisionBits);
+                document["_gh"] = hash;
+
+                var bbox = normalized.GetBoundingBox();
+                document["_mbb"] = new BsonArray
+                {
+                    new BsonValue(bbox.MinLat),
+                    new BsonValue(bbox.MinLon),
+                    new BsonValue(bbox.MaxLat),
+                    new BsonValue(bbox.MaxLon)
+                };
+            });
+
+            collection.EnsureIndex("_gh", BsonExpression.Create("_gh"));
+
+            RebuildComputedFields(collection);
+        }
+
+        public static void EnsureShapeIndex<T>(ILiteCollection<T> collection, Expression<Func<T, GeoShape>> selector)
+        {
+            EnsureInitialized();
+
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            if (selector == null)
+            {
+                throw new ArgumentNullException(nameof(selector));
+            }
+
+            if (collection is not LiteCollection<T> liteCollection)
+            {
+                throw new ArgumentException("Spatial indexing requires LiteCollection", nameof(collection));
+            }
+
+            var getter = selector.Compile();
+
+            liteCollection.RegisterWriteTransform((entity, document) =>
+            {
+                var shape = getter(entity);
+
+                if (shape == null)
+                {
+                    document["_mbb"] = BsonValue.Null;
+                    return;
+                }
+
+                if (shape is GeoPoint point)
+                {
+                    var hash = SpatialIndexing.ComputeMorton(point, 52);
+                    document["_gh"] = hash;
+                }
+
+                var bbox = shape.GetBoundingBox();
+                document["_mbb"] = new BsonArray
+                {
+                    new BsonValue(bbox.MinLat),
+                    new BsonValue(bbox.MinLon),
+                    new BsonValue(bbox.MaxLat),
+                    new BsonValue(bbox.MaxLon)
+                };
+            });
+
+            RebuildComputedFields(collection);
+        }
+
+        public static IEnumerable<T> Near<T>(ILiteCollection<T> collection, Func<T, GeoPoint> selector, GeoPoint center, double radiusMeters, int? limit = null)
+        {
+            EnsureInitialized();
+
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            if (selector == null)
+            {
+                throw new ArgumentNullException(nameof(selector));
+            }
+
+            if (center == null)
+            {
+                throw new ArgumentNullException(nameof(center));
+            }
+
+            if (radiusMeters < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(radiusMeters));
+            }
+
+            var results = new List<(T item, double distance)>();
+
+            foreach (var entity in collection.FindAll())
+            {
+                var point = selector(entity);
+
+                if (point == null)
+                {
+                    continue;
+                }
+
+                var distance = GeoMath.DistanceMeters(center, point);
+
+                if (distance <= radiusMeters)
+                {
+                    results.Add((entity, distance));
+                }
+            }
+
+            if (Options.SortNearByDistance)
+            {
+                results.Sort((a, b) => a.distance.CompareTo(b.distance));
+            }
+
+            if (limit.HasValue)
+            {
+                return results.Take(limit.Value).Select(r => r.item).ToList();
+            }
+
+            return results.Select(r => r.item).ToList();
+        }
+
+        public static IEnumerable<T> WithinBoundingBox<T>(ILiteCollection<T> collection, Func<T, GeoPoint> selector, double minLat, double minLon, double maxLat, double maxLon)
+        {
+            EnsureInitialized();
+
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            if (selector == null)
+            {
+                throw new ArgumentNullException(nameof(selector));
+            }
+
+            var latitudeRange = (min: Math.Min(minLat, maxLat), max: Math.Max(minLat, maxLat));
+            var lonRange = new LongitudeRange(minLon, maxLon);
+
+            return collection.FindAll()
+                .Where(entity =>
+                {
+                    var point = selector(entity);
+                    if (point == null)
+                    {
+                        return false;
+                    }
+
+                    return point.Lat >= latitudeRange.min && point.Lat <= latitudeRange.max && lonRange.Contains(point.Lon);
+                })
+                .ToList();
+        }
+
+        public static IEnumerable<T> Within<T>(ILiteCollection<T> collection, Func<T, GeoShape> selector, GeoPolygon area)
+        {
+            EnsureInitialized();
+
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            if (selector == null)
+            {
+                throw new ArgumentNullException(nameof(selector));
+            }
+
+            if (area == null)
+            {
+                throw new ArgumentNullException(nameof(area));
+            }
+
+            return collection.FindAll().Where(entity =>
+            {
+                var shape = selector(entity);
+
+                if (shape == null)
+                {
+                    return false;
+                }
+
+                return shape switch
+                {
+                    GeoPoint point => Geometry.ContainsPoint(area, point),
+                    GeoPolygon polygon => Geometry.Intersects(area, polygon) && polygon.Outer.All(p => Geometry.ContainsPoint(area, p)),
+                    GeoLineString line => line.Points.All(p => Geometry.ContainsPoint(area, p)),
+                    _ => false
+                };
+            }).ToList();
+        }
+
+        public static IEnumerable<T> Intersects<T>(ILiteCollection<T> collection, Func<T, GeoShape> selector, GeoShape query)
+        {
+            EnsureInitialized();
+
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            if (selector == null)
+            {
+                throw new ArgumentNullException(nameof(selector));
+            }
+
+            if (query == null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
+            return collection.FindAll().Where(entity =>
+            {
+                var shape = selector(entity);
+
+                if (shape == null)
+                {
+                    return false;
+                }
+
+                return shape switch
+                {
+                    GeoPoint point when query is GeoPolygon polygon => Geometry.ContainsPoint(polygon, point),
+                    GeoLineString line when query is GeoPolygon polygon => Geometry.Intersects(line, polygon),
+                    GeoPolygon polygon when query is GeoPolygon other => Geometry.Intersects(polygon, other),
+                    GeoLineString line when query is GeoLineString other => IntersectsLineStrings(line, other),
+                    _ => false
+                };
+            }).ToList();
+        }
+
+        public static IEnumerable<T> Contains<T>(ILiteCollection<T> collection, Func<T, GeoShape> selector, GeoPoint point)
+        {
+            EnsureInitialized();
+
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            if (selector == null)
+            {
+                throw new ArgumentNullException(nameof(selector));
+            }
+
+            if (point == null)
+            {
+                throw new ArgumentNullException(nameof(point));
+            }
+
+            return collection.FindAll().Where(entity =>
+            {
+                var shape = selector(entity);
+
+                return shape switch
+                {
+                    GeoPolygon polygon => Geometry.ContainsPoint(polygon, point),
+                    GeoPoint candidate => Math.Abs(candidate.Lat - point.Lat) < 1e-9 && Math.Abs(candidate.Lon - point.Lon) < 1e-9,
+                    GeoLineString line => line.Points.Any(p => Math.Abs(p.Lat - point.Lat) < 1e-9 && Math.Abs(p.Lon - point.Lon) < 1e-9),
+                    _ => false
+                };
+            }).ToList();
+        }
+
+        private static bool IntersectsLineStrings(GeoLineString a, GeoLineString b)
+        {
+            for (var i = 0; i < a.Points.Count - 1; i++)
+            {
+                for (var j = 0; j < b.Points.Count - 1; j++)
+                {
+                    if (Geometry.SegmentsIntersect(a.Points[i], a.Points[i + 1], b.Points[j], b.Points[j + 1]))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static void EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            lock (_initLock)
+            {
+                if (_initialized)
+                {
+                    return;
+                }
+
+                RegisterGeoTypes();
+                _initialized = true;
+            }
+        }
+
+        private static void RegisterGeoTypes()
+        {
+            void Register<TShape>(Func<TShape, BsonValue> serialize, Func<BsonValue, TShape> deserialize)
+                where TShape : GeoShape
+            {
+                BsonMapper.Global.RegisterType(typeof(TShape), value => serialize((TShape)value), bson => deserialize(bson));
+            }
+
+            Register<GeoShape>(GeoJson.ToBson, bson => (GeoShape)GeoJson.FromBson(bson.AsDocument));
+            Register<GeoPoint>(GeoJson.ToBson, bson => (GeoPoint)GeoJson.FromBson(bson.AsDocument));
+            Register<GeoLineString>(GeoJson.ToBson, bson => (GeoLineString)GeoJson.FromBson(bson.AsDocument));
+            Register<GeoPolygon>(GeoJson.ToBson, bson => (GeoPolygon)GeoJson.FromBson(bson.AsDocument));
+        }
+
+        private static void RebuildComputedFields<T>(ILiteCollection<T> collection)
+        {
+            foreach (var entity in collection.FindAll().ToList())
+            {
+                collection.Update(entity);
+            }
+        }
+    }
+}

--- a/LiteDB/Spatial/SpatialIndexing.cs
+++ b/LiteDB/Spatial/SpatialIndexing.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace LiteDB.Spatial
+{
+    internal static class SpatialIndexing
+    {
+        public static long ComputeMorton(GeoPoint point, int precisionBits)
+        {
+            if (point == null)
+            {
+                throw new ArgumentNullException(nameof(point));
+            }
+
+            if (precisionBits <= 0 || precisionBits > 60)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precisionBits), "Precision must be between 1 and 60 bits");
+            }
+
+            var bitsPerCoordinate = precisionBits / 2;
+
+            if (bitsPerCoordinate <= 0)
+            {
+                bitsPerCoordinate = 1;
+            }
+
+            var scaleLat = (1UL << bitsPerCoordinate) - 1UL;
+            var scaleLon = (1UL << bitsPerCoordinate) - 1UL;
+
+            var latNormalized = (point.Lat + 90d) / 180d;
+            var lonNormalized = (point.Lon + 180d) / 360d;
+
+            latNormalized = Math.Min(1d, Math.Max(0d, latNormalized));
+            lonNormalized = Math.Min(1d, Math.Max(0d, lonNormalized));
+
+            var latBits = (ulong)Math.Round(latNormalized * scaleLat);
+            var lonBits = (ulong)Math.Round(lonNormalized * scaleLon);
+
+            var morton = Interleave(lonBits, latBits, bitsPerCoordinate);
+
+            return unchecked((long)morton);
+        }
+
+        private static ulong Interleave(ulong x, ulong y, int bits)
+        {
+            ulong result = 0;
+
+            for (var i = 0; i < bits; i++)
+            {
+                var shift = (ulong)i;
+                result |= ((x >> i) & 1UL) << (int)(2 * shift);
+                result |= ((y >> i) & 1UL) << (int)(2 * shift + 1);
+            }
+
+            return result;
+        }
+    }
+}

--- a/LiteDB/Spatial/SpatialOptions.cs
+++ b/LiteDB/Spatial/SpatialOptions.cs
@@ -1,0 +1,24 @@
+namespace LiteDB.Spatial
+{
+    public enum DistanceFormula
+    {
+        Haversine
+    }
+
+    public enum AngleUnit
+    {
+        Degrees,
+        Radians
+    }
+
+    public sealed class SpatialOptions
+    {
+        public DistanceFormula Distance { get; set; } = DistanceFormula.Haversine;
+
+        public bool SortNearByDistance { get; set; } = true;
+
+        public int MaxCoveringCells { get; set; } = 32;
+
+        public AngleUnit AngleUnit { get; set; } = AngleUnit.Degrees;
+    }
+}


### PR DESCRIPTION
## Summary
- add LiteDB.Spatial geometry types, GeoJSON helpers, and high-level spatial query/index APIs
- compute geohash and bounding boxes during writes through new LiteCollection write transforms
- cover near, polygon, bounding-box, and GeoJSON behavior with new spatial tests

## Testing
- `dotnet test LiteDB.sln --settings tests.runsettings`


------
https://chatgpt.com/codex/tasks/task_e_68d48b685b7c832a826b9844dab2b76e