### PR TITLE
Add configuration handshake validation for repro runner

### DIFF
--- a/LiteDB.ReproRunner.Tests/ReproExecutorTests.cs
+++ b/LiteDB.ReproRunner.Tests/ReproExecutorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using LiteDB.ReproRunner.Cli.Execution;
 using LiteDB.ReproRunner.Shared;
@@ -32,5 +33,69 @@ public sealed class ReproExecutorTests
         Assert.Equal(ReproHostLogLevel.Error, observed[0].Level);
         Assert.Equal(string.Empty, output.ToString());
         Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public void TryProcessStructuredLine_RejectsMessagesBeforeConfiguration()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var executor = new ReproExecutor(output, error);
+        executor.ConfigureExpectedConfiguration(false, "5.0.20", 1);
+
+        var logEnvelope = ReproHostMessageEnvelope.CreateLog("hello", ReproHostLogLevel.Information);
+        var json = JsonSerializer.Serialize(logEnvelope, ReproJsonOptions.Default);
+
+        var parsed = executor.TryProcessStructuredLine(json, 0);
+
+        Assert.True(parsed);
+        Assert.Contains("configuration error", error.ToString());
+        Assert.Contains("expected configuration handshake", error.ToString());
+        Assert.Equal(string.Empty, output.ToString());
+    }
+
+    [Fact]
+    public void TryProcessStructuredLine_AllowsMessagesAfterValidConfiguration()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var executor = new ReproExecutor(output, error);
+        executor.ConfigureExpectedConfiguration(false, "5.0.20", 1);
+
+        var configuration = ReproHostMessageEnvelope.CreateConfiguration(false, "5.0.20");
+        var configurationJson = JsonSerializer.Serialize(configuration, ReproJsonOptions.Default);
+        var logEnvelope = ReproHostMessageEnvelope.CreateLog("ready", ReproHostLogLevel.Information);
+        var logJson = JsonSerializer.Serialize(logEnvelope, ReproJsonOptions.Default);
+
+        var configParsed = executor.TryProcessStructuredLine(configurationJson, 0);
+        var logParsed = executor.TryProcessStructuredLine(logJson, 0);
+
+        Assert.True(configParsed);
+        Assert.True(logParsed);
+        Assert.Contains("ready", output.ToString());
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public void TryProcessStructuredLine_FlagsConfigurationMismatch()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var executor = new ReproExecutor(output, error);
+        executor.ConfigureExpectedConfiguration(false, "5.0.20", 1);
+
+        var configuration = ReproHostMessageEnvelope.CreateConfiguration(true, "5.0.20");
+        var configurationJson = JsonSerializer.Serialize(configuration, ReproJsonOptions.Default);
+        var parsed = executor.TryProcessStructuredLine(configurationJson, 0);
+
+        Assert.True(parsed);
+        Assert.Contains("configuration error", error.ToString());
+        Assert.Contains("UseProjectReference=True", error.ToString(), StringComparison.OrdinalIgnoreCase);
+
+        var logEnvelope = ReproHostMessageEnvelope.CreateLog("ignored", ReproHostLogLevel.Information);
+        var logJson = JsonSerializer.Serialize(logEnvelope, ReproJsonOptions.Default);
+        executor.TryProcessStructuredLine(logJson, 0);
+
+        Assert.Equal(string.Empty, output.ToString());
     }
 }

--- a/LiteDB.ReproRunner.Tests/ReproHostClientTests.cs
+++ b/LiteDB.ReproRunner.Tests/ReproHostClientTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 using LiteDB.ReproRunner.Cli.Execution;
 using LiteDB.ReproRunner.Shared.Messaging;
 
@@ -21,6 +22,25 @@ public sealed class ReproHostClientTests
         Assert.Equal(ReproHostMessageTypes.Log, envelope!.Type);
         Assert.Equal(ReproHostLogLevel.Warning, envelope.Level);
         Assert.Equal("hello world", envelope.Text);
