### PR TITLE
Add state-aware repro evaluation and JSON reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,5 +55,13 @@ jobs:
       - name: Validate manifests
         run: dotnet run --project LiteDB.ReproRunner/LiteDB.ReproRunner.Cli -- validate
 
-      - name: Run Issue 2561 repro
-        run: dotnet run --project LiteDB.ReproRunner/LiteDB.ReproRunner.Cli -- run Issue_2561_TransactionMonitor --useProjectRef
+      # Execute every repro and emit a JSON summary that downstream automation can inspect.
+      - name: Run repro suite
+        run: dotnet run --project LiteDB.ReproRunner/LiteDB.ReproRunner.Cli -- run --all --report repro-summary.json
+
+      # Publish the summary so other jobs or manual reviewers can review the latest outcomes.
+      - name: Upload repro summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: repro-summary
+          path: repro-summary.json

--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,4 @@ FakesAssemblies/
 # Uncomment if necessary however generally it will be regenerated when needed
 #!**/packages/repositories.config
 /LiteDB.BadJsonTest
+repro-summary.json

--- a/LiteDB.ReproRunner.Tests/ManifestValidatorTests.cs
+++ b/LiteDB.ReproRunner.Tests/ManifestValidatorTests.cs
@@ -35,7 +35,9 @@ public sealed class ManifestValidatorTests
         Assert.Equal("Issue_000_Demo", manifest!.Id);
         Assert.Equal("Issue_000_Demo", rawId);
         Assert.Equal(120, manifest.TimeoutSeconds);
-        Assert.Equal("red", manifest.State);
+        Assert.Equal(ReproState.Red, manifest.State);
+        Assert.Null(manifest.ExpectedOutcomes.Package);
+        Assert.Null(manifest.ExpectedOutcomes.Latest);
     }
 
     [Fact]
