### PR TITLE
Add issue 2561 repro console app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,33 @@ jobs:
       - name: Test
         timeout-minutes: 5
         run: dotnet test LiteDB.sln --configuration Release --no-build --verbosity normal --settings tests.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" /p:DefineConstants=TESTING
+
+  repro-runner:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore
+        run: dotnet restore LiteDB.sln
+
+      - name: Build
+        run: dotnet build LiteDB.sln --configuration Release --no-restore
+
+      - name: List repros
+        run: dotnet run --project LiteDB.ReproRunner/LiteDB.ReproRunner.Cli -- list --strict
+
+      - name: Validate manifests
+        run: dotnet run --project LiteDB.ReproRunner/LiteDB.ReproRunner.Cli -- validate
+
+      - name: Run Issue 2561 repro
+        run: dotnet run --project LiteDB.ReproRunner/LiteDB.ReproRunner.Cli -- run Issue_2561_TransactionMonitor --useProjectRef

--- a/ConsoleApp1/ConsoleApp1.csproj
+++ b/ConsoleApp1/ConsoleApp1.csproj
@@ -5,10 +5,16 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LiteDbPackageVersion>5.0.20</LiteDbPackageVersion>
+    <UseLocalLiteDb Condition="'$(UseLocalLiteDb)' == ''">false</UseLocalLiteDb>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseLocalLiteDb)' == 'true'">
     <ProjectReference Include="..\LiteDB\LiteDB.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseLocalLiteDb)' != 'true'">
+    <PackageReference Include="LiteDB" Version="$(LiteDbPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/ConsoleApp1/Program.cs
+++ b/ConsoleApp1/Program.cs
@@ -1,98 +1,66 @@
-﻿using LiteDB;
+using System.IO;
+using System.Reflection;
+using System.Threading;
 using LiteDB.Engine;
 
-using System.Reflection.Emit;
-using System.Reflection.PortableExecutable;
+const string DatabaseName = "issue-2561-repro.db";
+var databasePath = Path.Combine(AppContext.BaseDirectory, DatabaseName);
 
-var password = "46jLz5QWd5fI3m4LiL2r";
-var path = $"C:\\LiteDB\\Examples\\CrashDB_{DateTime.Now.Ticks}.db";
+if (File.Exists(databasePath))
+{
+    File.Delete(databasePath);
+}
 
 var settings = new EngineSettings
 {
-    AutoRebuild = true,
-    Filename = path,
-    Password = password
+    Filename = databasePath
 };
 
-var data = Enumerable.Range(1, 10_000).Select(i => new BsonDocument
+Console.WriteLine($"LiteDB engine file: {databasePath}");
+Console.WriteLine("Creating an explicit transaction on the main thread...");
+
+using var engine = new LiteEngine(settings);
+engine.BeginTrans();
+
+var monitorField = typeof(LiteEngine).GetField("_monitor", BindingFlags.NonPublic | BindingFlags.Instance) ??
+    throw new InvalidOperationException("Could not locate the transaction monitor field.");
+
+var monitor = monitorField.GetValue(engine) ??
+    throw new InvalidOperationException("Failed to extract the transaction monitor instance.");
+
+var getTransaction = monitor.GetType().GetMethod(
+    "GetTransaction",
+    BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance,
+    binder: null,
+    types: new[] { typeof(bool), typeof(bool), typeof(bool).MakeByRefType() },
+    modifiers: null) ??
+    throw new InvalidOperationException("Could not locate GetTransaction on the monitor.");
+
+var getTransactionArgs = new object[] { false, false, null! };
+var transaction = getTransaction.Invoke(monitor, getTransactionArgs) ??
+    throw new InvalidOperationException("LiteDB did not return the thread-bound transaction.");
+
+Console.WriteLine("Main thread transaction captured. Launching a worker thread to mimic the finalizer...");
+
+var releaseTransaction = monitor.GetType().GetMethod(
+    "ReleaseTransaction",
+    BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance,
+    binder: null,
+    types: new[] { transaction.GetType() },
+    modifiers: null) ??
+    throw new InvalidOperationException("Could not locate ReleaseTransaction on the monitor.");
+
+var worker = new Thread(() =>
 {
-    ["_id"] = i,
-    ["name"] = Faker.Fullname(),
-    ["age"] = Faker.Age(),
-    ["created"] = Faker.Birthday(),
-    ["lorem"] = Faker.Lorem(5, 25)
-}).ToArray();
+    Console.WriteLine($"Worker thread {Environment.CurrentManagedThreadId} releasing the transaction...");
 
-try
-{
-    using (var db = new LiteEngine(settings))
-    {
-#if DEBUG || TESTING
-        db.SimulateDiskWriteFail = (page) =>
-        {
-            var p = new BasePage(page);
+    // This invocation throws LiteException("current thread must contains transaction parameter")
+    // because the worker thread never registered the transaction in its ThreadLocal slot.
+    releaseTransaction.Invoke(monitor, new[] { transaction });
+});
 
-            if (p.PageID == 248)
-            {
-                page.Write((uint)123123123, 8192-4);
-            }
-        };
-#endif
+worker.Start();
+worker.Join();
 
-        db.Pragma("USER_VERSION", 123);
+Console.WriteLine("If you see this message the repro did not trigger the crash.");
 
-        db.EnsureIndex("col1", "idx_age", "$.age", false);
-
-        db.Insert("col1", data, BsonAutoId.Int32);
-        db.Insert("col2", data, BsonAutoId.Int32);
-
-        var col1 = db.Query("col1", Query.All()).ToList().Count;
-        var col2 = db.Query("col2", Query.All()).ToList().Count;
-
-        Console.WriteLine("Inserted Col1: " + col1);
-        Console.WriteLine("Inserted Col2: " + col2);
-    }
-}
-catch (Exception ex)
-{
-    Console.WriteLine("ERROR: " + ex.Message);
-}
-
-Console.WriteLine("Recovering database...");
-
-using (var db = new LiteEngine(settings))
-{
-    var col1 = db.Query("col1", Query.All()).ToList().Count;
-    var col2 = db.Query("col2", Query.All()).ToList().Count;
-
-    Console.WriteLine($"Col1: {col1}");
-    Console.WriteLine($"Col2: {col2}");
-
-    var errors = new BsonArray(db.Query("_rebuild_errors", Query.All()).ToList()).ToString();
-
-    Console.WriteLine("Errors: " + errors);
-
-}
-
-/*
-var errors = new List<FileReaderError>();
-var fr = new FileReaderV8(settings, errors);
-
-fr.Open();
-var pragmas = fr.GetPragmas();
-var cols = fr.GetCollections().ToArray();
-var indexes = fr.GetIndexes(cols[0]);
-
-var docs1 = fr.GetDocuments("col1").ToArray();
-var docs2 = fr.GetDocuments("col2").ToArray();
-
-
-Console.WriteLine("Recovered Col1: " + docs1.Length);
-Console.WriteLine("Recovered Col2: " + docs2.Length);
-
-Console.WriteLine("# Errors: ");
-errors.ForEach(x => Console.WriteLine($"PageID: {x.PageID}/{x.Origin}/#{x.Position}[{x.Collection}]: " + x.Message));
-*/
-
-Console.WriteLine("\n\nEnd.");
-Console.ReadKey();