+    }
+
+    [Fact]
+    public async Task SendConfigurationAsync_WritesConfigurationEnvelope()
+    {
+        var writer = new StringWriter();
+        var client = new ReproHostClient(writer, TextReader.Null, CreateOptions());
+
+        await client.SendConfigurationAsync(true, "5.0.20");
+
+        var output = writer.ToString().Trim();
+        Assert.True(ReproHostMessageEnvelope.TryParse(output, out var envelope, out _));
+        Assert.NotNull(envelope);
+        Assert.Equal(ReproHostMessageTypes.Configuration, envelope!.Type);
+
+        var payload = envelope.DeserializePayload<ReproHostConfigurationPayload>();
+        Assert.NotNull(payload);
+        Assert.True(payload!.UseProjectReference);
+        Assert.Equal("5.0.20", payload.LiteDBPackageVersion);
     }
 
     [Fact]

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/RunCommand.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Commands/RunCommand.cs
@@ -187,14 +187,16 @@ internal sealed class RunCommand : AsyncCommand<RunCommandSettings>
                             manifest.Id,
                             packageVariantId,
                             packageDisplay,
-                            useProjectReference: false);
+                            useProjectReference: false,
+                            liteDbPackageVersion: packageVersion);
 
                         var latestPlan = _planner.CreateVariantPlan(
                             repro,
                             manifest.Id,
                             "ver_latest",
                             "Latest",
-                            useProjectReference: true);
+                            useProjectReference: true,
+                            liteDbPackageVersion: packageVersion);
 
                         plannedVariants.Add(packagePlan);
                         plannedVariants.Add(latestPlan);

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Execution/ReproBuildCoordinator.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Execution/ReproBuildCoordinator.cs
@@ -50,6 +50,11 @@ internal sealed class ReproBuildCoordinator
                 $"-p:OutputPath={plan.BuildOutputDirectory}"
             };
 
+            if (!string.IsNullOrWhiteSpace(plan.LiteDBPackageVersion))
+            {
+                arguments.Add($"-p:LiteDBPackageVersion={plan.LiteDBPackageVersion}");
+            }
+
             var (exitCode, output) = await RunProcessAsync(projectDirectory, arguments, cancellationToken).ConfigureAwait(false);
 
             if (exitCode != 0)

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Execution/ReproExecutor.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Execution/ReproExecutor.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using LiteDB.ReproRunner.Cli.Manifests;
@@ -15,6 +18,11 @@ internal sealed class ReproExecutor
     private readonly TextWriter _standardOut;
     private readonly TextWriter _standardError;
     private readonly object _writeLock = new();
+    private readonly object _configurationLock = new();
+    private readonly Dictionary<int, ConfigurationState> _configurationStates = new();
+    private ConfigurationExpectation? _configurationExpectation;
+    private bool _configurationMismatchDetected;
+    private int _expectedConfigurationInstances;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ReproExecutor"/> class using the console streams.
@@ -35,6 +43,26 @@ internal sealed class ReproExecutor
     internal Action<ReproExecutionLogEntry>? LogObserver { get; set; }
 
     internal bool SuppressConsoleLogOutput { get; set; }
+
+    internal void ConfigureExpectedConfiguration(bool useProjectReference, string? liteDbPackageVersion, int instanceCount)
+    {
+        var normalizedVersion = string.IsNullOrWhiteSpace(liteDbPackageVersion)
+            ? null
+            : liteDbPackageVersion.Trim();
+
+        lock (_configurationLock)
+        {
+            _configurationExpectation = new ConfigurationExpectation(useProjectReference, normalizedVersion);
+            _configurationStates.Clear();
+            _expectedConfigurationInstances = Math.Max(instanceCount, 0);
+            _configurationMismatchDetected = false;
+
+            for (var index = 0; index < _expectedConfigurationInstances; index++)
+            {
+                _configurationStates[index] = new ConfigurationState();
+            }
+        }
+    }
 
     /// <summary>
     /// Executes the provided repro build across the requested number of instances.
@@ -68,6 +96,7 @@ internal sealed class ReproExecutor
         }
 
         var manifest = repro.Manifest ?? throw new InvalidOperationException("Manifest is required to execute a repro.");
+        ConfigureExpectedConfiguration(build.Plan.UseProjectReference, build.Plan.LiteDBPackageVersion, instances);
         var projectDirectory = Path.GetDirectoryName(repro.ProjectPath)!;
         var stopwatch = Stopwatch.StartNew();
 
@@ -79,18 +108,33 @@ internal sealed class ReproExecutor
         var sharedRoot = Path.Combine(build.Plan.ExecutionRootDirectory, Sanitize(sharedKey), runIdentifier);
         Directory.CreateDirectory(sharedRoot);
 