@@ -60,5 +62,73 @@ public sealed class ManifestValidatorTests
 
         Assert.Null(manifest);
         Assert.Contains(validation.Errors, error => error.Contains("$.timeoutSeconds", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ParsesExpectedOutcomes()
+    {
+        const string json = """
+        {
+          "id": "Issue_002",
+          "title": "Expected outcomes",
+          "timeoutSeconds": 120,
+          "requiresParallel": false,
+          "defaultInstances": 1,
+          "state": "green",
+          "expectedOutcomes": {
+            "package": {
+              "kind": "hardFail",
+              "exitCode": -5,
+              "logContains": "NetworkException"
+            },
+            "latest": {
+              "kind": "noRepro"
+            }
+          }
+        }
+        """;
+
+        using var document = JsonDocument.Parse(json);
+        var validation = new ManifestValidationResult();
+        var validator = new ManifestValidator();
+
+        var manifest = validator.Validate(document.RootElement, validation, out _);
+
+        Assert.NotNull(manifest);
+        Assert.True(validation.IsValid);
+        Assert.Equal(ReproOutcomeKind.HardFail, manifest!.ExpectedOutcomes.Package!.Kind);
+        Assert.Equal(-5, manifest.ExpectedOutcomes.Package!.ExitCode);
+        Assert.Equal("NetworkException", manifest.ExpectedOutcomes.Package!.LogContains);
+        Assert.Equal(ReproOutcomeKind.NoRepro, manifest.ExpectedOutcomes.Latest!.Kind);
+    }
+
+    [Fact]
+    public void Validate_FailsWhenLatestHardFailDeclared()
+    {
+        const string json = """
+        {
+          "id": "Issue_003",
+          "title": "Invalid latest expectation",
+          "timeoutSeconds": 120,
+          "requiresParallel": false,
+          "defaultInstances": 1,
+          "state": "red",
+          "expectedOutcomes": {
+            "latest": {
+              "kind": "hardFail"
+            }
+          }
+        }
+        """;
+
+        using var document = JsonDocument.Parse(json);
+        var validation = new ManifestValidationResult();
+        var validator = new ManifestValidator();
+
+        var manifest = validator.Validate(document.RootElement, validation, out _);
+
+        Assert.NotNull(manifest);
+        Assert.False(validation.IsValid);
+        Assert.Contains(validation.Errors, error => error.Contains("expectedOutcomes.latest.kind", StringComparison.Ordinal));
     }
 }

--- a/LiteDB.ReproRunner.Tests/ReproOutcomeEvaluatorTests.cs
+++ b/LiteDB.ReproRunner.Tests/ReproOutcomeEvaluatorTests.cs
@@ -1,0 +1,119 @@
+using System;
+using LiteDB.ReproRunner.Cli.Execution;
+using LiteDB.ReproRunner.Cli.Manifests;
+
+namespace LiteDB.ReproRunner.Tests;
+
+public sealed class ReproOutcomeEvaluatorTests
+{
+    private static readonly ReproOutcomeEvaluator Evaluator = new();
+
+    [Fact]
+    public void Evaluate_AllowsRedReproWhenLatestStillFails()
+    {
+        var manifest = CreateManifest(ReproState.Red);
+        var packageResult = CreateResult(useProjectReference: false, exitCode: 0);
+        var latestResult = CreateResult(useProjectReference: true, exitCode: 0);
+
+        var evaluation = Evaluator.Evaluate(manifest, packageResult, latestResult);
+
+        Assert.False(evaluation.ShouldFail);
+        Assert.True(evaluation.Package.Met);
+        Assert.True(evaluation.Latest.Met);
+    }
+
+    [Fact]
+    public void Evaluate_FailsGreenWhenLatestStillReproduces()
+    {
+        var manifest = CreateManifest(ReproState.Green);
+        var packageResult = CreateResult(false, 0);
+        var latestResult = CreateResult(true, 0);
+
+        var evaluation = Evaluator.Evaluate(manifest, packageResult, latestResult);
+
+        Assert.True(evaluation.ShouldFail);
+        Assert.True(evaluation.Package.Met);
+        Assert.False(evaluation.Latest.Met);
+    }
+
+    [Fact]
+    public void Evaluate_RespectsHardFailExpectationWhenLogMatches()
+    {
+        var expectation = new ReproVariantOutcomeExpectations(
+            new ReproOutcomeExpectation(ReproOutcomeKind.HardFail, -5, "NetworkException"),
+            null);
+        var manifest = CreateManifest(ReproState.Green, expectation);
+        var packageResult = CreateResult(false, -5, "NetworkException at socket");
+
+        var evaluation = Evaluator.Evaluate(manifest, packageResult, null);
+
+        Assert.False(evaluation.Package.ShouldFail);
+        Assert.True(evaluation.Package.Met);
+        Assert.Equal(ReproOutcomeKind.HardFail, evaluation.Package.Expectation.Kind);
+    }
+
+    [Fact]
+    public void Evaluate_FailsHardFailWhenLogMissing()
+    {
+        var expectation = new ReproVariantOutcomeExpectations(
+            new ReproOutcomeExpectation(ReproOutcomeKind.HardFail, -5, "NetworkException"),
+            null);
+        var manifest = CreateManifest(ReproState.Green, expectation);
+        var packageResult = CreateResult(false, -5, "No matching text");
+
+        var evaluation = Evaluator.Evaluate(manifest, packageResult, null);
+
+        Assert.True(evaluation.Package.ShouldFail);
+        Assert.False(evaluation.Package.Met);
+        Assert.Contains("NetworkException", evaluation.Package.FailureReason);
+    }
+
+    [Fact]
+    public void Evaluate_WarnsFlakyLatestMismatch()
+    {
+        var manifest = CreateManifest(ReproState.Flaky);
+        var packageResult = CreateResult(false, 0);
+        var latestResult = CreateResult(true, 1);
+
+        var evaluation = Evaluator.Evaluate(manifest, packageResult, latestResult);
+
+        Assert.False(evaluation.ShouldFail);
+        Assert.True(evaluation.ShouldWarn);
+        Assert.True(evaluation.Package.Met);
+        Assert.False(evaluation.Latest.Met);
+    }
+
+    private static ReproManifest CreateManifest(ReproState state, ReproVariantOutcomeExpectations? expectations = null)
+    {
+        return new ReproManifest(
+            "Issue_Example",
+            "Example",
+            Array.Empty<string>(),
+            null,
+            120,
+            false,
+            1,
+            null,
+            Array.Empty<string>(),
+            Array.Empty<string>(),
+            state,
+            expectations ?? ReproVariantOutcomeExpectations.Empty);
+    }
+
+    private static ReproExecutionResult CreateResult(bool useProjectReference, int exitCode, string? output = null)
+    {
+        var captured = output is null
+            ? Array.Empty<ReproExecutionCapturedLine>()
+            : new[]
+            {
+                new ReproExecutionCapturedLine(ReproExecutionStream.StandardOutput, output)
+            };
+
+        return new ReproExecutionResult(
+            useProjectReference,
+            exitCode == 0,
+            exitCode,
+            TimeSpan.FromSeconds(1),
+            captured);
+    }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/RunCommand.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/RunCommand.cs
@@ -81,262 +81,159 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
             return 1;
         }
 
-        var report = new RunReport { Root = repository.RootPath };
-        var table = new Table().Border(TableBorder.Rounded).Expand().AddColumns("Repro", "State", "Package", "Latest");
-        var logLines = new List<string>();
-        var targetFps = settings.Fps ?? RunCommandSettings.DefaultFps;
-        var layout = new Layout("root")
-            .SplitRows(
-                new Layout("logs").Size(8),
-                new Layout("results"));
 
-        layout["results"].Update(table);
-        layout["logs"].Update(CreateLogView(logLines, targetFps));
+        var report = new RunReport { Root = repository.RootPath };
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .Expand()
+            .AddColumns("Repro", "Repro Version", "Reproduced", "Fixed", "Overall");
         var overallExitCode = 0;
         var plannedVariants = new List<RunVariantPlan>();
         var buildFailures = new List<BuildFailure>();
-        var uiUpdates = Channel.CreateUnbounded<UiUpdate>(new UnboundedChannelOptions
-        {
-            SingleReader = true,
-            AllowSynchronousContinuations = false
-        });
+        var useLiveDisplay = ShouldUseLiveDisplay();
 
         try
         {
-            await _console.Live(layout).StartAsync(async ctx =>
+            if (useLiveDisplay)
             {
-                var uiTask = ProcessUiUpdatesAsync(uiUpdates.Reader, table, layout, logLines, targetFps, ctx, _cancellationToken);
-                var writer = uiUpdates.Writer;
-                var previousObserver = _executor.LogObserver;
-                var previousSuppression = _executor.SuppressConsoleLogOutput;
-                _executor.SuppressConsoleLogOutput = true;
-                _executor.LogObserver = entry =>
-                {
-                    var formatted = FormatLogLine(entry);
-                    writer.TryWrite(new LogLineUpdate(formatted));
-                };
+                var logLines = new List<string>();
+                var targetFps = settings.Fps ?? RunCommandSettings.DefaultFps;
+                var layout = new Layout("root")
+                    .SplitRows(
+                        new Layout("logs").Size(8),
+                        new Layout("results"));
 
-                void QueueRow(string reproId, string state, string package, string latest)
-                {
-                    writer.TryWrite(new TableRowUpdate(reproId, state, package, latest));
-                }
+                layout["results"].Update(table);
+                layout["logs"].Update(CreateLogView(logLines, targetFps));
 
-                var rowStates = new Dictionary<string, ReproRowState>();
-
-                void UpdateRowState(string reproId, string state, string package, string latest)
+                var uiUpdates = Channel.CreateUnbounded<UiUpdate>(new UnboundedChannelOptions
                 {
-                    rowStates[reproId] = new ReproRowState(reproId, state, package, latest);
-                    writer.TryWrite(new TableRefreshUpdate(new Dictionary<string, ReproRowState>(rowStates)));
-                }
-
-                void LogBuild(string message)
-                {
-                    writer.TryWrite(new LogLineUpdate($"BUILD: {message}"));
-                }
+                    SingleReader = true,
+                    AllowSynchronousContinuations = false
+                });
 
                 try
                 {
-                    var candidates = new List<RunCandidate>();
-
-                    foreach (var repro in selected)
+                    await _console.Live(layout).StartAsync(async ctx =>
                     {
-                        _cancellationToken.ThrowIfCancellationRequested();
-
-                        if (!repro.IsValid)
+                        var uiTask = ProcessUiUpdatesAsync(uiUpdates.Reader, table, layout, logLines, targetFps, ctx, _cancellationToken);
+                        var writer = uiUpdates.Writer;
+                        var rowStates = new Dictionary<string, ReproRowState>();
+                        var previousObserver = _executor.LogObserver;
+                        var previousSuppression = _executor.SuppressConsoleLogOutput;
+                        _executor.SuppressConsoleLogOutput = true;
+                        _executor.LogObserver = entry =>
                         {
-                            if (!settings.SkipValidation)
+                            var formatted = FormatLogLine(entry);
+                            writer.TryWrite(new LogLineUpdate(formatted));
+                        };
+
+                        void HandleInitialRow(ReproRowState state)
+                        {
+                            rowStates[state.ReproId] = state;
+                            writer.TryWrite(new TableRowUpdate(state.ReproId, state.ReproVersion, state.Reproduced, state.Fixed, state.Overall));
+                        }
+
+                        void HandleRowUpdate(ReproRowState state)
+                        {
+                            rowStates[state.ReproId] = state;
+                            writer.TryWrite(new TableRefreshUpdate(new Dictionary<string, ReproRowState>(rowStates)));
+                        }
+
+                        void LogLine(string message)
+                        {
+                            writer.TryWrite(new LogLineUpdate(message));
+                        }
+
+                        void LogBuild(string message)
+                        {
+                            writer.TryWrite(new LogLineUpdate($"BUILD: {message}"));
+                        }
+
+                        try
+                        {
+                            var result = await RunExecutionLoopAsync(
+                                selected,
+                                settings,
+                                report,
+                                plannedVariants,
+                                buildFailures,
+                                HandleInitialRow,
+                                HandleRowUpdate,
+                                LogLine,
+                                LogBuild,
+                                _cancellationToken).ConfigureAwait(false);
+                            overallExitCode = result.ExitCode;
+                        }
+                        finally
+                        {
+                            _executor.LogObserver = previousObserver;
+                            _executor.SuppressConsoleLogOutput = previousSuppression;
+                            writer.TryComplete();
+
+                            try
                             {
-                                QueueRow(Markup.Escape(repro.RawId ?? "(unknown)"), "[red]Invalid[/]", "[red]❌[/]", "[red]❌[/]");
-                                overallExitCode = overallExitCode == 0 ? 2 : overallExitCode;
-                                continue;
+                                await uiTask.ConfigureAwait(false);
                             }
-
-                            if (repro.Manifest is null)
+                            catch (OperationCanceledException)
                             {
-                                QueueRow(Markup.Escape(repro.RawId ?? "(unknown)"), "[red]Invalid[/]", "[red]❌[/]", "[red]❌[/]");
-                                overallExitCode = overallExitCode == 0 ? 2 : overallExitCode;
-                                continue;
                             }
                         }
+                    }).ConfigureAwait(false);
+                }
+                finally
+                {
+                    uiUpdates.Writer.TryComplete();
+                }
+            }
+            else
+            {
+                var previousObserver = _executor.LogObserver;
+                var previousSuppression = _executor.SuppressConsoleLogOutput;
+                RunExecutionResult result;
 
-                        if (repro.Manifest is null)
-                        {
-                            QueueRow(Markup.Escape(repro.RawId ?? "(unknown)"), "[red]Missing[/]", "[red]❌[/]", "[red]❌[/]");
-                            overallExitCode = overallExitCode == 0 ? 2 : overallExitCode;
-                            continue;
-                        }
-
-                        var manifest = repro.Manifest;
-                        var instances = settings.Instances ?? manifest.DefaultInstances;
-
-                        if (manifest.RequiresParallel && instances < 2)
-                        {
-                            QueueRow(Markup.Escape(manifest.Id), "[red]Config Error[/]", "[red]❌[/]", "[red]❌[/]");
-                            overallExitCode = 1;
-                            continue;
-                        }
-
-                        if (repro.ProjectPath is null)
-                        {
-                            QueueRow(Markup.Escape(manifest.Id), "[red]Project Missing[/]", "[red]❌[/]", "[red]❌[/]");
-                            overallExitCode = overallExitCode == 0 ? 2 : overallExitCode;
-                            continue;
-                        }
-
-                        var timeoutSeconds = settings.Timeout ?? manifest.TimeoutSeconds;
-                        var packageVersion = TryResolvePackageVersion(repro.ProjectPath);
-                        var packageDisplay = packageVersion ?? "NuGet";
-                        var packageVariantId = BuildVariantIdentifier(packageVersion);
-
-                        var packagePlan = _planner.CreateVariantPlan(
-                            repro,
-                            manifest.Id,
-                            packageVariantId,
-                            packageDisplay,
-                            useProjectReference: false,
-                            liteDbPackageVersion: packageVersion);
-
-                        var latestPlan = _planner.CreateVariantPlan(
-                            repro,
-                            manifest.Id,
-                            "ver_latest",
-                            "Latest",
-                            useProjectReference: true,
-                            liteDbPackageVersion: packageVersion);
-
-                        plannedVariants.Add(packagePlan);
-                        plannedVariants.Add(latestPlan);
-
-                        var stateCell = FormatReproState(manifest.State);
-
-                        candidates.Add(new RunCandidate(
-                            manifest,
-                            instances,
-                            timeoutSeconds,
-                            packageDisplay,
-                            packagePlan,
-                            latestPlan,
-                            stateCell));
-
-                        // Add initial table row showing the repro is discovered and pending
-                        UpdateRowState(manifest.Id, stateCell, "[yellow]⏳[/]", "[yellow]⏳[/]");
-                        writer.TryWrite(new LogLineUpdate($"Discovered repro: {manifest.Id}"));
-                    }
-
-                    if (candidates.Count == 0)
+                try
+                {
+                    _executor.SuppressConsoleLogOutput = true;
+                    _executor.LogObserver = entry =>
                     {
-                        return;
-                    }
+                        var formatted = FormatLogLine(entry);
+                        _console.MarkupLine(formatted);
+                    };
 
-                    // Update all candidates to show building status
-                    foreach (var candidate in candidates)
-                    {
-                        UpdateRowState(candidate.Manifest.Id, candidate.StateCell, "[yellow]Building...[/]", "[yellow]⏳[/]");
-                    }
-
-                    LogBuild($"Starting build for {plannedVariants.Count} variants across {candidates.Count} repros");
-                    var buildResults = await _buildCoordinator.BuildAsync(plannedVariants, _cancellationToken).ConfigureAwait(false);
-                    LogBuild($"Build completed. Processing {buildResults.Count()} results");
-                    var buildLookup = buildResults.ToDictionary(result => result.Plan);
-
-                    foreach (var candidate in candidates)
-                    {
-                        var stateCell = candidate.StateCell;
-                        var packageBuild = buildLookup[candidate.PackagePlan];
-                        var latestBuild = buildLookup[candidate.LatestPlan];
-
-                        if (!packageBuild.Succeeded)
-                        {
-                            LogBuild($"Package build failed for {candidate.Manifest.Id} ({candidate.PackageDisplay})");
-                            UpdateRowState(candidate.Manifest.Id, stateCell, "[red]Build Failed[/]", "[red]❌[/]");
-                            overallExitCode = overallExitCode == 0 ? 1 : overallExitCode;
-                            buildFailures.Add(new BuildFailure(candidate.Manifest.Id, candidate.PackageDisplay, packageBuild.Output));
-                        }
-
-                        if (!latestBuild.Succeeded)
-                        {
-                            LogBuild($"Latest build failed for {candidate.Manifest.Id}");
-                            if (packageBuild.Succeeded)
-                            {
-                                UpdateRowState(candidate.Manifest.Id, stateCell, "[yellow]⏳[/]", "[red]Build Failed[/]");
-                            }
-
-                            overallExitCode = overallExitCode == 0 ? 1 : overallExitCode;
-                            buildFailures.Add(new BuildFailure(candidate.Manifest.Id, "Latest", latestBuild.Output));
-                        }
-
-                        ReproExecutionResult? packageResult = null;
-                        ReproExecutionResult? latestResult = null;
-
-                        if (packageBuild.Succeeded)
-                        {
-                            LogBuild($"Build succeeded for {candidate.Manifest.Id} ({candidate.PackageDisplay}), starting execution");
-                            UpdateRowState(candidate.Manifest.Id, stateCell, "[yellow]Running...[/]", latestBuild.Succeeded ? "[yellow]⏳[/]" : "[yellow]⏳[/]");
-                            packageResult = await _executor.ExecuteAsync(packageBuild, candidate.Instances, candidate.TimeoutSeconds, _cancellationToken).ConfigureAwait(false);
-                        }
-
-                        if (latestBuild.Succeeded)
-                        {
-                            var interimPackageStatus = packageResult is null
-                                ? (packageBuild.Succeeded ? "[yellow]⏳[/]" : "[red]Build Failed[/]")
-                                : "[yellow]Completed[/]";
-                            UpdateRowState(candidate.Manifest.Id, stateCell, interimPackageStatus, "[yellow]Running...[/]");
-                            latestResult = await _executor.ExecuteAsync(latestBuild, candidate.Instances, candidate.TimeoutSeconds, _cancellationToken).ConfigureAwait(false);
-                        }
-
-                        var evaluation = _outcomeEvaluator.Evaluate(candidate.Manifest, packageResult, latestResult);
-                        var packageCell = FormatVariantCell(evaluation.Package);
-                        var latestCell = FormatVariantCell(evaluation.Latest);
-
-                        UpdateRowState(candidate.Manifest.Id, stateCell, packageCell, latestCell);
-
-                        if (evaluation.Package.ShouldFail && evaluation.Package.FailureReason is string packageReason)
-                        {
-                            writer.TryWrite(new LogLineUpdate($"FAIL: {candidate.Manifest.Id} package - {packageReason}"));
-                        }
-
-                        if (evaluation.Latest.ShouldFail && evaluation.Latest.FailureReason is string latestReason)
-                        {
-                            writer.TryWrite(new LogLineUpdate($"FAIL: {candidate.Manifest.Id} latest - {latestReason}"));
-                        }
-                        else if (evaluation.Latest.ShouldWarn && evaluation.Latest.FailureReason is string latestWarning)
-                        {
-                            writer.TryWrite(new LogLineUpdate($"WARN: {candidate.Manifest.Id} latest - {latestWarning}"));
-                        }
-
-                        if (evaluation.ShouldFail)
-                        {
-                            overallExitCode = overallExitCode == 0 ? 1 : overallExitCode;
-                        }
-
-                        report.Add(new RunReportEntry
-                        {
-                            Id = candidate.Manifest.Id,
-                            State = candidate.Manifest.State,
-                            Failed = evaluation.ShouldFail,
-                            Warned = evaluation.ShouldWarn,
-                            Package = CreateReportVariant(evaluation.Package, candidate.PackagePlan.UseProjectReference),
-                            Latest = CreateReportVariant(evaluation.Latest, candidate.LatestPlan.UseProjectReference)
-                        });
-
-                        writer.TryWrite(new LogLineUpdate($"Completed execution for {candidate.Manifest.Id}"));
-                    }
+                    result = await RunExecutionLoopAsync(
+                        selected,
+                        settings,
+                        report,
+                        plannedVariants,
+                        buildFailures,
+                        _ => { },
+                        _ => { },
+                        message => _console.MarkupLine(message),
+                        message => _console.MarkupLine($"BUILD: {Markup.Escape(message)}"),
+                        _cancellationToken).ConfigureAwait(false);
+                    overallExitCode = result.ExitCode;
                 }
                 finally
                 {
                     _executor.LogObserver = previousObserver;
                     _executor.SuppressConsoleLogOutput = previousSuppression;
-                    writer.TryComplete();
-
-                    try
-                    {
-                        await uiTask.ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                    }
                 }
-            }).ConfigureAwait(false);
+
+                _console.WriteLine();
+                var finalTable = new Table()
+                    .Border(TableBorder.Rounded)
+                    .Expand()
+                    .AddColumns("Repro", "Repro Version", "Reproduced", "Fixed", "Overall");
+
+                foreach (var state in result.States.Values.OrderBy(s => s.ReproId))
+                {
+                    finalTable.AddRow(state.ReproId, state.ReproVersion, state.Reproduced, state.Fixed, state.Overall);
+                }
+
+                _console.Write(finalTable);
+            }
+
             if (buildFailures.Count > 0)
             {
                 _console.WriteLine();
@@ -374,6 +271,258 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
         }
 
         return overallExitCode;