--- a/LiteDB.ReproRunner.Tests/CliApplicationTests.cs
+++ b/LiteDB.ReproRunner.Tests/CliApplicationTests.cs
@@ -1,0 +1,52 @@
+using LiteDB.ReproRunner.Cli;
+using LiteDB.ReproRunner.Cli.Commands;
+using Spectre.Console;
+using Spectre.Console.Testing;
+
+namespace LiteDB.ReproRunner.Tests;
+
+public sealed class CliApplicationTests
+{
+    [Fact]
+    public async Task Validate_ReturnsErrorCodeWhenManifestInvalid()
+    {
+        var tempRoot = Directory.CreateTempSubdirectory();
+        try
+        {
+            var reproRoot = Path.Combine(tempRoot.FullName, "LiteDB.ReproRunner");
+            var reproDirectory = Path.Combine(reproRoot, "Repros", "BadRepro");
+            Directory.CreateDirectory(reproDirectory);
+
+            var manifest = """
+            {
+              "id": "Bad Repro",
+              "title": "",
+              "timeoutSeconds": 0,
+              "requiresParallel": false,
+              "defaultInstances": 0,
+              "state": "unknown"
+            }
+            """;
+
+            await File.WriteAllTextAsync(Path.Combine(reproDirectory, "repro.json"), manifest);
+            await File.WriteAllTextAsync(Path.Combine(reproDirectory, "BadRepro.csproj"), "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+
+            using var console = new TestConsole();
+            var command = new ValidateCommand(console, new ReproRootLocator());
+            var settings = new ValidateCommandSettings
+            {
+                All = true,
+                Root = reproRoot
+            };
+
+            var exitCode = command.Execute(null!, settings);
+
+            Assert.Equal(2, exitCode);
+            Assert.Contains("INVALID", console.Output, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot.FullName, true);
+        }
+    }
+}

--- a/LiteDB.ReproRunner.Tests/LiteDB.ReproRunner.Tests.csproj
+++ b/LiteDB.ReproRunner.Tests/LiteDB.ReproRunner.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Spectre.Console.Testing" Version="0.49.1" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB.ReproRunner\LiteDB.ReproRunner.Cli\LiteDB.ReproRunner.Cli.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.ReproRunner.Tests/ManifestValidatorTests.cs
+++ b/LiteDB.ReproRunner.Tests/ManifestValidatorTests.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using LiteDB.ReproRunner.Cli;
+
+namespace LiteDB.ReproRunner.Tests;
+
+public sealed class ManifestValidatorTests
+{
+    [Fact]
+    public void Validate_AllowsValidManifest()
+    {
+        const string json = """
+        {
+          "id": "Issue_000_Demo",
+          "title": "Demo repro",
+          "issues": ["https://example.com/issue"],
+          "failingSince": "5.0.x",
+          "timeoutSeconds": 120,
+          "requiresParallel": false,
+          "defaultInstances": 1,
+          "sharedDatabaseKey": "demo",
+          "args": ["--flag"],
+          "tags": ["demo"],
+          "state": "red"
+        }
+        """;
+
+        using var document = JsonDocument.Parse(json);
+        var validation = new ManifestValidationResult();
+        var validator = new ManifestValidator();
+
+        var manifest = validator.Validate(document.RootElement, validation, out var rawId);
+
+        Assert.NotNull(manifest);
+        Assert.True(validation.IsValid);
+        Assert.Equal("Issue_000_Demo", manifest!.Id);
+        Assert.Equal("Issue_000_Demo", rawId);
+        Assert.Equal(120, manifest.TimeoutSeconds);
+        Assert.Equal("red", manifest.State);
+    }
+
+    [Fact]
+    public void Validate_FailsWhenTimeoutOutOfRange()
+    {
+        const string json = """
+        {
+          "id": "Issue_001",
+          "title": "Invalid timeout",
+          "timeoutSeconds": 0,
+          "requiresParallel": false,
+          "defaultInstances": 1,
+          "state": "green"
+        }
+        """;
+
+        using var document = JsonDocument.Parse(json);
+        var validation = new ManifestValidationResult();
+        var validator = new ManifestValidator();
+
+        var manifest = validator.Validate(document.RootElement, validation, out _);
+
+        Assert.Null(manifest);
+        Assert.Contains(validation.Errors, error => error.Contains("$.timeoutSeconds", StringComparison.Ordinal));
+    }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/CliOutput.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/CliOutput.cs
@@ -1,0 +1,91 @@
+using Spectre.Console;
+
+namespace LiteDB.ReproRunner.Cli;
+
+internal static class CliOutput
+{
+    public static void PrintInvalid(IAnsiConsole console, DiscoveredRepro repro)
+    {
+        console.MarkupLine($"[red]INVALID[/]  {Markup.Escape(NormalizePath(repro.RelativeManifestPath))}");
+        foreach (var error in repro.Validation.Errors)
+        {
+            console.MarkupLine($"  - {Markup.Escape(error)}");
+        }
+    }
+
+    public static void PrintManifest(IAnsiConsole console, DiscoveredRepro repro)
+    {
+        if (repro.Manifest is null)
+        {
+            return;
+        }
+
+        var manifest = repro.Manifest;
+        var table = new Table().Border(TableBorder.Rounded).AddColumns("Field", "Value");
+        table.AddRow("Id", Markup.Escape(manifest.Id));
+        table.AddRow("Title", Markup.Escape(manifest.Title));
+        table.AddRow("State", Markup.Escape(manifest.State));
+        table.AddRow("TimeoutSeconds", Markup.Escape(manifest.TimeoutSeconds.ToString()));
+        table.AddRow("RequiresParallel", Markup.Escape(manifest.RequiresParallel.ToString()));
+        table.AddRow("DefaultInstances", Markup.Escape(manifest.DefaultInstances.ToString()));
+        table.AddRow("SharedDatabaseKey", Markup.Escape(manifest.SharedDatabaseKey ?? "-"));
+        table.AddRow("FailingSince", Markup.Escape(manifest.FailingSince ?? "-"));
+        table.AddRow("Tags", Markup.Escape(manifest.Tags.Count > 0 ? string.Join(", ", manifest.Tags) : "-"));
+        table.AddRow("Args", Markup.Escape(manifest.Args.Count > 0 ? string.Join(" ", manifest.Args) : "-"));
+
+        if (manifest.Issues.Count > 0)
+        {
+            table.AddRow("Issues", Markup.Escape(string.Join(Environment.NewLine, manifest.Issues)));
+        }
+
+        console.Write(table);
+    }
+
+    public static void PrintValidationResult(IAnsiConsole console, DiscoveredRepro repro)
+    {
+        if (repro.IsValid)
+        {
+            console.MarkupLine($"[green]VALID[/]    {Markup.Escape(NormalizePath(repro.RelativeManifestPath))}");
+        }
+        else
+        {
+            PrintInvalid(console, repro);
+        }
+    }
+
+    public static void PrintList(IAnsiConsole console, IReadOnlyList<DiscoveredRepro> valid)
+    {
+        if (valid.Count == 0)
+        {
+            console.MarkupLine("[yellow]No valid repro manifests found.[/]");
+            return;
+        }
+
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumns("Id", "State", "Timeout", "Failing Since", "Tags", "Title");
+
+        foreach (var repro in valid)
+        {
+            if (repro.Manifest is null)
+            {
+                continue;
+            }
+
+            var manifest = repro.Manifest;
+            table.AddRow(
+                Markup.Escape(manifest.Id),
+                Markup.Escape(manifest.State),
+                Markup.Escape($"{manifest.TimeoutSeconds}s"),
+                Markup.Escape(manifest.FailingSince ?? "-"),
+                Markup.Escape(manifest.Tags.Count > 0 ? string.Join(",", manifest.Tags) : "-"),
+                Markup.Escape(manifest.Title));
+        }
+
+        console.Write(table);
+    }
+
+    private static string NormalizePath(string path)
+    {
+        return path.Replace(Path.DirectorySeparatorChar, '/');
+    }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/ListCommand.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/ListCommand.cs
@@ -1,0 +1,38 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace LiteDB.ReproRunner.Cli.Commands;
+
+internal sealed class ListCommand : Command<ListCommandSettings>
+{
+    private readonly IAnsiConsole _console;
+    private readonly ReproRootLocator _rootLocator;
+
+    public ListCommand(IAnsiConsole console, ReproRootLocator rootLocator)
+    {
+        _console = console ?? throw new ArgumentNullException(nameof(console));
+        _rootLocator = rootLocator ?? throw new ArgumentNullException(nameof(rootLocator));
+    }
+
+    public override int Execute(CommandContext context, ListCommandSettings settings)
+    {
+        var repository = new ManifestRepository(_rootLocator.ResolveRoot(settings.Root));
+        var manifests = repository.Discover();
+        var valid = manifests.Where(x => x.IsValid).ToList();
+        var invalid = manifests.Where(x => !x.IsValid).ToList();
+
+        CliOutput.PrintList(_console, valid);
+
+        foreach (var repro in invalid)
+        {
+            CliOutput.PrintInvalid(_console, repro);
+        }
+
+        if (settings.Strict && invalid.Count > 0)
+        {
+            return 2;
+        }
+
+        return 0;
+    }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/ListCommandSettings.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/ListCommandSettings.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace LiteDB.ReproRunner.Cli.Commands;
+
+internal sealed class ListCommandSettings : RootCommandSettings
+{
+    [CommandOption("--strict")]
+    [Description("Return exit code 2 if any manifests are invalid.")]
+    public bool Strict { get; set; }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/RootCommandSettings.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/RootCommandSettings.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace LiteDB.ReproRunner.Cli.Commands;
+
+internal class RootCommandSettings : CommandSettings
+{
+    [CommandOption("--root <PATH>")]
+    [Description("Override the LiteDB.ReproRunner root directory.")]
+    public string? Root { get; set; }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/RunCommand.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/RunCommand.cs
@@ -1,0 +1,165 @@
+using System.Threading;
+using System.Xml.Linq;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace LiteDB.ReproRunner.Cli.Commands;
+
+internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
+{
+    private readonly IAnsiConsole _console;
+    private readonly ReproRootLocator _rootLocator;
+    private readonly ReproExecutor _executor;
+    private readonly CancellationToken _cancellationToken;
+
+    public RunCommand(IAnsiConsole console, ReproRootLocator rootLocator, ReproExecutor executor, CancellationToken cancellationToken)
+    {
+        _console = console ?? throw new ArgumentNullException(nameof(console));
+        _rootLocator = rootLocator ?? throw new ArgumentNullException(nameof(rootLocator));
+        _executor = executor ?? throw new ArgumentNullException(nameof(executor));
+        _cancellationToken = cancellationToken;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, RunCommandSettings settings)
+    {
+        _cancellationToken.ThrowIfCancellationRequested();
+        var repository = new ManifestRepository(_rootLocator.ResolveRoot(settings.Root));
+        var manifests = repository.Discover();
+        var selected = settings.All
+            ? manifests.ToList()
+            : manifests.Where(x => string.Equals(x.Manifest?.Id ?? x.RawId, settings.Id, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        if (selected.Count == 0)
+        {
+            if (settings.All)
+            {
+                _console.MarkupLine("[yellow]No repros discovered.[/]");
+                return 0;
+            }
+
+            _console.MarkupLine($"[red]Repro '{Markup.Escape(settings.Id!)}' was not found.[/]");
+            return 1;
+        }
+
+        var table = new Table().Border(TableBorder.Rounded).AddColumns("Repro", "Repro Version", "Reproduced", "Fixed");
+        var overallExitCode = 0;
+
+        await _console.Live(table).StartAsync(async ctx =>
+        {
+            foreach (var repro in selected)
+            {
+                _cancellationToken.ThrowIfCancellationRequested();
+
+                if (!repro.IsValid)
+                {
+                    if (!settings.SkipValidation)
+                    {
+                        table.AddRow(Markup.Escape(repro.RawId ?? "(unknown)"), "[red]Invalid[/]", "[red]❌[/]", "[red]❌[/]");
+                        ctx.Refresh();
+                        overallExitCode = overallExitCode == 0 ? 2 : overallExitCode;
+                        continue;
+                    }
+
+                    if (repro.Manifest is null)
+                    {
+                        table.AddRow(Markup.Escape(repro.RawId ?? "(unknown)"), "[red]Invalid[/]", "[red]❌[/]", "[red]❌[/]");
+                        ctx.Refresh();
+                        overallExitCode = overallExitCode == 0 ? 2 : overallExitCode;
+                        continue;
+                    }
+                }
+
+                if (repro.Manifest is null)
+                {
+                    table.AddRow(Markup.Escape(repro.RawId ?? "(unknown)"), "[red]Missing[/]", "[red]❌[/]", "[red]❌[/]");
+                    ctx.Refresh();
+                    overallExitCode = overallExitCode == 0 ? 2 : overallExitCode;
+                    continue;
+                }
+
+                var manifest = repro.Manifest;
+                var instances = settings.Instances ?? manifest.DefaultInstances;
+
+                if (manifest.RequiresParallel && instances < 2)
+                {
+                    table.AddRow(Markup.Escape(manifest.Id), "[red]Config Error[/]", "[red]❌[/]", "[red]❌[/]");
+                    ctx.Refresh();
+                    overallExitCode = 1;
+                    continue;
+                }
+
+                var timeoutSeconds = settings.Timeout ?? manifest.TimeoutSeconds;
+                var packageVersion = TryResolvePackageVersion(repro.ProjectPath);
+                var displayVersion = packageVersion ?? "NuGet";
+
+                _cancellationToken.ThrowIfCancellationRequested();
+
+                // Test with package version first
+                var packageResult = await _executor.ExecuteAsync(repro, false, instances, timeoutSeconds, _cancellationToken).ConfigureAwait(false);
+                
+                // Test with current code
+                var currentResult = await _executor.ExecuteAsync(repro, true, instances, timeoutSeconds, _cancellationToken).ConfigureAwait(false);
+
+                var reproducedStatus = packageResult.Reproduced ? "[green]✅[/]" : "[red]❌[/]";
+                var fixedStatus = currentResult.Reproduced 
+                    ? "[red]❌[/]"  // Still reproduces (crossed out X)
+                    : "[green]✅[/]";   // Fixed (check mark)
+
+                table.AddRow(Markup.Escape(manifest.Id), Markup.Escape(displayVersion), reproducedStatus, fixedStatus);
+                ctx.Refresh();
+
+                if (packageResult.Reproduced || currentResult.Reproduced)
+                {
+                    overallExitCode = overallExitCode == 0 ? 1 : overallExitCode;
+                }
+            }
+        }).ConfigureAwait(false);
+
+        return overallExitCode;
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        return duration.TotalSeconds >= 10
+            ? duration.ToString(@"hh\:mm\:ss")
+            : $"{duration.TotalSeconds:0.###}s";
+    }
+
+    private static string? TryResolvePackageVersion(string? projectPath)
+    {
+        if (projectPath is null || !File.Exists(projectPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var document = XDocument.Load(projectPath);
+            var ns = document.Root?.Name.Namespace ?? XNamespace.None;
+
+            var versionElement = document
+                .Descendants(ns + "LiteDBPackageVersion")
+                .FirstOrDefault();
+
+            if (versionElement is not null && !string.IsNullOrWhiteSpace(versionElement.Value))
+            {
+                return versionElement.Value.Trim();
+            }
+
+            var packageReference = document
+                .Descendants(ns + "PackageReference")
+                .FirstOrDefault(e => string.Equals(e.Attribute("Include")?.Value, "LiteDB", StringComparison.OrdinalIgnoreCase));
+
+            var version = packageReference?.Attribute("Version")?.Value;
+            if (!string.IsNullOrWhiteSpace(version))
+            {
+                return version!.Trim();
+            }
+        }
+        catch
+        {
+        }
+
+        return null;
+    }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/RunCommandSettings.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/RunCommandSettings.cs
@@ -1,0 +1,53 @@
+using System.ComponentModel;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace LiteDB.ReproRunner.Cli.Commands;
+
+internal sealed class RunCommandSettings : RootCommandSettings
+{
+    [CommandArgument(0, "[id]")]
+    [Description("Identifier of the repro to run.")]
+    public string? Id { get; set; }
+
+    [CommandOption("--all")]
+    [Description("Run every repro in sequence.")]
+    public bool All { get; set; }
+
+    [CommandOption("--instances <N>")]
+    [Description("Override the number of instances to launch.")]
+    public int? Instances { get; set; }
+
+    [CommandOption("--timeout <SECONDS>")]
+    [Description("Override the timeout applied to each repro.")]
+    public int? Timeout { get; set; }
+
+    [CommandOption("--skipValidation")]
+    [Description("Allow execution even when manifest validation fails.")]
+    public bool SkipValidation { get; set; }
+
+    public override ValidationResult Validate()
+    {
+        if (All && Id is not null)
+        {
+            return ValidationResult.Error("Cannot specify both --all and <id>.");
+        }
+
+        if (!All && Id is null)
+        {
+            return ValidationResult.Error("run requires a repro id or --all.");
+        }
+
+        if (Instances is int instances && instances < 1)
+        {
+            return ValidationResult.Error("--instances expects a positive integer.");
+        }
+
+        if (Timeout is int timeout && timeout < 1)
+        {
+            return ValidationResult.Error("--timeout expects a positive integer value in seconds.");
+        }
+
+        return base.Validate();
+    }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/ShowCommand.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/ShowCommand.cs
@@ -1,0 +1,38 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace LiteDB.ReproRunner.Cli.Commands;
+
+internal sealed class ShowCommand : Command<ShowCommandSettings>
+{
+    private readonly IAnsiConsole _console;
+    private readonly ReproRootLocator _rootLocator;
+
+    public ShowCommand(IAnsiConsole console, ReproRootLocator rootLocator)
+    {
+        _console = console ?? throw new ArgumentNullException(nameof(console));
+        _rootLocator = rootLocator ?? throw new ArgumentNullException(nameof(rootLocator));
+    }
+
+    public override int Execute(CommandContext context, ShowCommandSettings settings)
+    {
+        var repository = new ManifestRepository(_rootLocator.ResolveRoot(settings.Root));
+        var manifests = repository.Discover();
+        var repro = manifests.FirstOrDefault(x => string.Equals(x.Manifest?.Id ?? x.RawId, settings.Id, StringComparison.OrdinalIgnoreCase));
+
+        if (repro is null)
+        {
+            _console.MarkupLine($"[red]Repro '{Markup.Escape(settings.Id)}' was not found.[/]");
+            return 1;
+        }
+
+        if (!repro.IsValid)
+        {
+            CliOutput.PrintInvalid(_console, repro);
+            return 2;
+        }
+
+        CliOutput.PrintManifest(_console, repro);
+        return 0;
+    }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/ShowCommandSettings.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/ShowCommandSettings.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace LiteDB.ReproRunner.Cli.Commands;
+
+internal sealed class ShowCommandSettings : RootCommandSettings
+{
+    [CommandArgument(0, "<id>")]
+    [Description("Identifier of the repro to show.")]
+    public string Id { get; set; } = string.Empty;
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/ValidateCommand.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/ValidateCommand.cs
@@ -1,0 +1,44 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace LiteDB.ReproRunner.Cli.Commands;
+
+internal sealed class ValidateCommand : Command<ValidateCommandSettings>
+{
+    private readonly IAnsiConsole _console;
+    private readonly ReproRootLocator _rootLocator;
+
+    public ValidateCommand(IAnsiConsole console, ReproRootLocator rootLocator)
+    {
+        _console = console ?? throw new ArgumentNullException(nameof(console));
+        _rootLocator = rootLocator ?? throw new ArgumentNullException(nameof(rootLocator));
+    }
+
+    public override int Execute(CommandContext context, ValidateCommandSettings settings)
+    {
+        var repository = new ManifestRepository(_rootLocator.ResolveRoot(settings.Root));
+        var manifests = repository.Discover();
+
+        if (!settings.All && settings.Id is not null)
+        {
+            var repro = manifests.FirstOrDefault(x => string.Equals(x.Manifest?.Id ?? x.RawId, settings.Id, StringComparison.OrdinalIgnoreCase));
+            if (repro is null)
+            {
+                _console.MarkupLine($"[red]Repro '{Markup.Escape(settings.Id)}' was not found.[/]");
+                return 1;
+            }
+
+            CliOutput.PrintValidationResult(_console, repro);
+            return repro.IsValid ? 0 : 2;
+        }
+
+        var anyInvalid = false;
+        foreach (var repro in manifests)
+        {
+            CliOutput.PrintValidationResult(_console, repro);
+            anyInvalid |= !repro.IsValid;
+        }
+
+        return anyInvalid ? 2 : 0;
+    }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/ValidateCommandSettings.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/ValidateCommandSettings.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace LiteDB.ReproRunner.Cli.Commands;
+
+internal sealed class ValidateCommandSettings : RootCommandSettings
+{
+    [CommandOption("--all")]
+    [Description("Validate every repro manifest (default).")]
+    public bool All { get; set; }
+
+    [CommandOption("--id <ID>")]
+    [Description("Validate a single repro by id.")]
+    public string? Id { get; set; }
+
+    public override ValidationResult Validate()
+    {
+        if (All && Id is not null)
+        {
+            return ValidationResult.Error("Cannot specify both --all and --id.");
+        }
+
+        return base.Validate();
+    }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/DiscoveredRepro.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/DiscoveredRepro.cs
@@ -1,0 +1,42 @@
+namespace LiteDB.ReproRunner.Cli;
+
+internal sealed class DiscoveredRepro
+{
+    public DiscoveredRepro(
+        string rootPath,
+        string directoryPath,
+        string manifestPath,
+        string relativeManifestPath,
+        string? projectPath,
+        ReproManifest? manifest,
+        ManifestValidationResult validation,
+        string? rawId)
+    {
+        RootPath = rootPath;
+        DirectoryPath = directoryPath;
+        ManifestPath = manifestPath;
+        RelativeManifestPath = relativeManifestPath;
+        ProjectPath = projectPath;
+        Manifest = manifest;
+        Validation = validation;
+        RawId = rawId;
+    }
+
+    public string RootPath { get; }
+
+    public string DirectoryPath { get; }
+
+    public string ManifestPath { get; }
+
+    public string RelativeManifestPath { get; }
+
+    public string? ProjectPath { get; }
+
+    public ReproManifest? Manifest { get; }
+
+    public ManifestValidationResult Validation { get; }
+
+    public string? RawId { get; }
+
+    public bool IsValid => Manifest is not null && Validation.IsValid;
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/LiteDB.ReproRunner.Cli.csproj
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/LiteDB.ReproRunner.Cli.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Spectre.Console" Version="0.49.1" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/ManifestRepository.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/ManifestRepository.cs
@@ -1,0 +1,119 @@
+using System.Linq;
+using System.Text.Json;
+
+namespace LiteDB.ReproRunner.Cli;
+
+internal sealed class ManifestRepository
+{
+    private readonly string _rootPath;
+    private readonly string _reprosPath;
+    private readonly ManifestValidator _validator = new();
+
+    public ManifestRepository(string rootPath)
+    {
+        _rootPath = Path.GetFullPath(rootPath);
+        _reprosPath = Path.Combine(_rootPath, "Repros");
+    }
+
+    public string RootPath => _rootPath;
+
+    public IReadOnlyList<DiscoveredRepro> Discover()
+    {
+        if (!Directory.Exists(_reprosPath))
+        {
+            return Array.Empty<DiscoveredRepro>();
+        }
+
+        var repros = new List<DiscoveredRepro>();
+
+        foreach (var manifestPath in Directory.EnumerateFiles(_reprosPath, "repro.json", SearchOption.AllDirectories))
+        {
+            repros.Add(LoadManifest(manifestPath));
+        }
+
+        ApplyDuplicateValidation(repros);
+
+        repros.Sort((left, right) =>
+        {
+            var leftKey = left.Manifest?.Id ?? left.RawId ?? left.RelativeManifestPath;
+            var rightKey = right.Manifest?.Id ?? right.RawId ?? right.RelativeManifestPath;
+            return string.Compare(leftKey, rightKey, StringComparison.OrdinalIgnoreCase);
+        });
+
+        return repros;
+    }
+
+    private DiscoveredRepro LoadManifest(string manifestPath)
+    {
+        var validation = new ManifestValidationResult();
+        ReproManifest? manifest = null;
+        string? rawId = null;
+
+        try
+        {
+            using var stream = File.OpenRead(manifestPath);
+            using var document = JsonDocument.Parse(stream);
+            manifest = _validator.Validate(document.RootElement, validation, out rawId);
+        }
+        catch (JsonException ex)
+        {
+            validation.AddError($"Invalid JSON: {ex.Message}");
+        }
+        catch (IOException ex)
+        {
+            validation.AddError($"Unable to read manifest: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            validation.AddError($"Unable to read manifest: {ex.Message}");
+        }
+
+        var directory = Path.GetDirectoryName(manifestPath)!;
+        var relativeManifestPath = Path.GetRelativePath(_rootPath, manifestPath);
+
+        var projectFiles = Directory.GetFiles(directory, "*.csproj", SearchOption.TopDirectoryOnly);
+        string? projectPath = null;
+
+        if (projectFiles.Length == 0)
+        {
+            validation.AddError("No project file (*.csproj) found in repro directory.");
+        }
+        else if (projectFiles.Length > 1)
+        {
+            validation.AddError("Multiple project files found in repro directory. Only one project is supported.");
+        }
+        else
+        {
+            projectPath = projectFiles[0];
+        }
+
+        return new DiscoveredRepro(_rootPath, directory, manifestPath, relativeManifestPath, projectPath, manifest, validation, rawId);
+    }
+
+    private void ApplyDuplicateValidation(List<DiscoveredRepro> repros)
+    {
+        var groups = repros
+            .Where(r => !string.IsNullOrWhiteSpace(r.Manifest?.Id ?? r.RawId))
+            .GroupBy(r => (r.Manifest?.Id ?? r.RawId)!, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var group in groups)
+        {
+            if (group.Count() <= 1)
+            {
+                continue;
+            }
+
+            var allPaths = group
+                .Select(r => r.RelativeManifestPath.Replace(Path.DirectorySeparatorChar, '/'))
+                .ToList();
+
+            foreach (var repro in group)
+            {
+                var currentPath = repro.RelativeManifestPath.Replace(Path.DirectorySeparatorChar, '/');
+                var others = allPaths.Where(path => !string.Equals(path, currentPath, StringComparison.OrdinalIgnoreCase));
+                var othersList = string.Join(", ", others);
+                repro.Validation.AddError($"$.id: duplicate identifier also defined in {othersList}");
+            }
+        }
+    }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/ManifestValidationResult.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/ManifestValidationResult.cs
@@ -1,0 +1,18 @@
+namespace LiteDB.ReproRunner.Cli;
+
+internal sealed class ManifestValidationResult
+{
+    private readonly List<string> _errors = new();
+
+    public IReadOnlyList<string> Errors => _errors;
+
+    public bool IsValid => _errors.Count == 0;
+
+    public void AddError(string message)
+    {
+        if (!string.IsNullOrWhiteSpace(message))
+        {
+            _errors.Add(message.Trim());
+        }
+    }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/ManifestValidator.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/ManifestValidator.cs
@@ -1,0 +1,387 @@
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace LiteDB.ReproRunner.Cli;
+
+internal sealed class ManifestValidator
+{
+    private static readonly string[] AllowedStates = { "red", "green", "flaky" };
+    private static readonly Regex IdPattern = new("^[A-Za-z0-9_]+$", RegexOptions.Compiled);
+
+    public ReproManifest? Validate(JsonElement root, ManifestValidationResult validation, out string? rawId)
+    {
+        rawId = null;
+
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            validation.AddError("Manifest root must be a JSON object.");
+            return null;
+        }
+
+        var map = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        foreach (var property in root.EnumerateObject())
+        {
+            map[property.Name] = property.Value;
+        }
+
+        var allowed = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "id",
+            "title",
+            "issues",
+            "failingSince",
+            "timeoutSeconds",
+            "requiresParallel",
+            "defaultInstances",
+            "sharedDatabaseKey",
+            "args",
+            "tags",
+            "state"
+        };
+
+        foreach (var name in map.Keys)
+        {
+            if (!allowed.Contains(name))
+            {
+                validation.AddError($"$.{name}: unknown property.");
+            }
+        }
+
+        string? id = null;
+        if (map.TryGetValue("id", out var idElement))
+        {
+            if (idElement.ValueKind == JsonValueKind.String)
+            {
+                var value = idElement.GetString();
+                rawId = value;
+
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    validation.AddError("$.id: value must not be empty.");
+                }
+                else if (!IdPattern.IsMatch(value))
+                {
+                    validation.AddError($"$.id: must match ^[A-Za-z0-9_]+$ (got: {value}).");
+                }
+                else
+                {
+                    id = value;
+                }
+            }
+            else
+            {
+                validation.AddError($"$.id: expected string (got: {DescribeKind(idElement.ValueKind)}).");
+            }
+        }
+        else
+        {
+            validation.AddError("$.id: property is required.");
+        }
+
+        string? title = null;
+        if (map.TryGetValue("title", out var titleElement))
+        {
+            if (titleElement.ValueKind == JsonValueKind.String)
+            {
+                var value = titleElement.GetString();
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    validation.AddError("$.title: value must not be empty.");
+                }
+                else
+                {
+                    title = value!;
+                }
+            }
+            else
+            {
+                validation.AddError($"$.title: expected string (got: {DescribeKind(titleElement.ValueKind)}).");
+            }
+        }
+        else
+        {
+            validation.AddError("$.title: property is required.");
+        }
+
+        var issues = new List<string>();
+        if (map.TryGetValue("issues", out var issuesElement))
+        {
+            if (issuesElement.ValueKind == JsonValueKind.Array)
+            {
+                var index = 0;
+                foreach (var item in issuesElement.EnumerateArray())
+                {
+                    if (item.ValueKind != JsonValueKind.String)
+                    {
+                        validation.AddError($"$.issues[{index}]: expected string (got: {DescribeKind(item.ValueKind)}).");
+                    }
+                    else
+                    {
+                        var url = item.GetString();
+                        var trimmed = url?.Trim();
+                        if (string.IsNullOrWhiteSpace(trimmed) || !Uri.TryCreate(trimmed, UriKind.Absolute, out _))
+                        {
+                            validation.AddError($"$.issues[{index}]: '{url}' is not a valid absolute URL.");
+                        }
+                        else
+                        {
+                            issues.Add(trimmed);
+                        }
+                    }
+
+                    index++;
+                }
+            }
+            else
+            {
+                validation.AddError("$.issues: expected an array of strings.");
+            }
+        }
+
+        string? failingSince = null;
+        if (map.TryGetValue("failingSince", out var failingElement))
+        {
+            if (failingElement.ValueKind == JsonValueKind.String)
+            {
+                var value = failingElement.GetString();
+                var trimmed = value?.Trim();
+                if (!string.IsNullOrWhiteSpace(trimmed))
+                {
+                    failingSince = trimmed;
+                }
+                else
+                {
+                    validation.AddError("$.failingSince: value must not be empty when provided.");
+                }
+            }
+            else
+            {
+                validation.AddError("$.failingSince: expected string value.");
+            }
+        }
+
+        int? timeoutSeconds = null;
+        if (map.TryGetValue("timeoutSeconds", out var timeoutElement))
+        {
+            if (timeoutElement.ValueKind == JsonValueKind.Number && timeoutElement.TryGetInt32(out var timeout))
+            {
+                if (timeout < 1 || timeout > 36000)
+                {
+                    validation.AddError("$.timeoutSeconds: expected integer between 1 and 36000.");
+                }
+                else
+                {
+                    timeoutSeconds = timeout;
+                }
+            }
+            else
+            {
+                validation.AddError("$.timeoutSeconds: expected integer value.");
+            }
+        }
+        else
+        {
+            validation.AddError("$.timeoutSeconds: property is required.");
+        }
+
+        bool? requiresParallel = null;
+        if (map.TryGetValue("requiresParallel", out var parallelElement))
+        {
+            if (parallelElement.ValueKind == JsonValueKind.True || parallelElement.ValueKind == JsonValueKind.False)
+            {
+                requiresParallel = parallelElement.GetBoolean();
+            }
+            else
+            {
+                validation.AddError("$.requiresParallel: expected boolean value.");
+            }
+        }
+        else
+        {
+            validation.AddError("$.requiresParallel: property is required.");
+        }
+
+        int? defaultInstances = null;
+        if (map.TryGetValue("defaultInstances", out var instancesElement))
+        {
+            if (instancesElement.ValueKind == JsonValueKind.Number && instancesElement.TryGetInt32(out var instances))
+            {
+                if (instances < 1)
+                {
+                    validation.AddError("$.defaultInstances: expected integer >= 1.");
+                }
+                else
+                {
+                    defaultInstances = instances;
+                }
+            }
+            else
+            {
+                validation.AddError("$.defaultInstances: expected integer value.");
+            }
+        }
+        else
+        {
+            validation.AddError("$.defaultInstances: property is required.");
+        }
+
+        string? sharedDatabaseKey = null;
+        if (map.TryGetValue("sharedDatabaseKey", out var sharedElement))
+        {
+            if (sharedElement.ValueKind == JsonValueKind.String)
+            {
+                var value = sharedElement.GetString();
+                var trimmed = value?.Trim();
+                if (string.IsNullOrWhiteSpace(trimmed))
+                {
+                    validation.AddError("$.sharedDatabaseKey: value must not be empty when provided.");
+                }
+                else
+                {
+                    sharedDatabaseKey = trimmed;
+                }
+            }
+            else
+            {
+                validation.AddError("$.sharedDatabaseKey: expected string value.");
+            }
+        }
+
+        var args = new List<string>();
+        if (map.TryGetValue("args", out var argsElement))
+        {
+            if (argsElement.ValueKind == JsonValueKind.Array)
+            {
+                var index = 0;
+                foreach (var item in argsElement.EnumerateArray())
+                {
+                    if (item.ValueKind != JsonValueKind.String)
+                    {
+                        validation.AddError($"$.args[{index}]: expected string value.");
+                    }
+                    else
+                    {
+                        args.Add(item.GetString()!);
+                    }
+
+                    index++;
+                }
+            }
+            else
+            {
+                validation.AddError("$.args: expected an array of strings.");
+            }
+        }
+
+        var tags = new List<string>();
+        if (map.TryGetValue("tags", out var tagsElement))
+        {
+            if (tagsElement.ValueKind == JsonValueKind.Array)
+            {
+                var index = 0;
+                foreach (var item in tagsElement.EnumerateArray())
+                {
+                    if (item.ValueKind != JsonValueKind.String)
+                    {
+                        validation.AddError($"$.tags[{index}]: expected string value.");
+                    }
+                    else
+                    {
+                        var tag = item.GetString();
+                        var trimmed = tag?.Trim();
+                        if (!string.IsNullOrWhiteSpace(trimmed))
+                        {
+                            tags.Add(trimmed!);
+                        }
+                        else
+                        {
+                            validation.AddError($"$.tags[{index}]: value must not be empty.");
+                        }
+                    }
+
+                    index++;
+                }
+            }
+            else
+            {
+                validation.AddError("$.tags: expected an array of strings.");
+            }
+        }
+
+        string? state = null;
+        if (map.TryGetValue("state", out var stateElement))
+        {
+            if (stateElement.ValueKind == JsonValueKind.String)
+            {
+                var value = stateElement.GetString()?.Trim().ToLowerInvariant();
+                if (string.IsNullOrEmpty(value) || !AllowedStates.Contains(value))
+                {
+                    validation.AddError("$.state: expected one of red, green, flaky.");
+                }
+                else
+                {
+                    state = value;
+                }
+            }
+            else
+            {
+                validation.AddError("$.state: expected string value.");
+            }
+        }
+        else
+        {
+            validation.AddError("$.state: property is required.");
+        }
+
+        if (requiresParallel == true)
+        {
+            if (defaultInstances.HasValue && defaultInstances.Value < 2)
+            {
+                validation.AddError("$.defaultInstances: must be >= 2 when requiresParallel is true.");
+            }
+
+            if (string.IsNullOrWhiteSpace(sharedDatabaseKey))
+            {
+                validation.AddError("$.sharedDatabaseKey: required when requiresParallel is true.");
+            }
+        }
+
+        if (id is null || title is null || timeoutSeconds is null || requiresParallel is null || defaultInstances is null || state is null)
+        {
+            return null;
+        }
+
+        var issuesArray = issues.Count > 0 ? issues.ToArray() : Array.Empty<string>();
+        var argsArray = args.Count > 0 ? args.ToArray() : Array.Empty<string>();
+        var tagsArray = tags.Count > 0 ? tags.ToArray() : Array.Empty<string>();
+
+        return new ReproManifest(
+            id,
+            title,
+            issuesArray,
+            failingSince,
+            timeoutSeconds.Value,
+            requiresParallel.Value,
+            defaultInstances.Value,
+            sharedDatabaseKey,
+            argsArray,
+            tagsArray,
+            state);
+    }
+
+    private static string DescribeKind(JsonValueKind kind)
+    {
+        return kind switch
+        {
+            JsonValueKind.Array => "array",
+            JsonValueKind.Object => "object",
+            JsonValueKind.String => "string",
+            JsonValueKind.Number => "number",
+            JsonValueKind.True => "boolean",
+            JsonValueKind.False => "boolean",
+            JsonValueKind.Null => "null",
+            _ => kind.ToString().ToLowerInvariant()
+        };
+    }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Program.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Program.cs
@@ -1,0 +1,109 @@
+using System.Threading;
+using LiteDB.ReproRunner.Cli.Commands;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace LiteDB.ReproRunner.Cli;
+
+internal static class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        using var cts = new CancellationTokenSource();
+
+        Console.CancelKeyPress += (_, eventArgs) =>
+        {
+            eventArgs.Cancel = true;
+            cts.Cancel();
+        };
+
+        var (filteredArgs, rootOverride) = ExtractGlobalOptions(args);
+        var console = AnsiConsole.Create(new AnsiConsoleSettings());
+        var registrar = new TypeRegistrar();
+        registrar.RegisterInstance(typeof(IAnsiConsole), console);
+        registrar.RegisterInstance(typeof(ReproExecutor), new ReproExecutor());
+        registrar.RegisterInstance(typeof(ReproRootLocator), new ReproRootLocator(rootOverride));
+        registrar.RegisterInstance(typeof(CancellationToken), cts.Token);
+
+        var app = new CommandApp(registrar);
+        app.Configure(config =>
+        {
+            config.SetApplicationName("repro-runner");
+            config.AddCommand<ListCommand>("list").WithDescription("List discovered repros and highlight invalid manifests.");
+            config.AddCommand<ShowCommand>("show").WithDescription("Display manifest metadata for a repro.");
+            config.AddCommand<ValidateCommand>("validate").WithDescription("Validate repro manifests.");
+            config.AddCommand<RunCommand>("run").WithDescription("Execute repros against package and source builds.");
+        });
+
+        try
+        {
+            return await app.RunAsync(filteredArgs).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            console.MarkupLine("[yellow]Execution cancelled.[/]");
+            return 1;
+        }
+        catch (CommandRuntimeException ex)
+        {
+            console.WriteException(ex, ExceptionFormats.ShortenEverything);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            console.WriteException(ex, ExceptionFormats.ShortenEverything);
+            return 1;
+        }
+    }
+
+    private static (string[] FilteredArgs, string? RootOverride) ExtractGlobalOptions(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            return (Array.Empty<string>(), null);
+        }
+
+        var filtered = new List<string>();
+        string? rootOverride = null;
+        var index = 0;
+
+        while (index < args.Length)
+        {
+            var token = args[index];
+
+            if (!token.StartsWith("-", StringComparison.Ordinal))
+            {
+                break;
+            }
+
+            if (token == "--root")
+            {
+                index++;
+                if (index >= args.Length)
+                {
+                    throw new InvalidOperationException("--root requires a path.");
+                }
+
+                rootOverride = args[index];
+                index++;
+                continue;
+            }
+
+            if (token == "--")
+            {
+                filtered.Add(token);
+                index++;
+                break;
+            }
+
+            break;
+        }
+
+        for (; index < args.Length; index++)
+        {
+            filtered.Add(args[index]);
+        }
+
+        return (filtered.ToArray(), rootOverride);
+    }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Properties/AssemblyInfo.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("LiteDB.ReproRunner.Tests")]

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/ReproExecutor.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/ReproExecutor.cs
@@ -1,0 +1,219 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace LiteDB.ReproRunner.Cli;
+
+internal sealed class ReproExecutor
+{
+    public ReproExecutor()
+    {
+    }
+
+    public async Task<ReproExecutionResult> ExecuteAsync(DiscoveredRepro repro, bool useProjectReference, int instances, int timeoutSeconds, CancellationToken cancellationToken)
+    {
+        if (repro.ProjectPath is null)
+        {
+            return new ReproExecutionResult(useProjectReference, false, 2, TimeSpan.Zero);
+        }
+
+        var manifest = repro.Manifest ?? throw new InvalidOperationException("Manifest is required to execute a repro.");
+        var projectPath = repro.ProjectPath;
+        var projectDirectory = Path.GetDirectoryName(projectPath)!;
+        var stopwatch = Stopwatch.StartNew();
+
+        var buildExitCode = await RunProcessAsync(
+            projectDirectory,
+            new[]
+            {
+                "build",
+                projectPath,
+                "-c", "Release",
+                $"-p:UseProjectReference={(useProjectReference ? "true" : "false")}",
+                "--nologo"
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (buildExitCode != 0)
+        {
+            stopwatch.Stop();
+            return new ReproExecutionResult(useProjectReference, false, buildExitCode, stopwatch.Elapsed);
+        }
+
+        var sharedKey = !string.IsNullOrWhiteSpace(manifest.SharedDatabaseKey) ? manifest.SharedDatabaseKey! : manifest.Id;
+        var runIdentifier = Guid.NewGuid().ToString("N");
+        var sharedRoot = Path.Combine(Path.GetTempPath(), "LiteDB.ReproRunner", sharedKey, runIdentifier);
+        Directory.CreateDirectory(sharedRoot);
+
+        var exitCode = await RunInstancesAsync(
+            manifest,
+            projectDirectory,
+            projectPath,
+            useProjectReference,
+            instances,
+            timeoutSeconds,
+            sharedRoot,
+            cancellationToken).ConfigureAwait(false);
+
+        stopwatch.Stop();
+        return new ReproExecutionResult(useProjectReference, exitCode == 0, exitCode, stopwatch.Elapsed);
+    }
+
+    private async Task<int> RunInstancesAsync(
+        ReproManifest manifest,
+        string projectDirectory,
+        string projectPath,
+        bool useProjectReference,
+        int instances,
+        int timeoutSeconds,
+        string sharedRoot,
+        CancellationToken cancellationToken)
+    {
+        var runArgs = new List<string>
+        {
+            "run",
+            "--project", projectPath,
+            "-c", "Release",
+            "--no-build",
+            $"-p:UseProjectReference={(useProjectReference ? "true" : "false")}",
+        };
+
+        if (manifest.Args.Count > 0)
+        {
+            runArgs.Add("--");
+            runArgs.AddRange(manifest.Args);
+        }
+
+        var processes = new List<Process>();
+
+        try
+        {
+            for (var index = 0; index < instances; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var startInfo = CreateStartInfo(projectDirectory, runArgs);
+                startInfo.Environment["LITEDB_RR_SHARED_DB"] = sharedRoot;
+                startInfo.Environment["LITEDB_RR_INSTANCE_INDEX"] = index.ToString();
+                startInfo.Environment["LITEDB_RR_TOTAL_INSTANCES"] = instances.ToString();
+
+                var process = Process.Start(startInfo);
+                if (process is null)
+                {
+                    throw new InvalidOperationException("Failed to start repro process.");
+                }
+
+                processes.Add(process);
+            }
+
+            var timeout = TimeSpan.FromSeconds(timeoutSeconds);
+            var waitTasks = processes.Select(p => p.WaitForExitAsync(cancellationToken)).ToList();
+            var timeoutTask = Task.Delay(timeout, cancellationToken);
+            var completed = await Task.WhenAny(Task.WhenAll(waitTasks), timeoutTask).ConfigureAwait(false);
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                throw new OperationCanceledException(cancellationToken);
+            }
+
+            if (completed == timeoutTask)
+            {
+                foreach (var process in processes)
+                {
+                    TryKill(process);
+                }
+
+                return 1;
+            }
+
+            var exitCode = 0;
+
+            for (var index = 0; index < processes.Count; index++)
+            {
+                var process = processes[index];
+                if (process.ExitCode != 0)
+                {
+                    exitCode = exitCode == 0 ? process.ExitCode : exitCode;
+                }
+            }
+
+            return exitCode;
+        }
+        finally
+        {
+            foreach (var process in processes)
+            {
+                if (!process.HasExited)
+                {
+                    TryKill(process);
+                }
+
+                process.Dispose();
+            }
+        }
+    }
+
+    private static ProcessStartInfo CreateStartInfo(string workingDirectory, IEnumerable<string> arguments)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        return startInfo;
+    }
+
+    private async Task<int> RunProcessAsync(string workingDirectory, IEnumerable<string> arguments, CancellationToken cancellationToken)
+    {
+        var startInfo = CreateStartInfo(workingDirectory, arguments);
+
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start process.");
+
+        var outputPump = DrainStreamAsync(process.StandardOutput, cancellationToken);
+        var errorPump = DrainStreamAsync(process.StandardError, cancellationToken);
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        await Task.WhenAll(outputPump, errorPump).ConfigureAwait(false);
+
+        return process.ExitCode;
+    }
+
+    private static async Task DrainStreamAsync(StreamReader reader, CancellationToken cancellationToken)
+    {
+        var buffer = new char[1024];
+        while (!reader.EndOfStream)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var read = await reader.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                break;
+            }
+        }
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}
+
+internal readonly record struct ReproExecutionResult(bool UseProjectReference, bool Reproduced, int ExitCode, TimeSpan Duration);

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/ReproManifest.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/ReproManifest.cs
@@ -1,0 +1,52 @@
+namespace LiteDB.ReproRunner.Cli;
+
+internal sealed class ReproManifest
+{
+    public ReproManifest(
+        string id,
+        string title,
+        IReadOnlyList<string> issues,
+        string? failingSince,
+        int timeoutSeconds,
+        bool requiresParallel,
+        int defaultInstances,
+        string? sharedDatabaseKey,
+        IReadOnlyList<string> args,
+        IReadOnlyList<string> tags,
+        string state)
+    {
+        Id = id;
+        Title = title;
+        Issues = issues;
+        FailingSince = failingSince;
+        TimeoutSeconds = timeoutSeconds;
+        RequiresParallel = requiresParallel;
+        DefaultInstances = defaultInstances;
+        SharedDatabaseKey = sharedDatabaseKey;
+        Args = args;
+        Tags = tags;
+        State = state;
+    }
+
+    public string Id { get; }
+
+    public string Title { get; }
+
+    public IReadOnlyList<string> Issues { get; }
+
+    public string? FailingSince { get; }
+
+    public int TimeoutSeconds { get; }
+
+    public bool RequiresParallel { get; }
+
+    public int DefaultInstances { get; }
+
+    public string? SharedDatabaseKey { get; }
+
+    public IReadOnlyList<string> Args { get; }
+
+    public IReadOnlyList<string> Tags { get; }
+
+    public string State { get; }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/ReproRootLocator.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/ReproRootLocator.cs
@@ -1,0 +1,73 @@
+namespace LiteDB.ReproRunner.Cli;
+
+internal sealed class ReproRootLocator
+{
+    private readonly string? _defaultRoot;
+
+    public ReproRootLocator(string? defaultRoot = null)
+    {
+        _defaultRoot = string.IsNullOrWhiteSpace(defaultRoot) ? null : defaultRoot;
+    }
+
+    public string ResolveRoot(string? rootOverride)
+    {
+        var candidateRoot = string.IsNullOrWhiteSpace(rootOverride) ? _defaultRoot : rootOverride;
+
+        if (!string.IsNullOrEmpty(candidateRoot))
+        {
+            var candidate = Path.GetFullPath(candidateRoot!);
+            var resolved = TryResolveRoot(candidate);
+            if (resolved is null)
+            {
+                throw new InvalidOperationException($"Unable to locate a Repros directory under '{candidate}'.");
+            }
+
+            return resolved;
+        }
+
+        var searchRoots = new List<DirectoryInfo>
+        {
+            new DirectoryInfo(Directory.GetCurrentDirectory())
+        };
+
+        var baseDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+        if (!searchRoots.Any(d => string.Equals(d.FullName, baseDirectory.FullName, StringComparison.Ordinal)))
+        {
+            searchRoots.Add(baseDirectory);
+        }
+
+        foreach (var start in searchRoots)
+        {
+            var current = start;
+
+            while (current is not null)
+            {
+                var resolved = TryResolveRoot(current.FullName);
+                if (resolved is not null)
+                {
+                    return resolved;
+                }
+
+                current = current.Parent;
+            }
+        }
+
+        throw new InvalidOperationException("Unable to locate the LiteDB.ReproRunner directory. Use --root to specify the path.");
+    }
+
+    private static string? TryResolveRoot(string path)
+    {
+        if (Directory.Exists(Path.Combine(path, "Repros")))
+        {
+            return Path.GetFullPath(path);
+        }
+
+        var candidate = Path.Combine(path, "LiteDB.ReproRunner");
+        if (Directory.Exists(Path.Combine(candidate, "Repros")))
+        {
+            return Path.GetFullPath(candidate);
+        }
+
+        return null;
+    }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/TypeRegistrar.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/TypeRegistrar.cs
@@ -1,0 +1,79 @@
+using Microsoft.Extensions.DependencyInjection;
+using Spectre.Console.Cli;
+
+namespace LiteDB.ReproRunner.Cli;
+
+internal sealed class TypeRegistrar : ITypeRegistrar
+{
+    private readonly IServiceCollection _services = new ServiceCollection();
+
+    public void Register(Type service, Type implementation)
+    {
+        if (service is null)
+        {
+            throw new ArgumentNullException(nameof(service));
+        }
+
+        if (implementation is null)
+        {
+            throw new ArgumentNullException(nameof(implementation));
+        }
+
+        _services.AddSingleton(service, implementation);
+    }
+
+    public void RegisterInstance(Type service, object implementation)
+    {
+        if (service is null)
+        {
+            throw new ArgumentNullException(nameof(service));
+        }
+
+        if (implementation is null)
+        {
+            throw new ArgumentNullException(nameof(implementation));
+        }
+
+        _services.AddSingleton(service, implementation);
+    }
+
+    public void RegisterLazy(Type service, Func<object> factory)
+    {
+        if (service is null)
+        {
+            throw new ArgumentNullException(nameof(service));
+        }
+
+        if (factory is null)
+        {
+            throw new ArgumentNullException(nameof(factory));
+        }
+
+        _services.AddSingleton(service, _ => factory());
+    }
+
+    public ITypeResolver Build()
+    {
+        return new TypeResolver(_services.BuildServiceProvider());
+    }
+
+    private sealed class TypeResolver : ITypeResolver, IDisposable
+    {
+        private readonly ServiceProvider _provider;
+
+        public TypeResolver(ServiceProvider provider)
+        {
+            _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        }
+
+        public object? Resolve(Type? type)
+        {
+            return type is null ? null : _provider.GetService(type);
+        }
+
+        public void Dispose()
+        {
+            _provider.Dispose();
+        }
+    }
+}

--- a/LiteDB.ReproRunner/README.md
+++ b/LiteDB.ReproRunner/README.md
@@ -1,0 +1,226 @@
+# LiteDB ReproRunner
+
+The LiteDB ReproRunner is a small command-line harness that discovers, validates, and executes the
+**reproduction projects** ("repros") that live in this repository. Each repro is an isolated console
+application that demonstrates a past or current LiteDB issue. ReproRunner standardises the folder
+layout, metadata, and execution model so that contributors and CI machines can list, validate, and run
+repros deterministically.
+
+## Repository layout
+
+```
+LiteDB.ReproRunner/
+  README.md                         # You are here
+  LiteDB.ReproRunner.Cli/           # The command-line runner project
+  Repros/                           # One subfolder per repro
+    Issue_2561_TransactionMonitor/
+      Issue_2561_TransactionMonitor.csproj
+      Program.cs
+      repro.json
+      README.md
+```
+
+Each repro folder contains:
+
+* A `.csproj` console project that can target the NuGet package or the in-repo sources.
+* A `Program.cs` implementing the actual reproduction logic.
+* A `repro.json` manifest with metadata required by the CLI.
+* A short `README.md` describing the scenario and expected outcome.
+
+## Quick start
+
+Build the CLI and list the currently registered repros:
+
+```bash
+dotnet run --project LiteDB.ReproRunner/LiteDB.ReproRunner.Cli -- list
+```
+
+Show the manifest for a particular repro:
+
+```bash
+dotnet run --project LiteDB.ReproRunner/LiteDB.ReproRunner.Cli -- show Issue_2561_TransactionMonitor
+```
+
+Validate all manifests (exit code `2` means one or more manifests are invalid):
+
+```bash
+dotnet run --project LiteDB.ReproRunner/LiteDB.ReproRunner.Cli -- validate
+```
+
+Run a repro against the in-repo LiteDB sources:
+
+```bash
+dotnet run --project LiteDB.ReproRunner/LiteDB.ReproRunner.Cli -- run Issue_2561_TransactionMonitor --useProjectRef
+```
+
+## Writing a new repro
+
+1. **Create the folder** under `LiteDB.ReproRunner/Repros/`. The folder name should match the manifest
+   identifier, for example `Issue_1234_MyScenario/`.
+
+2. **Scaffold a console project** targeting `.NET 8` that toggles between the NuGet package and the
+   in-repo project using the `UseProjectReference` property:
+
+   ```xml
+   <Project Sdk="Microsoft.NET.Sdk">
+     <PropertyGroup>
+       <OutputType>Exe</OutputType>
+       <TargetFramework>net8.0</TargetFramework>
+       <ImplicitUsings>enable</ImplicitUsings>
+       <Nullable>enable</Nullable>
+       <UseProjectReference Condition="'$(UseProjectReference)' == ''">false</UseProjectReference>
+       <LiteDBPackageVersion Condition="'$(LiteDBPackageVersion)' == ''">5.0.20</LiteDBPackageVersion>
+     </PropertyGroup>
+
+     <ItemGroup Condition="'$(UseProjectReference)' == 'true'">
+       <ProjectReference Include="..\..\..\LiteDB\LiteDB.csproj" />
+     </ItemGroup>
+
+     <ItemGroup Condition="'$(UseProjectReference)' != 'true'">
+       <PackageReference Include="LiteDB" Version="$(LiteDBPackageVersion)" />
+     </ItemGroup>
+   </Project>
+   ```
+
+3. **Implement `Program.cs`** so that it:
+
+   * Performs the minimal work necessary to reproduce the issue.
+   * Exits with code `0` when the expected (possibly buggy) behaviour is observed.
+   * Exits non-zero when the repro cannot trigger the behaviour.
+   * Reads the orchestration environment variables:
+     * `LITEDB_RR_SHARED_DB` – path to the shared working directory for multi-process repros.
+     * `LITEDB_RR_INSTANCE_INDEX` – zero-based index for the current process.
+
+4. **Author `repro.json`** with the required metadata (see schema below). The CLI refuses to run
+   invalid manifests unless `--skipValidation` is provided.
+
+5. **Add a `README.md`** to document the scenario, relevant issue links, the expected outcome, and any
+   local troubleshooting tips.
+
+6. **Update CI** if the repro should be part of the smoke suite (typically red or flaky repros).
+
+## Manifest schema
+
+Every repro ships with a `repro.json` manifest. The CLI validates the manifest at discovery time and
+exposes the metadata in the `list`, `show`, and `run` commands.
+
+| Field                | Type          | Required | Notes |
+| -------------------- | ------------- | -------- | ----- |
+| `id`                 | string        | yes      | Unique identifier matching `^[A-Za-z0-9_]+$` and the folder name. |
+| `title`              | string        | yes      | Human readable summary. |
+| `issues`             | string[]      | no       | Absolute URLs to related GitHub issues. |
+| `failingSince`       | string        | no       | First version that exhibited the failure (e.g. `5.0.x`). |
+| `timeoutSeconds`     | int           | yes      | Global timeout (1–36000 seconds). |
+| `requiresParallel`   | bool          | yes      | `true` when the repro needs multiple processes. |
+| `defaultInstances`   | int           | yes      | Default process count (`≥ 2` when `requiresParallel=true`). |
+| `sharedDatabaseKey`  | string        | conditional | Required when `requiresParallel=true`, used to derive a shared working directory. |
+| `args`               | string[]      | no       | Extra arguments passed to `dotnet run --`. |
+| `tags`               | string[]      | no       | Arbitrary labels for filtering (`list` prints them). |
+| `state`              | enum          | yes      | One of `red`, `green`, or `flaky`. |
+
+Unknown properties are rejected to keep the schema tight. The CLI also validates that each repro
+folder contains exactly one `.csproj` file.
+
+### Validation output
+
+`repro-runner validate` prints `VALID` or `INVALID` lines for each manifest. Errors are grouped under
+an `INVALID` header that includes the relative path. Example:
+
+```
+INVALID  Repros/Issue_999_Bad/repro.json
+  - $.timeoutSeconds: expected integer between 1 and 36000.
+  - $.id: must match ^[A-Za-z0-9_]+$ (got: Issue 999 Bad)
+```
+
+`repro-runner list --strict` returns exit code `2` when any manifest is invalid; without `--strict`
+it merely prints the warnings.
+
+## CLI usage
+
+```
+Usage: repro-runner [--root <path>] <command> [options]
+```
+
+Global option:
+
+* `--root <path>` – Override the discovery root. Defaults to the nearest `LiteDB.ReproRunner` folder.
+
+Commands:
+
+* `list [--strict]` – Lists all discovered repros with their state, timeout, tags, and titles.
+* `show <id>` – Dumps the full manifest for a repro.
+* `validate [--all|--id <id>]` – Validates manifests. Exit code `2` indicates invalid manifests.
+* `run <id> [options]` – Executes a repro (see below).
+
+### Running repros
+
+```
+repro-runner run <id> [--useProjectRef|--usePackage] [--instances N] [--timeout S] [--skipValidation]
+```
+
+* `--useProjectRef` – Compile against the in-repo `LiteDB` project.
+* `--usePackage` – Use the NuGet package (default).
+* `--instances` – Override the number of processes to spawn. Must be ≥ 1 and ≥ 2 when the manifest
+  requires parallel execution.
+* `--timeout` – Override the manifest timeout (seconds).
+* `--skipValidation` – Run even when the manifest is invalid (execution still requires the manifest to
+  parse successfully).
+
+The runner performs a `dotnet build -c Release` once, then launches `dotnet run --no-build` for each
+instance. Processes inherit the manifest arguments and receive the orchestration environment
+variables described earlier. The shared working directory is unique per invocation and lives under
+`%TEMP%/LiteDB.ReproRunner/<sharedDatabaseKey>/<guid>`.
+
+Timeouts are enforced across all processes. When the timeout elapses the runner terminates all child
+processes and returns exit code `1`.
+
+## Parallel repros
+
+Set `requiresParallel` to `true` and choose a descriptive `sharedDatabaseKey`. The key is used to build
+a deterministic folder for shared resources (for example, a LiteDB data file). Each process receives:
+
+* `LITEDB_RR_SHARED_DB` – The shared directory path.
+* `LITEDB_RR_INSTANCE_INDEX` – The zero-based process index.
+* `LITEDB_RR_TOTAL_INSTANCES` – Total instances spawned for this run.
+
+The repro code is responsible for coordinating work across instances, often by using the shared
+folder to create or open the same database file.
+
+## CI integration
+
+The GitHub Actions workflow builds the repository in Release mode, then runs:
+
+1. `repro-runner list --strict`
+2. `repro-runner validate`
+3. A smoke repro run (initially `Issue_2561_TransactionMonitor`)
+
+Any non-zero exit code fails the job, ensuring the manifests stay valid and at least one repro is
+exercised on every PR.
+
+## Troubleshooting
+
+* **Manifest fails validation** – Run `repro-runner show <id>` to inspect the parsed metadata. Most
+  errors reference the JSON path that needs attention.
+* **Build failures** – When `repro-runner run` fails to build, the `dotnet build` exit code is printed.
+  Re-run the command with `--useProjectRef` or `--usePackage` to pinpoint which configuration is
+  failing.
+* **Timeouts** – Use `--timeout` to temporarily raise the limit while debugging long-running repros.
+* **Custom LiteDB package version** – Pass `-p:LiteDBPackageVersion=<version>` through the CLI to
+  target a specific NuGet version. The property is forwarded to both build and run invocations.
+
+## FAQ
+
+**Why not use xUnit?** Repros often require multi-process coordination, timeouts, or package/project
+switching. The CLI gives us deterministic orchestration without constraining the repro to the xUnit
+lifecycle. Test suites can still shell out to `repro-runner` if desired.
+
+**How do I mark a repro as fixed?** Update `state` to `green`, adjust the README, and ensure the repro
+now exits `0` when the fix is present. Keeping the repro around prevents regressions.
+
+**Can I share helper code?** Keep repros isolated so they are self-documenting. If you must share
+helpers, place them next to the CLI and avoid coupling repros together.
+
+## Further reading
+
+* [Issue 2561 – TransactionMonitor finalizer crash](https://github.com/litedb-org/LiteDB/issues/2561)
+* `LiteDB.ReproRunner.Cli` source for the discovery/validation logic.

--- a/LiteDB.ReproRunner/Repros/Issue_2561_TransactionMonitor/Issue_2561_TransactionMonitor.csproj
+++ b/LiteDB.ReproRunner/Repros/Issue_2561_TransactionMonitor/Issue_2561_TransactionMonitor.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UseProjectReference Condition="'$(UseProjectReference)' == ''">false</UseProjectReference>
+    <LiteDBPackageVersion Condition="'$(LiteDBPackageVersion)' == ''">5.0.20</LiteDBPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(UseProjectReference)' == 'true'">
+    <ProjectReference Include="..\..\..\LiteDB\LiteDB.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseProjectReference)' != 'true'">
+    <PackageReference Include="LiteDB" Version="$(LiteDBPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.ReproRunner/Repros/Issue_2561_TransactionMonitor/Program.cs
+++ b/LiteDB.ReproRunner/Repros/Issue_2561_TransactionMonitor/Program.cs
@@ -1,0 +1,137 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using LiteDB;
+
+namespace Issue_2561_TransactionMonitor;
+
+internal static class Program
+{
+    private const string DefaultDatabaseName = "issue2561.db";
+
+    private static int Main()
+    {
+        try
+        {
+            Run();
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("Reproduction failed: {0}", ex);
+            return 1;
+        }
+    }
+
+    private static void Run()
+    {
+        var sharedRoot = Environment.GetEnvironmentVariable("LITEDB_RR_SHARED_DB");
+        var databaseDirectory = string.IsNullOrWhiteSpace(sharedRoot)
+            ? AppContext.BaseDirectory
+            : sharedRoot;
+
+        Directory.CreateDirectory(databaseDirectory);
+
+        var databasePath = Path.Combine(databaseDirectory, DefaultDatabaseName);
+        if (File.Exists(databasePath))
+        {
+            File.Delete(databasePath);
+        }
+
+        Console.WriteLine($"Using database: {databasePath}");
+
+        var connectionString = new ConnectionString
+        {
+            Filename = databasePath,
+            Connection = ConnectionType.Direct
+        };
+
+        using var database = new LiteDatabase(connectionString);
+        var collection = database.GetCollection<BsonDocument>("docs");
+
+        var engineField = typeof(LiteDatabase).GetField("_engine", BindingFlags.Instance | BindingFlags.NonPublic)
+                         ?? throw new InvalidOperationException("LiteDatabase._engine field not found.");
+        var engine = engineField.GetValue(database) ?? throw new InvalidOperationException("LiteDatabase engine unavailable.");
+        var engineType = engine.GetType();
+
+        var beginTrans = engineType.GetMethod("BeginTrans", BindingFlags.Public | BindingFlags.Instance)
+                         ?? throw new InvalidOperationException("LiteEngine.BeginTrans method not found.");
+        var rollback = engineType.GetMethod("Rollback", BindingFlags.Public | BindingFlags.Instance)
+                       ?? throw new InvalidOperationException("LiteEngine.Rollback method not found.");
+        var monitorField = engineType.GetField("_monitor", BindingFlags.NonPublic | BindingFlags.Instance)
+                          ?? throw new InvalidOperationException("LiteEngine._monitor field not found.");
+        var monitor = monitorField.GetValue(engine) ?? throw new InvalidOperationException("Transaction monitor unavailable.");
+        var monitorType = monitor.GetType();
+
+        var transactionsProperty = monitorType.GetProperty("Transactions", BindingFlags.Public | BindingFlags.Instance)
+                                 ?? throw new InvalidOperationException("TransactionMonitor.Transactions property not found.");
+        var releaseTransaction = monitorType.GetMethod("ReleaseTransaction", BindingFlags.Public | BindingFlags.Instance)
+                               ?? throw new InvalidOperationException("TransactionMonitor.ReleaseTransaction method not found.");
+
+        Console.WriteLine("Opening explicit transaction on main thread...");
+
+        if (!(beginTrans.Invoke(engine, Array.Empty<object>()) is bool began) || !began)
+        {
+            throw new InvalidOperationException("BeginTrans returned false; the transaction was not created.");
+        }
+
+        collection.Insert(new BsonDocument
+        {
+            ["_id"] = ObjectId.NewObjectId(),
+            ["description"] = "Issue 2561 transaction monitor repro",
+            ["createdAt"] = DateTime.UtcNow
+        });
+
+        var transactions = (IEnumerable<object>)(transactionsProperty.GetValue(monitor)
+                              ?? throw new InvalidOperationException("Transaction list is unavailable."));
+
+        var capturedTransaction = transactions.Single();
+        var reproObserved = new ManualResetEventSlim(false);
+        LiteException? observedException = null;
+
+        var worker = new Thread(() =>
+        {
+            try
+            {
+                releaseTransaction.Invoke(monitor, new[] { capturedTransaction });
+                Console.Error.WriteLine("ReleaseTransaction completed without throwing.");
+            }
+            catch (TargetInvocationException invocationException) when (invocationException.InnerException is LiteException liteException)
+            {
+                observedException = liteException;
+                Console.WriteLine("Observed LiteException from ReleaseTransaction on worker thread:");
+                Console.WriteLine(liteException);
+            }
+            finally
+            {
+                reproObserved.Set();
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "Issue2561-Repro-Worker"
+        };
+
+        worker.Start();
+
+        if (!reproObserved.Wait(TimeSpan.FromSeconds(10)))
+        {
+            throw new TimeoutException("Timed out waiting for ReleaseTransaction to finish.");
+        }
+
+        rollback.Invoke(engine, Array.Empty<object>());
+
+        if (observedException is null)
+        {
+            throw new InvalidOperationException("Expected LiteException was not observed.");
+        }
+
+        if (!observedException.Message.Contains("current thread must contains transaction parameter", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"LiteException did not contain expected message. Actual: {observedException.Message}");
+        }
+
+        Console.WriteLine("Repro succeeded: ReleaseTransaction threw on the wrong thread.");
+    }
+}

--- a/LiteDB.ReproRunner/Repros/Issue_2561_TransactionMonitor/README.md
+++ b/LiteDB.ReproRunner/Repros/Issue_2561_TransactionMonitor/README.md
@@ -1,0 +1,32 @@
+# Issue 2561 – TransactionMonitor finalizer crash
+
+This repro demonstrates [LiteDB #2561](https://github.com/litedb-org/LiteDB/issues/2561). The
+`TransactionMonitor` finalizer (`TransactionService.Dispose(false)`) executes on the GC finalizer thread,
+which violates the monitor’s expectation that the transaction belongs to the current thread. The
+resulting `LiteException` brings the process down with the message `current thread must contains
+transaction parameter`.
+
+## Scenario
+
+1. Open a `LiteDatabase` connection against a clean data file.
+2. Begin an explicit transaction on the main thread and perform a write.
+3. Use reflection to grab the `TransactionMonitor` and the `TransactionService` tracked for the main thread.
+4. Invoke `TransactionMonitor.ReleaseTransaction` from a different thread to mimic the finalizer’s behavior.
+
+The monitor throws the same `LiteException` that was captured in the original crash, proving that the
+guard fails when the finalizer thread releases the transaction.
+
+## Running the repro
+
+```bash
+dotnet run --project LiteDB.ReproRunner/Repros/Issue_2561_TransactionMonitor/Issue_2561_TransactionMonitor.csproj -c Release -p:UseProjectReference=true
+```
+
+By default the project references the NuGet package (`LiteDBPackageVersion` defaults to `5.0.20`). Pass
+`-p:LiteDBPackageVersion=<version>` to pin a different package, or `-p:UseProjectReference=true` to link
+against the in-repo sources. The ReproRunner CLI orchestrates those switches automatically.
+
+## Expected outcome
+
+The repro prints the captured `LiteException` and exits with code `0` once the message containing
+`current thread must contains transaction parameter` is observed.

--- a/LiteDB.ReproRunner/Repros/Issue_2561_TransactionMonitor/repro.json
+++ b/LiteDB.ReproRunner/Repros/Issue_2561_TransactionMonitor/repro.json
@@ -1,0 +1,13 @@
+{
+  "id": "Issue_2561_TransactionMonitor",
+  "title": "Transaction monitor finalizer runs on wrong thread",
+  "issues": ["https://github.com/litedb-org/LiteDB/issues/2561"],
+  "failingSince": "5.0.x",
+  "timeoutSeconds": 120,
+  "requiresParallel": false,
+  "defaultInstances": 1,
+  "sharedDatabaseKey": "issue2561",
+  "args": [],
+  "tags": ["transaction", "monitor", "finalizer"],
+  "state": "red"
+}

--- a/LiteDB.sln
+++ b/LiteDB.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.32328.378
@@ -18,6 +18,18 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.RollbackRepro", "LiteDB.RollbackRepro\LiteDB.RollbackRepro.csproj", "{BE1D6CA2-134A-404A-8F1A-C48E4E240159}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Misc", "Misc", "{D455AC29-7847-4DF4-AD06-69042F8B8885}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "LiteDB.ReproRunner", "LiteDB.ReproRunner", "{C172DFBD-9BFC-41A4-82B9-5B9BBC90850D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.ReproRunner.Cli", "LiteDB.ReproRunner\LiteDB.ReproRunner.Cli\LiteDB.ReproRunner.Cli.csproj", "{CDCF5EED-50F3-4790-B180-10B203EE6B4B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Repros", "Repros", "{B0BD59D3-0D10-42BF-A744-533473577C8C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Issue_2561_TransactionMonitor", "LiteDB.ReproRunner\Repros\Issue_2561_TransactionMonitor\Issue_2561_TransactionMonitor.csproj", "{B5BF3DFE-5F26-447A-AF5A-60C6E3D341AC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{3B786621-2B82-4C69-8FE9-3889ECB36E75}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.ReproRunner.Tests", "LiteDB.ReproRunner.Tests\LiteDB.ReproRunner.Tests.csproj", "{3EF8E506-B57B-4A98-AD09-E687F9DC515D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -53,6 +65,18 @@ Global
 		{BE1D6CA2-134A-404A-8F1A-C48E4E240159}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BE1D6CA2-134A-404A-8F1A-C48E4E240159}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BE1D6CA2-134A-404A-8F1A-C48E4E240159}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CDCF5EED-50F3-4790-B180-10B203EE6B4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CDCF5EED-50F3-4790-B180-10B203EE6B4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CDCF5EED-50F3-4790-B180-10B203EE6B4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CDCF5EED-50F3-4790-B180-10B203EE6B4B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5BF3DFE-5F26-447A-AF5A-60C6E3D341AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5BF3DFE-5F26-447A-AF5A-60C6E3D341AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5BF3DFE-5F26-447A-AF5A-60C6E3D341AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5BF3DFE-5F26-447A-AF5A-60C6E3D341AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3EF8E506-B57B-4A98-AD09-E687F9DC515D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3EF8E506-B57B-4A98-AD09-E687F9DC515D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3EF8E506-B57B-4A98-AD09-E687F9DC515D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3EF8E506-B57B-4A98-AD09-E687F9DC515D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -66,5 +90,9 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{E8763934-E46A-4AAF-A2B5-E812016DAF84} = {D455AC29-7847-4DF4-AD06-69042F8B8885}
 		{BE1D6CA2-134A-404A-8F1A-C48E4E240159} = {D455AC29-7847-4DF4-AD06-69042F8B8885}
+		{CDCF5EED-50F3-4790-B180-10B203EE6B4B} = {C172DFBD-9BFC-41A4-82B9-5B9BBC90850D}
+		{B0BD59D3-0D10-42BF-A744-533473577C8C} = {C172DFBD-9BFC-41A4-82B9-5B9BBC90850D}
+		{B5BF3DFE-5F26-447A-AF5A-60C6E3D341AC} = {B0BD59D3-0D10-42BF-A744-533473577C8C}
+		{3EF8E506-B57B-4A98-AD09-E687F9DC515D} = {3B786621-2B82-4C69-8FE9-3889ECB36E75}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- replace the sample console project with a minimal reproduction of issue #2561 by calling the transaction monitor from a foreign thread
- allow switching between the LiteDB 5.0.20 NuGet package and the local LiteDB project via the `UseLocalLiteDb` MSBuild property

## Testing
- `dotnet run --project ConsoleApp1` *(fails with the expected LiteException reproduced from the issue)*
- `dotnet run --project ConsoleApp1 -p:UseLocalLiteDb=true` *(fails with the same exception while targeting the local project)*

------
https://chatgpt.com/codex/tasks/task_e_68d915db3c40832abdbbe248b0cb6cd0