-        var exitCode = await RunInstancesAsync(
-            manifest,
-            projectDirectory,
-            build.AssemblyPath,
-            instances,
-            timeoutSeconds,
-            sharedRoot,
-            runIdentifier,
-            cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var exitCode = await RunInstancesAsync(
+                manifest,
+                projectDirectory,
+                build.AssemblyPath,
+                instances,
+                timeoutSeconds,
+                sharedRoot,
+                runIdentifier,
+                cancellationToken).ConfigureAwait(false);
 
-        stopwatch.Stop();
-        return new ReproExecutionResult(build.Plan.UseProjectReference, exitCode == 0, exitCode, stopwatch.Elapsed);
+            FinalizeConfigurationValidation();
+            var configurationMismatch = HasConfigurationMismatch();
+
+            if (configurationMismatch && exitCode == 0)
+            {
+                exitCode = -2;
+            }
+
+            stopwatch.Stop();
+            return new ReproExecutionResult(build.Plan.UseProjectReference, exitCode == 0 && !configurationMismatch, exitCode, stopwatch.Elapsed);
+        }
+        finally
+        {
+            ResetConfigurationExpectation();
+        }
     }
 
     private async Task<int> RunInstancesAsync(
@@ -258,14 +302,19 @@ internal sealed class ReproExecutor
             return false;
         }
 