+    }
+
+
+    private async Task<RunExecutionResult> RunExecutionLoopAsync(
+        IReadOnlyList<DiscoveredRepro> selected,
+        RunCommandSettings settings,
+        RunReport report,
+        List<RunVariantPlan> plannedVariants,
+        List<BuildFailure> buildFailures,
+        Action<ReproRowState> onInitialRow,
+        Action<ReproRowState> onRowStateUpdated,
+        Action<string> logLine,
+        Action<string> logBuild,
+        CancellationToken cancellationToken)
+    {
+        var overallExitCode = 0;
+        var candidates = new List<RunCandidate>();
+        var finalStates = new Dictionary<string, ReproRowState>();
+
+        foreach (var repro in selected)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!repro.IsValid)
+            {
+                if (!settings.SkipValidation)
+                {
+                    var state = new ReproRowState(Markup.Escape(repro.RawId ?? "(unknown)"), "[red]n/a[/]", "[red]❌[/]", "[red]❌[/]", "[red]Invalid[/]");
+                    onInitialRow(state);
+                    finalStates[state.ReproId] = state;
+                    overallExitCode = overallExitCode == 0 ? 2 : overallExitCode;
+                    continue;
+                }
+
+                if (repro.Manifest is null)
+                {
+                    var state = new ReproRowState(Markup.Escape(repro.RawId ?? "(unknown)"), "[red]n/a[/]", "[red]❌[/]", "[red]❌[/]", "[red]Invalid[/]");
+                    onInitialRow(state);
+                    finalStates[state.ReproId] = state;
+                    overallExitCode = overallExitCode == 0 ? 2 : overallExitCode;
+                    continue;
+                }
+            }
+
+            if (repro.Manifest is null)
+            {
+                var state = new ReproRowState(Markup.Escape(repro.RawId ?? "(unknown)"), "[red]n/a[/]", "[red]❌[/]", "[red]❌[/]", "[red]Missing[/]");
+                onInitialRow(state);
+                finalStates[state.ReproId] = state;
+                overallExitCode = overallExitCode == 0 ? 2 : overallExitCode;
+                continue;
+            }
+
+            var manifest = repro.Manifest;
+            var instances = settings.Instances ?? manifest.DefaultInstances;
+
+            if (manifest.RequiresParallel && instances < 2)
+            {
+                var state = new ReproRowState(Markup.Escape(manifest.Id), "[red]n/a[/]", "[red]❌[/]", "[red]❌[/]", "[red]Config Error[/]");
+                onInitialRow(state);
+                finalStates[state.ReproId] = state;
+                overallExitCode = 1;
+                continue;
+            }
+
+            if (repro.ProjectPath is null)
+            {
+                var state = new ReproRowState(Markup.Escape(manifest.Id), "[red]n/a[/]", "[red]❌[/]", "[red]❌[/]", "[red]Project Missing[/]");
+                onInitialRow(state);
+                finalStates[state.ReproId] = state;
+                overallExitCode = overallExitCode == 0 ? 2 : overallExitCode;
+                continue;
+            }
+
+            var timeoutSeconds = settings.Timeout ?? manifest.TimeoutSeconds;
+            var packageVersion = TryResolvePackageVersion(repro.ProjectPath);
+            var packageDisplay = packageVersion ?? "NuGet";
+            var packageVariantId = BuildVariantIdentifier(packageVersion);
+            var failingSince = string.IsNullOrWhiteSpace(manifest.FailingSince)
+                ? packageDisplay
+                : manifest.FailingSince!;
+            var reproVersionCell = Markup.Escape(failingSince);
+            var pendingOverallCell = FormatOverallPending(manifest.State);
+
+            var packagePlan = _planner.CreateVariantPlan(
+                repro,
+                manifest.Id,
+                packageVariantId,
+                packageDisplay,
+                useProjectReference: false,
+                liteDbPackageVersion: packageVersion);
+
+            var latestPlan = _planner.CreateVariantPlan(
+                repro,
+                manifest.Id,
+                "ver_latest",
+                "Latest",
+                useProjectReference: true,
+                liteDbPackageVersion: packageVersion);
+
+            plannedVariants.Add(packagePlan);
+            plannedVariants.Add(latestPlan);
+
+            var candidate = new RunCandidate(
+                manifest,
+                instances,
+                timeoutSeconds,
+                packageDisplay,
+                packagePlan,
+                latestPlan,
+                reproVersionCell);
+
+            candidates.Add(candidate);
+
+            var pendingState = new ReproRowState(manifest.Id, reproVersionCell, "[yellow]⏳[/]", "[yellow]⏳[/]", pendingOverallCell);
+            onRowStateUpdated(pendingState);
+            finalStates[manifest.Id] = pendingState;
+
+            logLine($"Discovered repro: {Markup.Escape(manifest.Id)}");
+        }
+
+        if (candidates.Count == 0)
+        {
+            return new RunExecutionResult(overallExitCode, finalStates);
+        }
+
+        foreach (var candidate in candidates)
+        {
+            var buildingState = new ReproRowState(
+                candidate.Manifest.Id,
+                candidate.ReproVersionCell,
+                "[yellow]Building...[/]",
+                "[yellow]⏳[/]",
+                FormatOverallPending(candidate.Manifest.State));
+            onRowStateUpdated(buildingState);
+            finalStates[candidate.Manifest.Id] = buildingState;
+        }
+
+        logBuild($"Starting build for {plannedVariants.Count} variants across {candidates.Count} repros");
+        var buildResults = await _buildCoordinator.BuildAsync(plannedVariants, cancellationToken).ConfigureAwait(false);
+        logBuild($"Build completed. Processing {buildResults.Count()} results");
+        var buildLookup = buildResults.ToDictionary(result => result.Plan);
+
+        foreach (var candidate in candidates)
+        {
+            var packageBuild = buildLookup[candidate.PackagePlan];
+            var latestBuild = buildLookup[candidate.LatestPlan];
+
+            if (!packageBuild.Succeeded)
+            {
+                logBuild($"Package build failed for {Markup.Escape(candidate.Manifest.Id)} ({Markup.Escape(candidate.PackageDisplay)})");
+                var failedState = new ReproRowState(candidate.Manifest.Id, candidate.ReproVersionCell, "[red]Build Failed[/]", "[red]❌[/]", "[red]Build Failed[/]");
+                onRowStateUpdated(failedState);
+                finalStates[candidate.Manifest.Id] = failedState;
+                overallExitCode = overallExitCode == 0 ? 1 : overallExitCode;
+                buildFailures.Add(new BuildFailure(candidate.Manifest.Id, candidate.PackageDisplay, packageBuild.Output));
+            }
+
+            if (!latestBuild.Succeeded)
+            {
+                logBuild($"Latest build failed for {Markup.Escape(candidate.Manifest.Id)}");
+                if (packageBuild.Succeeded)
+                {
+                    var partialState = new ReproRowState(candidate.Manifest.Id, candidate.ReproVersionCell, "[yellow]⏳[/]", "[red]Build Failed[/]", "[red]Build Failed[/]");
+                    onRowStateUpdated(partialState);
+                    finalStates[candidate.Manifest.Id] = partialState;
+                }
+
+                overallExitCode = overallExitCode == 0 ? 1 : overallExitCode;
+                buildFailures.Add(new BuildFailure(candidate.Manifest.Id, "Latest", latestBuild.Output));
+            }
+
+            ReproExecutionResult? packageResult = null;
+            ReproExecutionResult? latestResult = null;
+
+            if (packageBuild.Succeeded)
+            {
+                logBuild($"Build succeeded for {Markup.Escape(candidate.Manifest.Id)} ({Markup.Escape(candidate.PackageDisplay)}), starting execution");
+                var runningState = new ReproRowState(candidate.Manifest.Id, candidate.ReproVersionCell, "[yellow]Running...[/]", latestBuild.Succeeded ? "[yellow]⏳[/]" : "[yellow]⏳[/]", FormatOverallPending(candidate.Manifest.State));
+                onRowStateUpdated(runningState);
+                finalStates[candidate.Manifest.Id] = runningState;
+                packageResult = await _executor.ExecuteAsync(packageBuild, candidate.Instances, candidate.TimeoutSeconds, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (latestBuild.Succeeded)
+            {
+                var interimPackageStatus = packageResult is null
+                    ? (packageBuild.Succeeded ? "[yellow]⏳[/]" : "[red]Build Failed[/]")
+                    : "[yellow]Completed[/]";
+                var latestRunningState = new ReproRowState(candidate.Manifest.Id, candidate.ReproVersionCell, interimPackageStatus, "[yellow]Running...[/]", FormatOverallPending(candidate.Manifest.State));
+                onRowStateUpdated(latestRunningState);
+                finalStates[candidate.Manifest.Id] = latestRunningState;
+                latestResult = await _executor.ExecuteAsync(latestBuild, candidate.Instances, candidate.TimeoutSeconds, cancellationToken).ConfigureAwait(false);
+            }
+
+            var evaluation = _outcomeEvaluator.Evaluate(candidate.Manifest, packageResult, latestResult);
+            var packageCell = FormatVariantCell(evaluation.Package);
+            var latestCell = FormatVariantCell(evaluation.Latest);
+            var overallCell = FormatOverallCell(evaluation);
+            var finalState = new ReproRowState(candidate.Manifest.Id, candidate.ReproVersionCell, packageCell, latestCell, overallCell);
+            onRowStateUpdated(finalState);
+            finalStates[candidate.Manifest.Id] = finalState;
+
+            if (evaluation.Package.ShouldFail && evaluation.Package.FailureReason is string packageReason)
+            {
+                logLine($"FAIL: {Markup.Escape(candidate.Manifest.Id)} package - {Markup.Escape(packageReason)}");
+            }
+
+            if (evaluation.Latest.ShouldFail && evaluation.Latest.FailureReason is string latestReason)
+            {
+                logLine($"FAIL: {Markup.Escape(candidate.Manifest.Id)} latest - {Markup.Escape(latestReason)}");
+            }
+            else if (evaluation.Latest.ShouldWarn && evaluation.Latest.FailureReason is string latestWarning)
+            {
+                logLine($"WARN: {Markup.Escape(candidate.Manifest.Id)} latest - {Markup.Escape(latestWarning)}");
+            }
+
+            if (evaluation.ShouldFail)
+            {
+                overallExitCode = overallExitCode == 0 ? 1 : overallExitCode;
+            }
+
+            report.Add(new RunReportEntry
+            {
+                Id = candidate.Manifest.Id,
+                State = candidate.Manifest.State,
+                Failed = evaluation.ShouldFail,
+                Warned = evaluation.ShouldWarn,
+                Package = CreateReportVariant(evaluation.Package, candidate.PackagePlan.UseProjectReference),
+                Latest = CreateReportVariant(evaluation.Latest, candidate.LatestPlan.UseProjectReference)
+            });
+
+            logLine($"Completed execution for {Markup.Escape(candidate.Manifest.Id)}");
+        }
+
+        return new RunExecutionResult(overallExitCode, finalStates);
+    }
+
+    private bool ShouldUseLiveDisplay()
+    {
+        if (IsCiEnvironment())
+        {
+            return false;
+        }
+
+        return _console.Profile.Capabilities.Interactive;
+    }
+
+    private static bool IsCiEnvironment()
+    {
+        static bool IsTrue(string? value) => !string.IsNullOrEmpty(value) && string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+        return IsTrue(Environment.GetEnvironmentVariable("GITHUB_ACTIONS")) || IsTrue(Environment.GetEnvironmentVariable("CI"));
     }
 
     private static async Task WriteReportAsync(RunReport report, string path, string? format, CancellationToken cancellationToken)
@@ -465,6 +614,22 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
         return $"{symbol} {detail} [dim](exp {expectation})[/]";
     }
 
