### PR TITLE
Split CI build and test stages across SDK matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
     strategy:
       matrix:
         include:
+          - dotnet-version: 6.0.x
+            quality: ga
+          - dotnet-version: 7.0.x
+            quality: ga
           - dotnet-version: 8.0.x
             quality: ga
           - dotnet-version: 9.0.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   build:
+    name: Build (net8 artifacts)
     runs-on: ubuntu-latest
 
     steps:
@@ -13,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up .NET SDK
+      - name: Set up .NET 8 SDK
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
@@ -24,6 +25,55 @@ jobs:
       - name: Build
         run: dotnet build LiteDB.sln --configuration Release --no-restore /p:DefineConstants=TESTING
 
-      - name: Test
-        timeout-minutes: 5
-        run: dotnet test LiteDB.sln --configuration Release --no-build --verbosity normal --settings tests.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" /p:DefineConstants=TESTING
+      - name: Upload build outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: net8-build
+          if-no-files-found: error
+          path: |
+            LiteDB/bin/Release
+            LiteDB/obj
+            LiteDB.Tests/bin/Release
+            LiteDB.Tests/obj
+
+  test:
+    name: Test on SDK ${{ matrix.dotnet-version }}
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        include:
+          - dotnet-version: 8.0.x
+            quality: ga
+          - dotnet-version: 9.0.x
+            quality: preview
+          - dotnet-version: 10.0.x
+            quality: preview
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install .NET 8 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Install matrix SDK
+        if: matrix.dotnet-version != '8.0.x'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-quality: ${{ matrix.quality }}
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: net8-build
+          path: .
+
+      - name: Run tests without rebuilding
+        run: dotnet test LiteDB.Tests/LiteDB.Tests.csproj --configuration Release --no-build --verbosity normal --settings tests.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" /p:DefineConstants=TESTING

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      DOTNET_ROLL_FORWARD: Major
     strategy:
       matrix:
         include:
@@ -81,3 +83,31 @@ jobs:
 
       - name: Run tests without rebuilding
         run: dotnet test LiteDB.Tests/LiteDB.Tests.csproj --configuration Release --no-build --verbosity normal --settings tests.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed" /p:DefineConstants=TESTING
+
+      - name: Summarize test results
+        if: always()
+        run: |
+          python - <<'PY'
+          import xml.etree.ElementTree as ET
+          from pathlib import Path
+
+          trx_dir = Path('LiteDB.Tests/TestResults')
+          candidates = sorted(trx_dir.glob('*.trx'), key=lambda p: p.stat().st_mtime, reverse=True)
+          if not candidates:
+              raise SystemExit('No TRX files were produced by dotnet test')
+
+          latest = candidates[0]
+          ns = {'t': 'http://microsoft.com/schemas/VisualStudio/TeamTest/2010'}
+          root = ET.parse(latest).getroot()
+          counters = root.find('.//t:Counters', ns)
+          if counters is None:
+              raise SystemExit('TRX file is missing Counters data')
+
+          total = int(counters.get('total', 0))
+          executed = int(counters.get('executed', 0))
+          passed = int(counters.get('passed', 0))
+          failed = sum(int(counters.get(key, 0)) for key in ('failed', 'error', 'timeout', 'aborted'))
+          skipped = total - executed
+
+          print(f'Test summary ({latest.name}): total={total}, passed={passed}, failed={failed}, skipped={skipped}')
+          PY


### PR DESCRIPTION
## Summary
- build the solution with the .NET 8 SDK and publish the compiled outputs as artifacts
- run the test suite on .NET 8, 9, and 10 SDKs using the prebuilt binaries without rebuilding

## Testing
- not run (CI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc31338f7c832abbccf310ff86e232