+        StructuredMessageObserver?.Invoke(instanceIndex, envelope!);
+
+        if (!HandleConfigurationHandshake(instanceIndex, envelope!))
+        {
+            return true;
+        }
+
         HandleStructuredMessage(instanceIndex, envelope!);
         return true;
     }
 
     private void HandleStructuredMessage(int instanceIndex, ReproHostMessageEnvelope envelope)
     {
-        StructuredMessageObserver?.Invoke(instanceIndex, envelope);
-
         switch (envelope.Type)
         {
             case ReproHostMessageTypes.Log:
@@ -283,10 +332,194 @@ internal sealed class ReproExecutor
                     : string.Empty;
                 WriteOutputLine($"[{instanceIndex}] progress: {envelope.Event ?? "(unknown)"}{suffix}");
                 break;
+            case ReproHostMessageTypes.Configuration:
+                break;
             default:
                 WriteOutputLine($"[{instanceIndex}] {envelope.Type}: {envelope.Text ?? string.Empty}");
                 break;
         }
+    }
+
+    private bool HandleConfigurationHandshake(int instanceIndex, ReproHostMessageEnvelope envelope)
+    {
+        string? errorMessage = null;
+        var shouldProcess = true;
+
+        lock (_configurationLock)
+        {
+            if (_configurationExpectation is not { } expectation)
+            {
+                if (string.Equals(envelope.Type, ReproHostMessageTypes.Configuration, StringComparison.Ordinal))
+                {
+                    shouldProcess = false;
+                }
+
+                return shouldProcess;
+            }
+
+            if (!_configurationStates.TryGetValue(instanceIndex, out var state))
+            {
+                state = new ConfigurationState();
+                _configurationStates[instanceIndex] = state;
+            }
+
+            if (!state.Received)
+            {
+                if (!string.Equals(envelope.Type, ReproHostMessageTypes.Configuration, StringComparison.Ordinal))
+                {
+                    errorMessage = "expected configuration handshake before other messages.";
+                    state.Received = true;
+                    state.IsValid = false;
+                    _configurationMismatchDetected = true;
+                    shouldProcess = false;
+                }
+                else
+                {
+                    var payload = envelope.DeserializePayload<ReproHostConfigurationPayload>();
+                    if (payload is null)
+                    {
+                        errorMessage = "reported configuration without a payload.";
+                        state.Received = true;
+                        state.IsValid = false;
+                        _configurationMismatchDetected = true;
+                        shouldProcess = false;
+                    }
+                    else
+                    {
+                        var actualVersion = string.IsNullOrWhiteSpace(payload.LiteDBPackageVersion)
+                            ? null
+                            : payload.LiteDBPackageVersion.Trim();
+
+                        var expectedVersion = expectation.LiteDbPackageVersion;
+                        var versionMatches = string.Equals(
+                            actualVersion ?? string.Empty,
+                            expectedVersion ?? string.Empty,
+                            StringComparison.OrdinalIgnoreCase);
+
+                        if (payload.UseProjectReference != expectation.UseProjectReference || !versionMatches)
+                        {
+                            var expectedVersionDisplay = expectedVersion ?? "(unspecified)";
+                            var actualVersionDisplay = actualVersion ?? "(unspecified)";
+                            errorMessage = $"reported configuration UseProjectReference={payload.UseProjectReference}, LiteDBPackageVersion={actualVersionDisplay} but expected UseProjectReference={expectation.UseProjectReference}, LiteDBPackageVersion={expectedVersionDisplay}.";
+                            state.IsValid = false;
+                            _configurationMismatchDetected = true;
+                        }
+                        else
+                        {
+                            state.IsValid = true;
+                        }
+
+                        state.Received = true;
+                        shouldProcess = false;
+                    }
+                }
+            }
+            else if (!state.IsValid)
+            {
+                shouldProcess = false;
+            }
+            else if (string.Equals(envelope.Type, ReproHostMessageTypes.Configuration, StringComparison.Ordinal))
+            {
+                shouldProcess = false;
+            }
+        }
+
+        if (errorMessage is not null)
+        {
+            WriteConfigurationError(instanceIndex, errorMessage);
+        }
+
+        return shouldProcess;
+    }
+
+    private void FinalizeConfigurationValidation()
+    {
+        List<int>? missingInstances = null;
+
+        lock (_configurationLock)
+        {
+            if (_configurationExpectation is null)
+            {
+                return;
+            }
+
+            for (var index = 0; index < _expectedConfigurationInstances; index++)
+            {
+                if (!_configurationStates.TryGetValue(index, out var state))
+                {
+                    state = new ConfigurationState();
+                    _configurationStates[index] = state;
+                }
+
+                if (!state.Received)
+                {
+                    state.Received = true;
+                    state.IsValid = false;
+                    _configurationMismatchDetected = true;
+                    missingInstances ??= new List<int>();
+                    missingInstances.Add(index);
+                }
+            }
+        }
+
+        if (missingInstances is null)
+        {
+            return;
+        }
+
+        foreach (var instanceIndex in missingInstances)
+        {
+            WriteConfigurationError(instanceIndex, "did not report configuration handshake.");
+        }
+    }
+
+    private bool HasConfigurationMismatch()
+    {
+        lock (_configurationLock)
+        {
+            if (_configurationExpectation is null)
+            {
+                return false;
+            }
+
+            if (_configurationMismatchDetected)
+            {
+                return true;
+            }
+
+            foreach (var state in _configurationStates.Values)
+            {
+                if (!state.IsValid)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    private void ResetConfigurationExpectation()
+    {
+        lock (_configurationLock)
+        {
+            _configurationExpectation = null;
+            _configurationStates.Clear();
+            _configurationMismatchDetected = false;
+            _expectedConfigurationInstances = 0;
+        }
+    }
+
+    private void WriteConfigurationError(int instanceIndex, string message)
+    {
+        LogObserver?.Invoke(new ReproExecutionLogEntry(instanceIndex, $"configuration error: {message}", ReproHostLogLevel.Error));
+
+        if (SuppressConsoleLogOutput)
+        {
+            return;
+        }
+
+        WriteErrorLine($"[{instanceIndex}] configuration error: {message}");
     }
 
     private void WriteLogMessage(int instanceIndex, ReproHostMessageEnvelope envelope)
@@ -408,6 +641,15 @@ internal sealed class ReproExecutor
 
         return builder.Length == 0 ? "shared" : builder.ToString();
     }
+
+    private sealed class ConfigurationState
+    {
+        public bool Received { get; set; }
+
+        public bool IsValid { get; set; } = true;
+    }
+
+    private readonly record struct ConfigurationExpectation(bool UseProjectReference, string? LiteDbPackageVersion);
 }
 
 /// <summary>

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Execution/RunDirectoryPlanner.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Cli/Execution/RunDirectoryPlanner.cs
@@ -26,13 +26,15 @@ internal sealed class RunDirectoryPlanner
     /// <param name="variantIdentifier">The identifier to use for the variant directory.</param>
     /// <param name="displayName">The display label shown to the user.</param>
     /// <param name="useProjectReference">Indicates whether the repro should build against the source project.</param>
+    /// <param name="liteDbPackageVersion">The LiteDB package version associated with the variant.</param>
     /// <returns>The planned variant with prepared directories.</returns>
     public RunVariantPlan CreateVariantPlan(
         DiscoveredRepro repro,
         string manifestIdentifier,
         string variantIdentifier,
         string displayName,
-        bool useProjectReference)
+        bool useProjectReference,
+        string? liteDbPackageVersion)
     {
         if (repro is null)
         {
@@ -66,6 +68,7 @@ internal sealed class RunDirectoryPlanner
             repro,
             displayName,
             useProjectReference,
+            liteDbPackageVersion,
             manifestIdentifier,
             variantIdentifier,
             variantRoot,
@@ -120,6 +123,7 @@ internal sealed class RunVariantPlan : IDisposable
     /// <param name="repro">The repro that produced this plan.</param>
     /// <param name="displayName">The friendly name presented to the user.</param>
     /// <param name="useProjectReference">Indicates whether a project reference build should be used.</param>
+    /// <param name="liteDbPackageVersion">The LiteDB package version associated with the plan.</param>
     /// <param name="manifestIdentifier">The identifier used for the manifest directory.</param>
     /// <param name="variantIdentifier">The identifier used for the variant directory.</param>
     /// <param name="rootDirectory">The root directory allocated for the variant.</param>
@@ -130,6 +134,7 @@ internal sealed class RunVariantPlan : IDisposable
         DiscoveredRepro repro,
         string displayName,
         bool useProjectReference,
+        string? liteDbPackageVersion,
         string manifestIdentifier,
         string variantIdentifier,
         string rootDirectory,
@@ -140,6 +145,7 @@ internal sealed class RunVariantPlan : IDisposable
         Repro = repro ?? throw new ArgumentNullException(nameof(repro));
         DisplayName = displayName;
         UseProjectReference = useProjectReference;
+        LiteDBPackageVersion = liteDbPackageVersion;
         ManifestIdentifier = manifestIdentifier;
         VariantIdentifier = variantIdentifier;
         RootDirectory = rootDirectory ?? throw new ArgumentNullException(nameof(rootDirectory));
@@ -162,6 +168,11 @@ internal sealed class RunVariantPlan : IDisposable
     /// Gets a value indicating whether the build uses project references.
     /// </summary>
     public bool UseProjectReference { get; }
+
+    /// <summary>
+    /// Gets the LiteDB package version associated with the plan, when applicable.
+    /// </summary>
+    public string? LiteDBPackageVersion { get; }
 
     /// <summary>
     /// Gets the identifier used for the manifest directory.

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Shared/Messaging/ReproHostClient.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Shared/Messaging/ReproHostClient.cs
@@ -103,6 +103,18 @@ public sealed class ReproHostClient
     }
 
     /// <summary>
+    /// Sends a configuration handshake to the host.
+    /// </summary>
+    /// <param name="useProjectReference">Indicates whether the repro was built against the source project.</param>
+    /// <param name="liteDbPackageVersion">The LiteDB package version referenced by the repro, when applicable.</param>
+    /// <param name="cancellationToken">The token used to observe cancellation requests.</param>
+    /// <returns>A task that completes when the message has been written.</returns>
+    public Task SendConfigurationAsync(bool useProjectReference, string? liteDbPackageVersion, CancellationToken cancellationToken = default)
+    {
+        return SendAsync(ReproHostMessageEnvelope.CreateConfiguration(useProjectReference, liteDbPackageVersion), cancellationToken);
+    }
+
+    /// <summary>
     /// Sends a structured log message to the host synchronously.
     /// </summary>
     /// <param name="message">The log message text.</param>
@@ -142,6 +154,16 @@ public sealed class ReproHostClient
     public void SendProgress(string stage, double? percentComplete = null, object? payload = null)
     {
         SendProgressAsync(stage, percentComplete, payload).GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Sends a configuration handshake to the host synchronously.
+    /// </summary>
+    /// <param name="useProjectReference">Indicates whether the repro was built against the source project.</param>
+    /// <param name="liteDbPackageVersion">The LiteDB package version referenced by the repro, when applicable.</param>
+    public void SendConfiguration(bool useProjectReference, string? liteDbPackageVersion)
+    {
+        SendConfigurationAsync(useProjectReference, liteDbPackageVersion).GetAwaiter().GetResult();
     }
 
     /// <summary>

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Shared/Messaging/ReproHostConfigurationPayload.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Shared/Messaging/ReproHostConfigurationPayload.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace LiteDB.ReproRunner.Shared.Messaging;
+
+/// <summary>
+/// Represents the configuration handshake payload emitted by repro processes.
+/// </summary>
+public sealed record class ReproHostConfigurationPayload
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the repro was built against the source project.
+    /// </summary>
+    [JsonPropertyName("useProjectReference")]
+    public required bool UseProjectReference { get; init; }
+
+    /// <summary>
+    /// Gets or sets the LiteDB package version used by the repro when built from NuGet.
+    /// </summary>
+    [JsonPropertyName("liteDBPackageVersion")]
+    public string? LiteDBPackageVersion { get; init; }
+}

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Shared/Messaging/ReproHostMessageEnvelope.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Shared/Messaging/ReproHostMessageEnvelope.cs
@@ -144,6 +144,29 @@ public sealed class ReproHostMessageEnvelope
     }
 
     /// <summary>