+    private static string FormatOverallCell(ReproRunEvaluation evaluation)
+    {
+        var symbol = evaluation.ShouldFail
+            ? "[red]❌[/]"
+            : evaluation.ShouldWarn
+                ? "[yellow]⚠️[/]"
+                : "[green]✅[/]";
+
+        return $"{symbol} {FormatReproState(evaluation.State)}";
+    }
+
+    private static string FormatOverallPending(ReproState state)
+    {
+        return $"[yellow]⏳[/] {FormatReproState(state)}";
+    }
+
     private static string FormatReproState(ReproState state)
     {
         return state switch
@@ -525,6 +690,8 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
         return null;
     }
 
+    private sealed record RunExecutionResult(int ExitCode, Dictionary<string, ReproRowState> States);
+
     private sealed record RunCandidate(
         ReproManifest Manifest,
         int Instances,
@@ -532,7 +699,7 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
         string PackageDisplay,
         RunVariantPlan PackagePlan,
         RunVariantPlan LatestPlan,
-        string StateCell);
+        string ReproVersionCell);
 
     private sealed record BuildFailure(string ManifestId, string Variant, IReadOnlyList<string> Output);
 
@@ -602,14 +769,17 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
                         layout["logs"].Update(CreateLogView(logLines, fps));
                         break;
                     case TableRowUpdate rowUpdate:
-                        table.AddRow(rowUpdate.ReproId, rowUpdate.State, rowUpdate.Package, rowUpdate.Latest);
+                        table.AddRow(rowUpdate.ReproId, rowUpdate.ReproVersion, rowUpdate.Reproduced, rowUpdate.Fixed, rowUpdate.Overall);
                         break;
                     case TableRefreshUpdate refreshUpdate:
                         // Rebuild the entire table with current states
-                        var newTable = new Table().Border(TableBorder.Rounded).Expand().AddColumns("Repro", "State", "Package", "Latest");
+                        var newTable = new Table()
+                            .Border(TableBorder.Rounded)
+                            .Expand()
+                            .AddColumns("Repro", "Repro Version", "Reproduced", "Fixed", "Overall");
                         foreach (var state in refreshUpdate.RowStates.Values.OrderBy(s => s.ReproId))
                         {
-                            newTable.AddRow(state.ReproId, state.State, state.Package, state.Latest);
+                            newTable.AddRow(state.ReproId, state.ReproVersion, state.Reproduced, state.Fixed, state.Overall);
                         }
                         layout["results"].Update(newTable);
                         break;
@@ -656,9 +826,9 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
 
     private sealed record LogLineUpdate(string Line) : UiUpdate;
 
-    private sealed record TableRowUpdate(string ReproId, string State, string Package, string Latest) : UiUpdate;
+    private sealed record TableRowUpdate(string ReproId, string ReproVersion, string Reproduced, string Fixed, string Overall) : UiUpdate;
 
     private sealed record TableRefreshUpdate(Dictionary<string, ReproRowState> RowStates) : UiUpdate;
 
-    private sealed record ReproRowState(string ReproId, string State, string Package, string Latest);
+    private sealed record ReproRowState(string ReproId, string ReproVersion, string Reproduced, string Fixed, string Overall);
 }

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/RunCommand.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/RunCommand.cs
@@ -1,4 +1,8 @@
+using System;
 using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
 using System.Threading.Channels;
 using System.Xml.Linq;
 using LiteDB.ReproRunner.Cli.Execution;
@@ -21,6 +25,7 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
     private readonly ReproBuildCoordinator _buildCoordinator;
     private readonly ReproExecutor _executor;
     private readonly CancellationToken _cancellationToken;
+    private readonly ReproOutcomeEvaluator _outcomeEvaluator = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RunCommand"/> class.
@@ -76,7 +81,8 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
             return 1;
         }
 
-        var table = new Table().Border(TableBorder.Rounded).Expand().AddColumns("Repro", "Repro Version", "Reproduced", "Fixed");
+        var report = new RunReport { Root = repository.RootPath };
+        var table = new Table().Border(TableBorder.Rounded).Expand().AddColumns("Repro", "State", "Package", "Latest");
         var logLines = new List<string>();
         var targetFps = settings.Fps ?? RunCommandSettings.DefaultFps;
         var layout = new Layout("root")
@@ -110,16 +116,16 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
                     writer.TryWrite(new LogLineUpdate(formatted));
                 };
 
-                void QueueRow(string reproId, string version, string reproduced, string fixedStatus)
+                void QueueRow(string reproId, string state, string package, string latest)
                 {
-                    writer.TryWrite(new TableRowUpdate(reproId, version, reproduced, fixedStatus));
+                    writer.TryWrite(new TableRowUpdate(reproId, state, package, latest));
                 }
 
                 var rowStates = new Dictionary<string, ReproRowState>();
 
-                void UpdateRowState(string reproId, string version, string reproduced, string fixedStatus)
+                void UpdateRowState(string reproId, string state, string package, string latest)
                 {
-                    rowStates[reproId] = new ReproRowState(reproId, version, reproduced, fixedStatus);
+                    rowStates[reproId] = new ReproRowState(reproId, state, package, latest);
                     writer.TryWrite(new TableRefreshUpdate(new Dictionary<string, ReproRowState>(rowStates)));
                 }
 
@@ -201,16 +207,19 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
                         plannedVariants.Add(packagePlan);
                         plannedVariants.Add(latestPlan);
 
+                        var stateCell = FormatReproState(manifest.State);
+
                         candidates.Add(new RunCandidate(
                             manifest,
                             instances,
                             timeoutSeconds,
                             packageDisplay,
                             packagePlan,
-                            latestPlan));
+                            latestPlan,
+                            stateCell));
 
                         // Add initial table row showing the repro is discovered and pending
-                        UpdateRowState(manifest.Id, "[yellow]Pending[/]", "[yellow]⏳[/]", "[yellow]⏳[/]");
+                        UpdateRowState(manifest.Id, stateCell, "[yellow]⏳[/]", "[yellow]⏳[/]");
                         writer.TryWrite(new LogLineUpdate($"Discovered repro: {manifest.Id}"));
                     }
 
@@ -222,7 +231,7 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
                     // Update all candidates to show building status
                     foreach (var candidate in candidates)
                     {
-                        UpdateRowState(candidate.Manifest.Id, "[yellow]Building...[/]", "[yellow]⏳[/]", "[yellow]⏳[/]");
+                        UpdateRowState(candidate.Manifest.Id, candidate.StateCell, "[yellow]Building...[/]", "[yellow]⏳[/]");
                     }
 
                     LogBuild($"Starting build for {plannedVariants.Count} variants across {candidates.Count} repros");
