### PR TITLE
Disable GitVersion in shallow clones

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,9 @@
 <Project>
   <PropertyGroup>
-    <_RootGitHeadPath>$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', '.git', 'HEAD'))</_RootGitHeadPath>
-    <GitVersionEnabled Condition="'$(GitVersionEnabled)' == '' and Exists('$(_RootGitHeadPath)')">true</GitVersionEnabled>
+    <_RootGitDirectory>$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', '.git'))</_RootGitDirectory>
+    <_RootGitHeadPath>$([System.IO.Path]::Combine('$(_RootGitDirectory)', 'HEAD'))</_RootGitHeadPath>
+    <_RootGitShallowPath>$([System.IO.Path]::Combine('$(_RootGitDirectory)', 'shallow'))</_RootGitShallowPath>
+    <GitVersionEnabled Condition="'$(GitVersionEnabled)' == '' and Exists('$(_RootGitHeadPath)') and !Exists('$(_RootGitShallowPath)')">true</GitVersionEnabled>
     <GitVersionEnabled Condition="'$(GitVersionEnabled)' == ''">false</GitVersionEnabled>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- ensure GitVersion stays disabled when the repository is a shallow clone by checking for .git/shallow

## Testing
- dotnet build
- dotnet test
- dotnet pack

------
https://chatgpt.com/codex/tasks/task_e_68d8f3a6c074832ab5c28255a5c5c0b4