+    /// Creates a configuration handshake message envelope.
+    /// </summary>
+    /// <param name="useProjectReference">Indicates whether the repro was built against the source project.</param>
+    /// <param name="liteDbPackageVersion">The LiteDB package version referenced by the repro, when applicable.</param>
+    /// <param name="timestamp">An optional timestamp to associate with the message.</param>
+    /// <returns>The constructed configuration message envelope.</returns>
+    public static ReproHostMessageEnvelope CreateConfiguration(bool useProjectReference, string? liteDbPackageVersion, DateTimeOffset? timestamp = null)
+    {
+        var payload = new ReproHostConfigurationPayload
+        {
+            UseProjectReference = useProjectReference,
+            LiteDBPackageVersion = liteDbPackageVersion
+        };
+
+        return new ReproHostMessageEnvelope
+        {
+            Type = ReproHostMessageTypes.Configuration,
+            Timestamp = timestamp ?? DateTimeOffset.UtcNow,
+            Payload = JsonSerializer.SerializeToElement(payload, ReproJsonOptions.Default)
+        };
+    }
+
+    /// <summary>
     /// Deserializes the payload to a strongly typed value.
     /// </summary>
     /// <typeparam name="T">The payload type.</typeparam>

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Shared/Messaging/ReproHostMessageTypes.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Shared/Messaging/ReproHostMessageTypes.cs
@@ -24,4 +24,9 @@ public static class ReproHostMessageTypes
     /// Identifies progress updates emitted by repros.
     /// </summary>
     public const string Progress = "progress";