@@ -232,14 +241,14 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
 
                     foreach (var candidate in candidates)
                     {
+                        var stateCell = candidate.StateCell;
                         var packageBuild = buildLookup[candidate.PackagePlan];
                         var latestBuild = buildLookup[candidate.LatestPlan];
 
-                        // Check build status and update table accordingly
                         if (!packageBuild.Succeeded)
                         {
                             LogBuild($"Package build failed for {candidate.Manifest.Id} ({candidate.PackageDisplay})");
-                            UpdateRowState(candidate.Manifest.Id, "[red]Build Failed[/]", "[red]❌[/]", "[red]❌[/]");
+                            UpdateRowState(candidate.Manifest.Id, stateCell, "[red]Build Failed[/]", "[red]❌[/]");
                             overallExitCode = overallExitCode == 0 ? 1 : overallExitCode;
                             buildFailures.Add(new BuildFailure(candidate.Manifest.Id, candidate.PackageDisplay, packageBuild.Output));
                         }
@@ -247,10 +256,11 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
                         if (!latestBuild.Succeeded)
                         {
                             LogBuild($"Latest build failed for {candidate.Manifest.Id}");
-                            if (packageBuild.Succeeded) // Only update if package build succeeded (otherwise already marked as failed)
+                            if (packageBuild.Succeeded)
                             {
-                                UpdateRowState(candidate.Manifest.Id, Markup.Escape(candidate.PackageDisplay), "[yellow]-[/]", "[red]❌[/]");
+                                UpdateRowState(candidate.Manifest.Id, stateCell, "[yellow]⏳[/]", "[red]Build Failed[/]");
                             }
+
                             overallExitCode = overallExitCode == 0 ? 1 : overallExitCode;
                             buildFailures.Add(new BuildFailure(candidate.Manifest.Id, "Latest", latestBuild.Output));
                         }
@@ -258,41 +268,57 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
                         ReproExecutionResult? packageResult = null;
                         ReproExecutionResult? latestResult = null;
 
-                        // Execute package version if build succeeded
                         if (packageBuild.Succeeded)
                         {
                             LogBuild($"Build succeeded for {candidate.Manifest.Id} ({candidate.PackageDisplay}), starting execution");
-                            UpdateRowState(candidate.Manifest.Id, Markup.Escape(candidate.PackageDisplay), "[yellow]Running...[/]", "[yellow]⏳[/]");
+                            UpdateRowState(candidate.Manifest.Id, stateCell, "[yellow]Running...[/]", latestBuild.Succeeded ? "[yellow]⏳[/]" : "[yellow]⏳[/]");
                             packageResult = await _executor.ExecuteAsync(packageBuild, candidate.Instances, candidate.TimeoutSeconds, _cancellationToken).ConfigureAwait(false);
                         }
 
-                        // Execute latest version if build succeeded
                         if (latestBuild.Succeeded)
                         {
-                            var currentReproduced = packageResult is null ? "[yellow]-[/]" : (packageResult.Value.Reproduced ? "[green]✅[/]" : "[red]❌[/]");
-                            UpdateRowState(candidate.Manifest.Id, Markup.Escape(candidate.PackageDisplay), currentReproduced, "[yellow]Running...[/]");
+                            var interimPackageStatus = packageResult is null
+                                ? (packageBuild.Succeeded ? "[yellow]⏳[/]" : "[red]Build Failed[/]")
+                                : "[yellow]Completed[/]";
+                            UpdateRowState(candidate.Manifest.Id, stateCell, interimPackageStatus, "[yellow]Running...[/]");
                             latestResult = await _executor.ExecuteAsync(latestBuild, candidate.Instances, candidate.TimeoutSeconds, _cancellationToken).ConfigureAwait(false);
                         }
 
-                        // Final status update
-                        var versionCell = packageBuild.Succeeded
-                            ? Markup.Escape(candidate.PackageDisplay)
-                            : "[red]Build Failed[/]";
+                        var evaluation = _outcomeEvaluator.Evaluate(candidate.Manifest, packageResult, latestResult);
+                        var packageCell = FormatVariantCell(evaluation.Package);
+                        var latestCell = FormatVariantCell(evaluation.Latest);
 
-                        var reproducedStatus = packageResult is null
-                            ? "[yellow]-[/]"
-                            : (packageResult.Value.Reproduced ? "[green]✅[/]" : "[red]❌[/]");
+                        UpdateRowState(candidate.Manifest.Id, stateCell, packageCell, latestCell);
 
-                        var fixedStatus = latestResult is null
-                            ? "[yellow]-[/]"
-                            : (latestResult.Value.Reproduced ? "[red]❌[/]" : "[green]✅[/]");
+                        if (evaluation.Package.ShouldFail && evaluation.Package.FailureReason is string packageReason)
+                        {
+                            writer.TryWrite(new LogLineUpdate($"FAIL: {candidate.Manifest.Id} package - {packageReason}"));
+                        }
 
-                        if ((packageResult?.Reproduced ?? false) || (latestResult?.Reproduced ?? false))
+                        if (evaluation.Latest.ShouldFail && evaluation.Latest.FailureReason is string latestReason)
+                        {
+                            writer.TryWrite(new LogLineUpdate($"FAIL: {candidate.Manifest.Id} latest - {latestReason}"));
+                        }
+                        else if (evaluation.Latest.ShouldWarn && evaluation.Latest.FailureReason is string latestWarning)
+                        {
+                            writer.TryWrite(new LogLineUpdate($"WARN: {candidate.Manifest.Id} latest - {latestWarning}"));
+                        }
+
+                        if (evaluation.ShouldFail)
                         {
                             overallExitCode = overallExitCode == 0 ? 1 : overallExitCode;
                         }
 
-                        UpdateRowState(candidate.Manifest.Id, versionCell, reproducedStatus, fixedStatus);
+                        report.Add(new RunReportEntry
+                        {
+                            Id = candidate.Manifest.Id,
+                            State = candidate.Manifest.State,
+                            Failed = evaluation.ShouldFail,
+                            Warned = evaluation.ShouldWarn,
+                            Package = CreateReportVariant(evaluation.Package, candidate.PackagePlan.UseProjectReference),
+                            Latest = CreateReportVariant(evaluation.Latest, candidate.LatestPlan.UseProjectReference)
+                        });
+
                         writer.TryWrite(new LogLineUpdate($"Completed execution for {candidate.Manifest.Id}"));
                     }
                 }
@@ -342,7 +368,112 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
             }
         }
 
+        if (settings.ReportPath is string reportPath)
+        {
+            await WriteReportAsync(report, reportPath, settings.ReportFormat, _cancellationToken).ConfigureAwait(false);
+        }
+
         return overallExitCode;
+    }
+
+    private static async Task WriteReportAsync(RunReport report, string path, string? format, CancellationToken cancellationToken)
+    {
+        if (format is not null && !string.Equals(format, "json", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"Unsupported report format '{format}'.");
+        }
+
+        var serializerOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true
+        };
+
+        var json = JsonSerializer.Serialize(report, serializerOptions);
+
+        if (string.Equals(path, "-", StringComparison.Ordinal))
+        {
+            await Console.Out.WriteLineAsync(json).ConfigureAwait(false);
+            return;
+        }
+
+        var fullPath = Path.GetFullPath(path);
+        var directory = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await File.WriteAllTextAsync(fullPath, json, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static RunReportVariant CreateReportVariant(ReproVariantEvaluation evaluation, bool useProjectReference)
+    {
+        var capturedLines = Array.Empty<RunReportCapturedLine>();
+
+        if (evaluation.Result is ReproExecutionResult result)
+        {
+            capturedLines = result.CapturedOutput
+                .Select(line => new RunReportCapturedLine
+                {
+                    Stream = line.Stream == ReproExecutionStream.StandardOutput ? "stdout" : "stderr",
+                    Text = line.Text ?? string.Empty
+                })
+                .ToArray();
+        }
+
+        return new RunReportVariant
+        {
+            Expected = evaluation.Expectation.Kind,
+            ExpectedExitCode = evaluation.Expectation.ExitCode,
+            ExpectedLogContains = evaluation.Expectation.LogContains,
+            Actual = evaluation.ActualKind,
+            Met = evaluation.Met,
+            ExitCode = evaluation.Result?.ExitCode,
+            DurationSeconds = evaluation.Result?.Duration.TotalSeconds,
+            UseProjectReference = evaluation.Result?.UseProjectReference ?? useProjectReference,
+            FailureReason = evaluation.FailureReason,
+            Output = capturedLines
+        };
+    }
+
+    private static string FormatVariantCell(ReproVariantEvaluation evaluation)
+    {
+        var symbol = evaluation.Met
+            ? "[green]✅[/]"
+            : evaluation.ShouldWarn
+                ? "[yellow]⚠️[/]"
+                : "[red]❌[/]";
+
+        string detail;
+        if (evaluation.Result is ReproExecutionResult result)
+        {
+            detail = string.Format(CultureInfo.InvariantCulture, "exit {0}", result.ExitCode);
+        }
+        else
+        {
+            detail = "no-run";
+        }
+
+        var expectation = evaluation.Expectation.Kind switch
+        {
+            ReproOutcomeKind.Reproduce => "repro",
+            ReproOutcomeKind.NoRepro => "no-repro",
+            ReproOutcomeKind.HardFail => "hard-fail",
+            _ => evaluation.Expectation.Kind.ToString().ToLowerInvariant()
+        };
+
+        return $"{symbol} {detail} [dim](exp {expectation})[/]";
+    }
+
+    private static string FormatReproState(ReproState state)
+    {
+        return state switch
+        {
+            ReproState.Red => "[red]red[/]",
+            ReproState.Green => "[green]green[/]",
+            ReproState.Flaky => "[yellow]flaky[/]",
+            _ => Markup.Escape(state.ToString().ToLowerInvariant())
+        };
     }
 
     private static string BuildVariantIdentifier(string? packageVersion)
@@ -400,7 +531,8 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
         int TimeoutSeconds,
         string PackageDisplay,
         RunVariantPlan PackagePlan,
-        RunVariantPlan LatestPlan);
+        RunVariantPlan LatestPlan,
+        string StateCell);
 
     private sealed record BuildFailure(string ManifestId, string Variant, IReadOnlyList<string> Output);
 
@@ -470,14 +602,14 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
                         layout["logs"].Update(CreateLogView(logLines, fps));
                         break;
                     case TableRowUpdate rowUpdate:
-                        table.AddRow(rowUpdate.ReproId, rowUpdate.Version, rowUpdate.Reproduced, rowUpdate.Fixed);
+                        table.AddRow(rowUpdate.ReproId, rowUpdate.State, rowUpdate.Package, rowUpdate.Latest);
                         break;
                     case TableRefreshUpdate refreshUpdate:
                         // Rebuild the entire table with current states
-                        var newTable = new Table().Border(TableBorder.Rounded).Expand().AddColumns("Repro", "Repro Version", "Reproduced", "Fixed");
+                        var newTable = new Table().Border(TableBorder.Rounded).Expand().AddColumns("Repro", "State", "Package", "Latest");
                         foreach (var state in refreshUpdate.RowStates.Values.OrderBy(s => s.ReproId))
                         {
-                            newTable.AddRow(state.ReproId, state.Version, state.Reproduced, state.Fixed);
+                            newTable.AddRow(state.ReproId, state.State, state.Package, state.Latest);
                         }
                         layout["results"].Update(newTable);
                         break;
@@ -524,9 +656,9 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
 
     private sealed record LogLineUpdate(string Line) : UiUpdate;
 
-    private sealed record TableRowUpdate(string ReproId, string Version, string Reproduced, string Fixed) : UiUpdate;
+    private sealed record TableRowUpdate(string ReproId, string State, string Package, string Latest) : UiUpdate;
 
     private sealed record TableRefreshUpdate(Dictionary<string, ReproRowState> RowStates) : UiUpdate;
 
-    private sealed record ReproRowState(string ReproId, string Version, string Reproduced, string Fixed);
+    private sealed record ReproRowState(string ReproId, string State, string Package, string Latest);
 }

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/RunCommandSettings.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/RunCommandSettings.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -54,6 +55,20 @@ internal sealed class RunCommandSettings : RootCommandSettings
     public decimal? Fps { get; set; }
 
     /// <summary>
+    /// Gets or sets the optional report output path.
+    /// </summary>
+    [CommandOption("--report <PATH>")]
+    [Description("Write a machine-readable report to the specified file or '-' for stdout.")]
+    public string? ReportPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the report format.
+    /// </summary>
+    [CommandOption("--report-format <FORMAT>")]
+    [Description("Report format (currently only 'json').")] 
+    public string? ReportFormat { get; set; }
+
+    /// <summary>
     /// Validates the run command settings.
     /// </summary>
     /// <returns>The validation result describing any errors.</returns>
@@ -82,6 +97,16 @@ internal sealed class RunCommandSettings : RootCommandSettings
         if (Fps is decimal fps && fps <= 0)
         {
             return ValidationResult.Error("--fps expects a positive decimal value.");
+        }
+
+        if (ReportFormat is string format && !string.Equals(format, "json", StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Error("--report-format supports only 'json'.");
+        }
+
+        if (ReportPath is null && ReportFormat is not null)
+        {
+            return ValidationResult.Error("--report-format requires --report.");
         }
 
         return base.Validate();

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Execution/ReproExecutor.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Execution/ReproExecutor.cs
@@ -15,6 +15,8 @@ namespace LiteDB.ReproRunner.Cli.Execution;
 /// </summary>
 internal sealed class ReproExecutor
 {
+    private const int CapturedOutputLimit = 200;
+
     private readonly TextWriter _standardOut;
     private readonly TextWriter _standardError;
     private readonly object _writeLock = new();
@@ -85,14 +87,14 @@ internal sealed class ReproExecutor
 
         if (!build.Succeeded || string.IsNullOrWhiteSpace(build.AssemblyPath))
         {
-            return new ReproExecutionResult(build.Plan.UseProjectReference, false, build.ExitCode, TimeSpan.Zero);
+            return new ReproExecutionResult(build.Plan.UseProjectReference, false, build.ExitCode, TimeSpan.Zero, Array.Empty<ReproExecutionCapturedLine>());
         }
 
         var repro = build.Plan.Repro;
 
         if (repro.ProjectPath is null)
         {
-            return new ReproExecutionResult(build.Plan.UseProjectReference, false, build.ExitCode, TimeSpan.Zero);
+            return new ReproExecutionResult(build.Plan.UseProjectReference, false, build.ExitCode, TimeSpan.Zero, Array.Empty<ReproExecutionCapturedLine>());
         }
 
         var manifest = repro.Manifest ?? throw new InvalidOperationException("Manifest is required to execute a repro.");
@@ -108,6 +110,8 @@ internal sealed class ReproExecutor
         var sharedRoot = Path.Combine(build.Plan.ExecutionRootDirectory, Sanitize(sharedKey), runIdentifier);
         Directory.CreateDirectory(sharedRoot);
 
+        var capturedOutput = new BoundedLogBuffer(CapturedOutputLimit);
+
         try
         {
             var exitCode = await RunInstancesAsync(
@@ -118,6 +122,7 @@ internal sealed class ReproExecutor
                 timeoutSeconds,
                 sharedRoot,
                 runIdentifier,
+                capturedOutput,
                 cancellationToken).ConfigureAwait(false);
 
             FinalizeConfigurationValidation();
@@ -129,7 +134,12 @@ internal sealed class ReproExecutor
             }
 
             stopwatch.Stop();
-            return new ReproExecutionResult(build.Plan.UseProjectReference, exitCode == 0 && !configurationMismatch, exitCode, stopwatch.Elapsed);
+            return new ReproExecutionResult(
+                build.Plan.UseProjectReference,
+                exitCode == 0 && !configurationMismatch,
+                exitCode,
+                stopwatch.Elapsed,
+                capturedOutput.ToSnapshot());
         }
         finally
         {
@@ -145,6 +155,7 @@ internal sealed class ReproExecutor
         int timeoutSeconds,
         string sharedRoot,
         string runIdentifier,
+        BoundedLogBuffer capturedOutput,
         CancellationToken cancellationToken)
     {
         var manifestArgs = manifest.Args;
@@ -171,8 +182,8 @@ internal sealed class ReproExecutor
                 }
 
                 processes.Add(process);
-                outputTasks.Add(PumpStandardOutputAsync(process, index, cancellationToken));
-                errorTasks.Add(PumpStandardErrorAsync(process, index, cancellationToken));
+                outputTasks.Add(PumpStandardOutputAsync(process, index, capturedOutput, cancellationToken));
+                errorTasks.Add(PumpStandardErrorAsync(process, index, capturedOutput, cancellationToken));
 
                 await SendHostHandshakeAsync(process, manifest, sharedRoot, runIdentifier, index, instances, cancellationToken).ConfigureAwait(false);
             }
@@ -250,7 +261,7 @@ internal sealed class ReproExecutor
         return startInfo;
     }
 
-    private async Task PumpStandardOutputAsync(Process process, int instanceIndex, CancellationToken cancellationToken)
+    private async Task PumpStandardOutputAsync(Process process, int instanceIndex, BoundedLogBuffer capturedOutput, CancellationToken cancellationToken)
     {
         try
         {
@@ -263,6 +274,7 @@ internal sealed class ReproExecutor
                     break;
                 }
 
+                capturedOutput.Add(ReproExecutionStream.StandardOutput, line);
                 if (!TryProcessStructuredLine(line, instanceIndex))
                 {
                     WriteOutputLine($"[{instanceIndex}] {line}");
@@ -274,7 +286,7 @@ internal sealed class ReproExecutor
         }
     }
 
-    private async Task PumpStandardErrorAsync(Process process, int instanceIndex, CancellationToken cancellationToken)
+    private async Task PumpStandardErrorAsync(Process process, int instanceIndex, BoundedLogBuffer capturedOutput, CancellationToken cancellationToken)
     {
         try
         {
@@ -287,6 +299,7 @@ internal sealed class ReproExecutor
                     break;
                 }
 
+                capturedOutput.Add(ReproExecutionStream.StandardError, line);
                 WriteErrorLine($"[{instanceIndex}] {line}");
             }
         }
@@ -582,6 +595,46 @@ internal sealed class ReproExecutor
         }
     }
 