+
+    /// <summary>
+    /// Identifies configuration handshakes emitted by repros.
+    /// </summary>
+    public const string Configuration = "configuration";
 }

--- a/LiteDB.ReproRunner/LiteDB.ReproRunner.Shared/ReproConfigurationReporter.cs
+++ b/LiteDB.ReproRunner/LiteDB.ReproRunner.Shared/ReproConfigurationReporter.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using LiteDB.ReproRunner.Shared.Messaging;
+
+namespace LiteDB.ReproRunner.Shared;
+
+/// <summary>
+/// Provides helpers for reporting the repro build configuration back to the host.
+/// </summary>
+public static class ReproConfigurationReporter
+{
+    private const string UseProjectReferenceMetadataKey = "LiteDB.ReproRunner.UseProjectReference";
+    private const string LiteDbPackageVersionMetadataKey = "LiteDB.ReproRunner.LiteDBPackageVersion";
+
+    /// <summary>
+    /// Reads the repro configuration metadata from the entry assembly and sends it to the host synchronously.
+    /// </summary>
+    /// <param name="client">The client used to communicate with the host.</param>
+    public static void SendConfiguration(ReproHostClient client)
+    {
+        if (client is null)
+        {
+            throw new ArgumentNullException(nameof(client));
+        }
+
+        var (useProjectReference, packageVersion) = ReadConfiguration();
+        client.SendConfiguration(useProjectReference, packageVersion);
+    }
+
+    /// <summary>
+    /// Reads the repro configuration metadata from the entry assembly and sends it to the host asynchronously.
+    /// </summary>
+    /// <param name="client">The client used to communicate with the host.</param>
+    /// <param name="cancellationToken">The token used to observe cancellation requests.</param>
+    /// <returns>A task that completes when the configuration has been transmitted.</returns>
+    public static Task SendConfigurationAsync(ReproHostClient client, CancellationToken cancellationToken = default)
+    {
+        if (client is null)
+        {
+            throw new ArgumentNullException(nameof(client));
+        }
+
+        var (useProjectReference, packageVersion) = ReadConfiguration();
+        return client.SendConfigurationAsync(useProjectReference, packageVersion, cancellationToken);
+    }
+
+    private static (bool UseProjectReference, string? LiteDbPackageVersion) ReadConfiguration()
+    {
+        var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+        var metadata = assembly.GetCustomAttributes<AssemblyMetadataAttribute>();
+
+        string? useProjectReferenceValue = null;
+        string? packageVersionValue = null;
+
+        foreach (var attribute in metadata)
+        {
+            if (string.Equals(attribute.Key, UseProjectReferenceMetadataKey, StringComparison.Ordinal))
+            {
+                useProjectReferenceValue = attribute.Value;
+            }
+            else if (string.Equals(attribute.Key, LiteDbPackageVersionMetadataKey, StringComparison.Ordinal))
+            {
+                packageVersionValue = attribute.Value;
+            }
+        }
+
+        var useProjectReference = ParseBoolean(useProjectReferenceValue);
+        var packageVersion = string.IsNullOrWhiteSpace(packageVersionValue) ? null : packageVersionValue;
+        return (useProjectReference, packageVersion);
+    }
+
+    private static bool ParseBoolean(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        if (bool.TryParse(value, out var parsed))
+        {
+            return parsed;
+        }
+
+        return string.Equals(value, "1", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "on", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/LiteDB.ReproRunner/Repros/Issue_2561_TransactionMonitor/Issue_2561_TransactionMonitor.csproj
+++ b/LiteDB.ReproRunner/Repros/Issue_2561_TransactionMonitor/Issue_2561_TransactionMonitor.csproj
@@ -21,4 +21,9 @@
     <ProjectReference Include="..\..\LiteDB.ReproRunner.Shared\LiteDB.ReproRunner.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyMetadata Include="LiteDB.ReproRunner.UseProjectReference" Value="$(UseProjectReference)" />
+    <AssemblyMetadata Include="LiteDB.ReproRunner.LiteDBPackageVersion" Value="$(LiteDBPackageVersion)" />
+  </ItemGroup>
+
 </Project>

--- a/LiteDB.ReproRunner/Repros/Issue_2561_TransactionMonitor/Program.cs
+++ b/LiteDB.ReproRunner/Repros/Issue_2561_TransactionMonitor/Program.cs
@@ -15,6 +15,7 @@ internal static class Program
     private static int Main()
     {
         var host = ReproHostClient.CreateDefault();
+        ReproConfigurationReporter.SendConfiguration(host);
         var context = ReproContext.FromEnvironment();
 
         host.SendLifecycle("starting", new

--- a/LiteDB.ReproRunner/Repros/Issue_2586_RollbackTransaction/Issue_2586_RollbackTransaction.csproj
+++ b/LiteDB.ReproRunner/Repros/Issue_2586_RollbackTransaction/Issue_2586_RollbackTransaction.csproj
@@ -19,4 +19,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\LiteDB.ReproRunner.Shared\LiteDB.ReproRunner.Shared.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyMetadata Include="LiteDB.ReproRunner.UseProjectReference" Value="$(UseProjectReference)" />
+    <AssemblyMetadata Include="LiteDB.ReproRunner.LiteDBPackageVersion" Value="$(LiteDBPackageVersion)" />
+  </ItemGroup>
 </Project>

--- a/LiteDB.ReproRunner/Repros/Issue_2586_RollbackTransaction/Program.cs
+++ b/LiteDB.ReproRunner/Repros/Issue_2586_RollbackTransaction/Program.cs
@@ -24,6 +24,7 @@ internal static class Program
     private static int Main()
     {
         var host = ReproHostClient.CreateDefault();
+        ReproConfigurationReporter.SendConfiguration(host);
         var context = ReproContext.FromEnvironment();
 
         host.SendLifecycle("starting", new


### PR DESCRIPTION
## Summary
- extend repro messaging with a configuration envelope and helper to emit assembly metadata
- require each repro entry point to send its build configuration and enforce it on the CLI run path
- capture the expected LiteDB package version in run plans, propagate it through builds, and add regression coverage

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d9b5962e08832a8f52062057eec6c1