+    private sealed class BoundedLogBuffer
+    {
+        private readonly int _capacity;
+        private readonly Queue<ReproExecutionCapturedLine> _buffer;
+        private readonly object _sync = new();
+
+        public BoundedLogBuffer(int capacity)
+        {
+            _capacity = Math.Max(1, capacity);
+            _buffer = new Queue<ReproExecutionCapturedLine>(_capacity);
+        }
+
+        public void Add(ReproExecutionStream stream, string text)
+        {
+            if (text is null)
+            {
+                return;
+            }
+
+            var entry = new ReproExecutionCapturedLine(stream, text);
+
+            lock (_sync)
+            {
+                _buffer.Enqueue(entry);
+                while (_buffer.Count > _capacity)
+                {
+                    _buffer.Dequeue();
+                }
+            }
+        }
+
+        public IReadOnlyList<ReproExecutionCapturedLine> ToSnapshot()
+        {
+            lock (_sync)
+            {
+                return _buffer.ToArray();
+            }
+        }
+    }
+
     private void WriteOutputLine(string message)
     {
         if (SuppressConsoleLogOutput)
@@ -659,7 +712,8 @@ internal sealed class ReproExecutor
 /// <param name="Reproduced">Indicates whether the repro successfully reproduced the issue.</param>
 /// <param name="ExitCode">The exit code reported by the repro host.</param>
 /// <param name="Duration">The elapsed time for the execution.</param>
-internal readonly record struct ReproExecutionResult(bool UseProjectReference, bool Reproduced, int ExitCode, TimeSpan Duration);
+/// <param name="CapturedOutput">The captured standard output and error lines.</param>
+internal readonly record struct ReproExecutionResult(bool UseProjectReference, bool Reproduced, int ExitCode, TimeSpan Duration, IReadOnlyList<ReproExecutionCapturedLine> CapturedOutput);
 
 /// <summary>
 /// Represents a structured log entry emitted during repro execution.
@@ -668,3 +722,19 @@ internal readonly record struct ReproExecutionResult(bool UseProjectReference, b
 /// <param name="Message">The log message text.</param>
 /// <param name="Level">The severity associated with the log entry.</param>
 internal readonly record struct ReproExecutionLogEntry(int InstanceIndex, string Message, ReproHostLogLevel Level);
+
+/// <summary>
+/// Identifies the stream that produced a captured line of output.
+/// </summary>
+internal enum ReproExecutionStream
+{
+    StandardOutput,
+    StandardError
+}
+
+/// <summary>
+/// Represents a captured line of standard output or error for report generation.
+/// </summary>
+/// <param name="Stream">The source stream for the line.</param>
+/// <param name="Text">The raw text captured from the process.</param>
+internal readonly record struct ReproExecutionCapturedLine(ReproExecutionStream Stream, string Text);

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Execution/ReproOutcomeEvaluator.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Execution/ReproOutcomeEvaluator.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using LiteDB.ReproRunner.Cli.Manifests;
+
+namespace LiteDB.ReproRunner.Cli.Execution;
+
+internal sealed class ReproOutcomeEvaluator
+{
+    public ReproRunEvaluation Evaluate(ReproManifest manifest, ReproExecutionResult? packageResult, ReproExecutionResult? latestResult)
+    {
+        if (manifest is null)
+        {
+            throw new ArgumentNullException(nameof(manifest));
+        }
+
+        var packageExpectation = manifest.ExpectedOutcomes.Package ?? new ReproOutcomeExpectation(ReproOutcomeKind.Reproduce, null, null);
+        var latestExpectation = manifest.ExpectedOutcomes.Latest ?? CreateDefaultLatestExpectation(manifest.State);
+
+        var package = EvaluateVariant(packageExpectation, packageResult, isLatest: false, manifest.State);
+        var latest = EvaluateVariant(latestExpectation, latestResult, isLatest: true, manifest.State);
+
+        var shouldFail = package.ShouldFail || latest.ShouldFail;
+        var shouldWarn = package.ShouldWarn || latest.ShouldWarn;
+
+        return new ReproRunEvaluation(manifest.State, package, latest, shouldFail, shouldWarn);
+    }
+
+    private static ReproVariantEvaluation EvaluateVariant(
+        ReproOutcomeExpectation expectation,
+        ReproExecutionResult? result,
+        bool isLatest,
+        ReproState state)
+    {
+        var actualKind = ComputeActualKind(result);
+        var (met, failureReason) = MatchesExpectation(expectation, result);
+
+        var shouldFail = false;
+        var shouldWarn = false;
+
+        if (!met)
+        {
+            if (isLatest)
+            {
+                if (state == ReproState.Flaky)
+                {
+                    shouldWarn = true;
+                }
+                else
+                {
+                    shouldFail = true;
+                }
+            }
+            else
+            {
+                shouldFail = true;
+            }
+        }
+
+        return new ReproVariantEvaluation(expectation, actualKind, result, met, shouldFail, shouldWarn, failureReason);
+    }
+
+    private static (bool Met, string? FailureReason) MatchesExpectation(ReproOutcomeExpectation expectation, ReproExecutionResult? result)
+    {
+        if (result is null)
+        {
+            return (false, "Variant did not execute.");
+        }
+
+        var exitCode = result.Value.ExitCode;
+
+        switch (expectation.Kind)
+        {
+            case ReproOutcomeKind.Reproduce:
+                if (exitCode != 0)
+                {
+                    return (false, $"Expected exit code 0 but observed {exitCode}.");
+                }
+                break;
+            case ReproOutcomeKind.NoRepro:
+            case ReproOutcomeKind.HardFail:
+                if (exitCode == 0)
+                {
+                    return (false, "Expected non-zero exit code.");
+                }
+                break;
+            default:
+                return (false, $"Unsupported expectation kind: {expectation.Kind}.");
+        }
+
+        if (expectation.ExitCode.HasValue && exitCode != expectation.ExitCode.Value)
+        {
+            return (false, $"Expected exit code {expectation.ExitCode.Value} but observed {exitCode}.");
+        }
+
+        if (!MatchesLog(expectation.LogContains, result.Value.CapturedOutput))
+        {
+            return (false, $"Expected output containing '{expectation.LogContains}'.");
+        }
+
+        return (true, null);
+    }
+
+    private static bool MatchesLog(string? expected, IReadOnlyList<ReproExecutionCapturedLine> lines)
+    {
+        if (string.IsNullOrWhiteSpace(expected))
+        {
+            return true;
+        }
+
+        foreach (var line in lines)
+        {
+            if (line.Text?.IndexOf(expected, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static ReproOutcomeKind ComputeActualKind(ReproExecutionResult? result)
+    {
+        if (result is null)
+        {
+            return ReproOutcomeKind.NoRepro;
+        }
+
+        return result.Value.ExitCode == 0
+            ? ReproOutcomeKind.Reproduce
+            : ReproOutcomeKind.NoRepro;
+    }
+
+    private static ReproOutcomeExpectation CreateDefaultLatestExpectation(ReproState state)
+    {
+        return state switch
+        {
+            ReproState.Red => new ReproOutcomeExpectation(ReproOutcomeKind.Reproduce, null, null),
+            ReproState.Green => new ReproOutcomeExpectation(ReproOutcomeKind.NoRepro, null, null),
+            ReproState.Flaky => new ReproOutcomeExpectation(ReproOutcomeKind.Reproduce, null, null),
+            _ => new ReproOutcomeExpectation(ReproOutcomeKind.Reproduce, null, null)
+        };
+    }
+}
+
+internal sealed class ReproRunEvaluation
+{
+    public ReproRunEvaluation(ReproState state, ReproVariantEvaluation package, ReproVariantEvaluation latest, bool shouldFail, bool shouldWarn)
+    {
+        State = state;
+        Package = package;
+        Latest = latest;
+        ShouldFail = shouldFail;
+        ShouldWarn = shouldWarn;
+    }
+
+    public ReproState State { get; }
+
+    public ReproVariantEvaluation Package { get; }
+
+    public ReproVariantEvaluation Latest { get; }
+
+    public bool ShouldFail { get; }
+
+    public bool ShouldWarn { get; }
+}
+
+internal sealed class ReproVariantEvaluation
+{
+    public ReproVariantEvaluation(
+        ReproOutcomeExpectation expectation,
+        ReproOutcomeKind actualKind,
+        ReproExecutionResult? result,
+        bool met,
+        bool shouldFail,
+        bool shouldWarn,
+        string? failureReason)
+    {
+        Expectation = expectation;
+        ActualKind = actualKind;
+        Result = result;
+        Met = met;
+        ShouldFail = shouldFail;
+        ShouldWarn = shouldWarn;
+        FailureReason = failureReason;
+    }
+
+    public ReproOutcomeExpectation Expectation { get; }
+
+    public ReproOutcomeKind ActualKind { get; }
+
+    public ReproExecutionResult? Result { get; }
+
+    public bool Met { get; }
+
+    public bool ShouldFail { get; }
+
+    public bool ShouldWarn { get; }
+
+    public string? FailureReason { get; }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Execution/RunReportModels.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Execution/RunReportModels.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using LiteDB.ReproRunner.Cli.Manifests;
+
+namespace LiteDB.ReproRunner.Cli.Execution;
+
+internal sealed class RunReport
+{
+    public DateTimeOffset GeneratedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    public string? Root { get; init; }
+
+    public IReadOnlyList<RunReportEntry> Repros => _repros;
+
+    private readonly List<RunReportEntry> _repros = new();
+
+    public void Add(RunReportEntry entry)
+    {
+        if (entry is null)
+        {
+            throw new ArgumentNullException(nameof(entry));
+        }
+
+        _repros.Add(entry);
+    }
+}
+
+internal sealed class RunReportEntry
+{
+    public string Id { get; init; } = string.Empty;
+
+    public ReproState State { get; init; }
+
+    public bool Failed { get; init; }
+
+    public bool Warned { get; init; }
+
+    public RunReportVariant Package { get; init; } = new();
+
+    public RunReportVariant Latest { get; init; } = new();
+}
+
+internal sealed class RunReportVariant
+{
+    public ReproOutcomeKind Expected { get; init; }
+
+    public int? ExpectedExitCode { get; init; }
+
+    public string? ExpectedLogContains { get; init; }
+
+    public ReproOutcomeKind Actual { get; init; }
+
+    public bool Met { get; init; }
+
+    public int? ExitCode { get; init; }
+
+    public double? DurationSeconds { get; init; }
+
+    public bool UseProjectReference { get; init; }
+
+    public string? FailureReason { get; init; }
+
+    public IReadOnlyList<RunReportCapturedLine> Output { get; init; } = Array.Empty<RunReportCapturedLine>();
+}
+
+internal sealed class RunReportCapturedLine
+{
+    public string Stream { get; init; } = string.Empty;
+
+    public string Text { get; init; } = string.Empty;
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Infrastructure/CliOutput.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Infrastructure/CliOutput.cs
@@ -38,7 +38,7 @@ internal static class CliOutput
         var table = new Table().Border(TableBorder.Rounded).AddColumns("Field", "Value");
         table.AddRow("Id", Markup.Escape(manifest.Id));
         table.AddRow("Title", Markup.Escape(manifest.Title));
-        table.AddRow("State", Markup.Escape(manifest.State));
+        table.AddRow("State", Markup.Escape(FormatState(manifest.State)));
         table.AddRow("TimeoutSeconds", Markup.Escape(manifest.TimeoutSeconds.ToString()));
         table.AddRow("RequiresParallel", Markup.Escape(manifest.RequiresParallel.ToString()));
         table.AddRow("DefaultInstances", Markup.Escape(manifest.DefaultInstances.ToString()));
@@ -98,7 +98,7 @@ internal static class CliOutput
             var manifest = repro.Manifest;
             table.AddRow(
                 Markup.Escape(manifest.Id),
-                Markup.Escape(manifest.State),
+                Markup.Escape(FormatState(manifest.State)),
                 Markup.Escape($"{manifest.TimeoutSeconds}s"),
                 Markup.Escape(manifest.FailingSince ?? "-"),
                 Markup.Escape(manifest.Tags.Count > 0 ? string.Join(",", manifest.Tags) : "-"),
@@ -111,5 +111,16 @@ internal static class CliOutput
     private static string NormalizePath(string path)
     {
         return path.Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    private static string FormatState(ReproState state)
+    {
+        return state switch
+        {
+            ReproState.Red => "red",
+            ReproState.Green => "green",
+            ReproState.Flaky => "flaky",
+            _ => state.ToString().ToLowerInvariant()
+        };
     }
 }

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Manifests/ManifestValidator.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Manifests/ManifestValidator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -9,7 +10,12 @@ namespace LiteDB.ReproRunner.Cli.Manifests;
 /// </summary>
 internal sealed class ManifestValidator
 {
-    private static readonly string[] AllowedStates = { "red", "green", "flaky" };
+    private static readonly Dictionary<string, ReproState> AllowedStates = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["red"] = ReproState.Red,
+        ["green"] = ReproState.Green,
+        ["flaky"] = ReproState.Flaky
+    };
     private static readonly Regex IdPattern = new("^[A-Za-z0-9_]+$", RegexOptions.Compiled);
 
     /// <summary>
@@ -47,7 +53,8 @@ internal sealed class ManifestValidator
             "sharedDatabaseKey",
             "args",
             "tags",
-            "state"
+            "state",
+            "expectedOutcomes"
         };
 
         foreach (var name in map.Keys)
@@ -319,19 +326,19 @@ internal sealed class ManifestValidator
             }
         }
 
-        string? state = null;
+        ReproState? state = null;
         if (map.TryGetValue("state", out var stateElement))
         {
             if (stateElement.ValueKind == JsonValueKind.String)
             {
-                var value = stateElement.GetString()?.Trim().ToLowerInvariant();
-                if (string.IsNullOrEmpty(value) || !AllowedStates.Contains(value))
+                var value = stateElement.GetString()?.Trim();
+                if (string.IsNullOrEmpty(value) || !AllowedStates.TryGetValue(value, out var parsedState))
                 {
                     validation.AddError("$.state: expected one of red, green, flaky.");
                 }
                 else
                 {
-                    state = value;
+                    state = parsedState;
                 }
             }
             else
@@ -342,6 +349,12 @@ internal sealed class ManifestValidator
         else
         {
             validation.AddError("$.state: property is required.");
+        }
+
+        ReproVariantOutcomeExpectations? expectedOutcomes = ReproVariantOutcomeExpectations.Empty;
+        if (map.TryGetValue("expectedOutcomes", out var expectedOutcomesElement))
+        {
+            expectedOutcomes = ParseExpectedOutcomes(expectedOutcomesElement, validation);
         }
 
         if (requiresParallel == true)
@@ -357,7 +370,7 @@ internal sealed class ManifestValidator
             }
         }
 
-        if (id is null || title is null || timeoutSeconds is null || requiresParallel is null || defaultInstances is null || state is null)
+        if (id is null || title is null || timeoutSeconds is null || requiresParallel is null || defaultInstances is null || state is null || expectedOutcomes is null)
         {
             return null;
         }
@@ -377,7 +390,8 @@ internal sealed class ManifestValidator
             sharedDatabaseKey,
             argsArray,
             tagsArray,
-            state);
+            state.Value,
+            expectedOutcomes);
     }
 
     private static string DescribeKind(JsonValueKind kind)
@@ -393,5 +407,148 @@ internal sealed class ManifestValidator
             JsonValueKind.Null => "null",
             _ => kind.ToString().ToLowerInvariant()
         };
+    }
+
+    private static ReproVariantOutcomeExpectations? ParseExpectedOutcomes(JsonElement root, ManifestValidationResult validation)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            validation.AddError("$.expectedOutcomes: expected object value.");
+            return null;
+        }
+
+        var allowed = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "package",
+            "latest"
+        };
+
+        foreach (var property in root.EnumerateObject())
+        {
+            if (!allowed.Contains(property.Name))
+            {
+                validation.AddError($"$.expectedOutcomes.{property.Name}: unknown property.");
+            }
+        }
+
+        ReproOutcomeExpectation? package = null;
+        ReproOutcomeExpectation? latest = null;
+
+        if (root.TryGetProperty("package", out var packageElement))
+        {
+            package = ParseOutcomeExpectation(packageElement, "$.expectedOutcomes.package", validation);
+        }
+
+        if (root.TryGetProperty("latest", out var latestElement))
+        {
+            latest = ParseOutcomeExpectation(latestElement, "$.expectedOutcomes.latest", validation);
+            if (latest?.Kind == ReproOutcomeKind.HardFail)
+            {
+                validation.AddError("$.expectedOutcomes.latest.kind: hardFail is only supported for the package variant.");
+            }
+        }
+
+        if (package is null && root.TryGetProperty("package", out _))
+        {
+            return null;
+        }
+
+        if (latest is null && root.TryGetProperty("latest", out _))
+        {
+            return null;
+        }
+
+        return new ReproVariantOutcomeExpectations(package, latest);
+    }
+
+    private static ReproOutcomeExpectation? ParseOutcomeExpectation(JsonElement element, string path, ManifestValidationResult validation)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            validation.AddError($"{path}: expected object value.");
+            return null;
+        }
+
+        var allowed = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "kind",
+            "exitCode",
+            "logContains"
+        };
+
+        foreach (var property in element.EnumerateObject())
+        {
+            if (!allowed.Contains(property.Name))
+            {
+                validation.AddError($"{path}.{property.Name}: unknown property.");
+            }
+        }
+
+        if (!element.TryGetProperty("kind", out var kindElement) || kindElement.ValueKind != JsonValueKind.String)
+        {
+            validation.AddError($"{path}.kind: expected string value.");
+            return null;
+        }
+
+        var kindText = kindElement.GetString()?.Trim();
+        if (string.IsNullOrEmpty(kindText))
+        {
+            validation.AddError($"{path}.kind: value must not be empty.");
+            return null;
+        }
+
+        ReproOutcomeKind kind;
+        switch (kindText.ToLowerInvariant())
+        {
+            case "reproduce":
+                kind = ReproOutcomeKind.Reproduce;
+                break;
+            case "norepro":
+                kind = ReproOutcomeKind.NoRepro;
+                break;
+            case "hardfail":
+                kind = ReproOutcomeKind.HardFail;
+                break;
+            default:
+                validation.AddError($"{path}.kind: expected one of reproduce, norepro, hardFail.");
+                return null;
+        }
+
+        int? exitCode = null;
+        if (element.TryGetProperty("exitCode", out var exitCodeElement))
+        {
+            if (exitCodeElement.ValueKind == JsonValueKind.Number && exitCodeElement.TryGetInt32(out var parsed))
+            {
+                exitCode = parsed;
+            }
+            else
+            {
+                validation.AddError($"{path}.exitCode: expected integer value.");
+                return null;
+            }
+        }
+
+        string? logContains = null;
+        if (element.TryGetProperty("logContains", out var logElement))
+        {
+            if (logElement.ValueKind == JsonValueKind.String)
+            {
+                var value = logElement.GetString();
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    validation.AddError($"{path}.logContains: value must not be empty when provided.");
+                    return null;
+                }
+
+                logContains = value;
+            }
+            else
+            {
+                validation.AddError($"{path}.logContains: expected string value.");
+                return null;
+            }
+        }
+
+        return new ReproOutcomeExpectation(kind, exitCode, logContains);
     }
 }

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Manifests/ReproManifest.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Manifests/ReproManifest.cs
@@ -19,6 +19,7 @@ internal sealed class ReproManifest
     /// <param name="args">Additional command-line arguments passed to the repro host.</param>
     /// <param name="tags">Tags describing the repro characteristics.</param>
     /// <param name="state">The current state of the repro (e.g., red, green).</param>
+    /// <param name="expectedOutcomes">The optional expected outcomes per variant.</param>
     public ReproManifest(
         string id,
         string title,
@@ -30,7 +31,8 @@ internal sealed class ReproManifest
         string? sharedDatabaseKey,
         IReadOnlyList<string> args,
         IReadOnlyList<string> tags,
-        string state)
+        ReproState state,
+        ReproVariantOutcomeExpectations expectedOutcomes)
     {
         Id = id;
         Title = title;
@@ -43,6 +45,7 @@ internal sealed class ReproManifest
         Args = args;
         Tags = tags;
         State = state;
+        ExpectedOutcomes = expectedOutcomes ?? ReproVariantOutcomeExpectations.Empty;
     }
 
     /// <summary>
@@ -96,7 +99,12 @@ internal sealed class ReproManifest
     public IReadOnlyList<string> Tags { get; }
 
     /// <summary>
-    /// Gets the declared state of the repro (for example, "red").
+    /// Gets the declared state of the repro (for example, <see cref="ReproState.Red"/>).
     /// </summary>
-    public string State { get; }
+    public ReproState State { get; }
+
+    /// <summary>
+    /// Gets the expected outcomes for the package and latest variants.
+    /// </summary>
+    public ReproVariantOutcomeExpectations ExpectedOutcomes { get; }
 }

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Manifests/ReproOutcomeExpectation.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Manifests/ReproOutcomeExpectation.cs
@@ -1,0 +1,17 @@
+namespace LiteDB.ReproRunner.Cli.Manifests;
+
+internal sealed class ReproOutcomeExpectation
+{
+    public ReproOutcomeExpectation(ReproOutcomeKind kind, int? exitCode, string? logContains)
+    {
+        Kind = kind;
+        ExitCode = exitCode;
+        LogContains = logContains;
+    }
+
+    public ReproOutcomeKind Kind { get; }
+
+    public int? ExitCode { get; }
+
+    public string? LogContains { get; }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Manifests/ReproOutcomeKind.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Manifests/ReproOutcomeKind.cs
@@ -1,0 +1,8 @@
+namespace LiteDB.ReproRunner.Cli.Manifests;
+
+internal enum ReproOutcomeKind
+{
+    Reproduce,
+    NoRepro,
+    HardFail
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Manifests/ReproState.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Manifests/ReproState.cs
@@ -1,0 +1,8 @@
+namespace LiteDB.ReproRunner.Cli.Manifests;
+
+internal enum ReproState
+{
+    Red,
+    Green,
+    Flaky
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Manifests/ReproVariantOutcomeExpectations.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Manifests/ReproVariantOutcomeExpectations.cs
@@ -1,0 +1,16 @@
+namespace LiteDB.ReproRunner.Cli.Manifests;
+
+internal sealed class ReproVariantOutcomeExpectations
+{
+    public static readonly ReproVariantOutcomeExpectations Empty = new(null, null);
+
+    public ReproVariantOutcomeExpectations(ReproOutcomeExpectation? package, ReproOutcomeExpectation? latest)
+    {
+        Package = package;
+        Latest = latest;
+    }
+
+    public ReproOutcomeExpectation? Package { get; }
+
+    public ReproOutcomeExpectation? Latest { get; }
+}

--- a/LiteDB.ReproRunner/README.md
+++ b/LiteDB.ReproRunner/README.md
@@ -117,9 +117,41 @@ exposes the metadata in the `list`, `show`, and `run` commands.
 | `args`               | string[]      | no       | Extra arguments passed to `dotnet run --`. |
 | `tags`               | string[]      | no       | Arbitrary labels for filtering (`list` prints them). |
 | `state`              | enum          | yes      | One of `red`, `green`, or `flaky`. |
+| `expectedOutcomes`   | object        | no       | Optional overrides for package/latest expectations (see below). |
 
 Unknown properties are rejected to keep the schema tight. The CLI also validates that each repro
 folder contains exactly one `.csproj` file.
+
+### Expected outcomes
+
+The optional `expectedOutcomes` block lets a manifest describe how each variant should behave. When
+absent, the CLI assumes the package build reproduces the issue (`kind: reproduce`) while the latest
+build matches the manifest state (`red` expects another reproduction, `green` expects `noRepro`, and
+`flaky` tolerates either outcome but emits a warning when it deviates).
+
+```json
+"expectedOutcomes": {
+  "package": {
+    "kind": "hardFail",
+    "exitCode": -5,
+    "logContains": "NetworkException"
+  },
+  "latest": {
+    "kind": "noRepro"
+  }
+}
+```
+
+Each variant supports the following `kind` values:
+
+* `reproduce` – Exit code `0` indicates success.
+* `noRepro` – Any non-zero exit code is treated as expected, signalling that the repro no longer
+  manifests the issue.
+* `hardFail` – Reserved for the package build. Use this when reproduction requires the host to crash
+  with a specific exit code or log message. The latest build must always exit cleanly.
+
+`exitCode` constrains the expected exit value, while `logContains` (case-insensitive) ensures the
+captured stdout/stderr output contains a specific substring. Leave them unset to accept any value.
 
 ### Validation output
 
@@ -163,6 +195,8 @@ repro-runner run <id> [--instances N] [--timeout S] [--skipValidation]
 * `--timeout` – Override the manifest timeout (seconds).
 * `--skipValidation` – Run even when the manifest is invalid (execution still requires the manifest to
   parse successfully).
+* `--report <path>` – Emit a JSON summary of the run to the specified file (use `-` for stdout).
+* `--report-format json` – Explicitly request JSON output. Additional formats may be added later.
 
 Each invocation plans deterministic run directories under the CLI’s output folder
 (`bin/<tfm>/<configuration>/runs/<manifest>/<variant>`), cleans any leftover artifacts, and prepares all
@@ -175,6 +209,40 @@ cancellations occur.
 Timeouts are enforced across all processes. When the timeout elapses the runner terminates all child
 processes and returns exit code `1`. Build failures surface in the run table and return a non-zero exit
 code even when execution is skipped.
+
+### Machine-readable reports
+
+Pass `--report <path>` (or `--report -` to stream to stdout) to persist the run summary as JSON. Each
+entry captures the manifest state, expectation result, exit codes, durations, and a trimmed copy of the
+stdout/stderr output:
+
+```json
+{
+  "generatedAt": "2024-03-31T12:34:56.7891234+00:00",
+  "repros": [
+    {
+      "id": "Issue_2561_TransactionMonitor",
+      "state": "Red",
+      "failed": false,
+      "package": {
+        "expected": "Reproduce",
+        "met": true,
+        "exitCode": 0,
+        "durationSeconds": 8.2
+      },
+      "latest": {
+        "expected": "Reproduce",
+        "met": true,
+        "exitCode": 0,
+        "durationSeconds": 8.1
+      }
+    }
+  ]
+}
+```
+
+The workflow publishes this file as an artifact so that other tools (for example, dashboards or
+auto-triage bots) can reason about the latest run without scraping console output.
 
 ## Parallel repros
 
@@ -191,14 +259,26 @@ folder to create or open the same database file.
 
 ## CI integration
 
-The GitHub Actions workflow builds the repository in Release mode, then runs:
+The GitHub Actions workflow builds the repository in Release mode and then exercises the CLI in three
+steps:
 
 1. `repro-runner list --strict`
 2. `repro-runner validate`
-3. A smoke repro run (initially `Issue_2561_TransactionMonitor`)
+3. `repro-runner run --all --report repro-summary.json`
 
-Any non-zero exit code fails the job, ensuring the manifests stay valid and at least one repro is
-exercised on every PR.
+Execution honours the manifest state and expectations:
+
+* **Package variant** – Must reproduce the issue. If the manifest declares a `hardFail` expectation,
+  the runner accepts the specified crash signature instead.
+* **Latest variant (`red`)** – Still expected to reproduce. CI stays green even though the repro
+  remains failing.
+* **Latest variant (`green`)** – Must *not* reproduce. When the repro finally passes, CI turns green
+  automatically.
+* **Latest variant (`flaky`)** – Deviations emit warnings in the JSON report and table output but do
+  not fail the build.
+
+The JSON summary (`repro-summary.json`) is uploaded as an artifact so downstream automation can
+inspect exit codes, durations, and captured logs.
 
 ## Troubleshooting
 
@@ -217,8 +297,9 @@ exercised on every PR.
 switching. The CLI gives us deterministic orchestration without constraining the repro to the xUnit
 lifecycle. Test suites can still shell out to `repro-runner` if desired.
 
-**How do I mark a repro as fixed?** Update `state` to `green`, adjust the README, and ensure the repro
-now exits `0` when the fix is present. Keeping the repro around prevents regressions.
+**How do I mark a repro as fixed?** Update `state` to `green`, adjust the README, and make sure the
+`expectedOutcomes.latest` entry (or the implicit default) expects `noRepro`. Hard-fail overrides for the
+package build can stay in place. Keeping the repro around prevents regressions.
 
 **Can I share helper code?** Keep repros isolated so they are self-documenting. If you must share
 helpers, place them next to the CLI and avoid coupling repros together.


### PR DESCRIPTION
## Summary
- interpret manifest state via a new outcome evaluator and manifest expectation types, including hard-fail metadata
- capture repro stdout/stderr for analysis, emit JSON run reports, and update the workflow to run all repros with reporting
- document the state-aware policy, hard-fail expectations, and report usage while expanding unit coverage for manifests and evaluation

## Testing
- dotnet test LiteDB.ReproRunner.Tests/LiteDB.ReproRunner.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d9a6a5f630832aa3da1d7841bdc5b3