### PR TITLE
Add repro for DiskService disposal failure

### DIFF
--- a/LiteDB.ReproRunner/Repros/Issue_2614_DiskServiceDispose/Issue_2614_DiskServiceDispose.csproj
+++ b/LiteDB.ReproRunner/Repros/Issue_2614_DiskServiceDispose/Issue_2614_DiskServiceDispose.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UseProjectReference Condition="'$(UseProjectReference)' == ''">false</UseProjectReference>
+    <LiteDBPackageVersion Condition="'$(LiteDBPackageVersion)' == ''">5.0.21</LiteDBPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(UseProjectReference)' == 'true'">
+    <ProjectReference Include="..\..\..\LiteDB\LiteDB.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseProjectReference)' != 'true'">
+    <PackageReference Include="LiteDB" Version="$(LiteDBPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\LiteDB.ReproRunner.Shared\LiteDB.ReproRunner.Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyMetadata Include="LiteDB.ReproRunner.UseProjectReference" Value="$(UseProjectReference)" />
+    <AssemblyMetadata Include="LiteDB.ReproRunner.LiteDBPackageVersion" Value="$(LiteDBPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.ReproRunner/Repros/Issue_2614_DiskServiceDispose/Program.cs
+++ b/LiteDB.ReproRunner/Repros/Issue_2614_DiskServiceDispose/Program.cs
@@ -1,0 +1,232 @@
+using System.Runtime.InteropServices;
+using LiteDB;
+using LiteDB.ReproRunner.Shared;
+using LiteDB.ReproRunner.Shared.Messaging;
+
+namespace Issue_2614_DiskServiceDispose;
+
+internal static class Program
+{
+    private const ulong FileSizeLimitBytes = 4096;
+    private const string DatabaseFileName = "issue2614-disk.db";
+
+    private static int Main()
+    {
+        var host = ReproHostClient.CreateDefault();
+        ReproConfigurationReporter.SendConfiguration(host);
+        var context = ReproContext.FromEnvironment();
+
+        host.SendLifecycle("starting", new
+        {
+            context.InstanceIndex,
+            context.TotalInstances,
+            context.SharedDatabaseRoot
+        });
+
+        try
+        {
+            if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+            {
+                const string message = "This repro requires a Unix-like environment to adjust RLIMIT_FSIZE.";
+                host.SendLog(message, ReproHostLogLevel.Error);
+                host.SendResult(false, message);
+                host.SendLifecycle("completed", new { Success = false });
+                return 1;
+            }
+
+            Run(host, context);
+
+            host.SendResult(true, "DiskService left the database file locked after initialization failure.");
+            host.SendLifecycle("completed", new { Success = true });
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            host.SendLog($"Reproduction failed: {ex}", ReproHostLogLevel.Error);
+            host.SendResult(false, "Reproduction failed unexpectedly.", new { Exception = ex.ToString() });
+            host.SendLifecycle("completed", new { Success = false });
+            Console.Error.WriteLine(ex);
+            return 1;
+        }
+    }
+
+    private static void Run(ReproHostClient host, ReproContext context)
+    {
+        NativeMethods.IgnoreSigxfsz();
+
+        var rootDirectory = string.IsNullOrWhiteSpace(context.SharedDatabaseRoot)
+            ? Path.Combine(AppContext.BaseDirectory, "issue2614")
+            : context.SharedDatabaseRoot;
+
+        Directory.CreateDirectory(rootDirectory);
+
+        var databasePath = Path.Combine(rootDirectory, DatabaseFileName);
+
+        if (File.Exists(databasePath))
+        {
+            host.SendLog($"Removing pre-existing database file: {databasePath}");
+            File.Delete(databasePath);
+        }
+
+        var limitScope = FileSizeLimitScope.Apply(host, FileSizeLimitBytes);
+
+        var connectionString = new ConnectionString
+        {
+            Filename = databasePath,
+            Connection = ConnectionType.Direct
+        };
+
+        host.SendLog($"Attempting to create database at {databasePath}");
+
+        Exception? observedException = null;
+
+        try
+        {
+            try
+            {
+                using var database = new LiteDatabase(connectionString);
+                throw new InvalidOperationException("LiteDatabase constructor succeeded unexpectedly.");
+            }
+            catch (Exception ex)
+            {
+                observedException = ex;
+                host.SendLog($"Observed exception while opening database: {ex.GetType().FullName}: {ex.Message}");
+            }
+
+            if (observedException is null)
+            {
+                throw new InvalidOperationException("No exception observed while creating the database.");
+            }
+        }
+        finally
+        {
+            limitScope.Dispose();
+        }
+
+        host.SendLog("Restored original file size limit. Checking for lingering file handles...");
+
+        var lockObserved = false;
+
+        try
+        {
+            using var stream = File.Open(databasePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            host.SendLog("Successfully reopened the database file with exclusive access.", ReproHostLogLevel.Error);
+        }
+        catch (IOException ioException)
+        {
+            lockObserved = true;
+            host.SendLog($"Failed to reopen database file due to lingering handle: {ioException.Message}", ReproHostLogLevel.Information);
+        }
+
+        if (!lockObserved)
+        {
+            throw new InvalidOperationException("Database file reopened successfully; the repro did not observe the lock.");
+        }
+
+        try
+        {
+            host.SendLog("Attempting to delete the locked database file.");
+            File.Delete(databasePath);
+        }
+        catch (Exception deleteException)
+        {
+            host.SendLog($"Expected failure deleting locked file: {deleteException.Message}");
+        }
+    }
+
+    private sealed class FileSizeLimitScope : IDisposable
+    {
+        private readonly NativeMethods.RLimit _original;
+        private bool _restored;
+
+        private FileSizeLimitScope(NativeMethods.RLimit original)
+        {
+            _original = original;
+        }
+
+        public static FileSizeLimitScope Apply(ReproHostClient host, ulong requestedLimit)
+        {
+            var original = NativeMethods.GetFileSizeLimit();
+            host.SendLog($"Original RLIMIT_FSIZE: cur={original.rlim_cur}, max={original.rlim_max}");
+
+            var newLimit = original;
+            var effectiveLimit = Math.Min(original.rlim_max, requestedLimit);
+
+            if (effectiveLimit == 0)
+            {
+                throw new InvalidOperationException($"Unable to set RLIMIT_FSIZE to zero. Original max={original.rlim_max}.");
+            }
+
+            newLimit.rlim_cur = effectiveLimit;
+            NativeMethods.SetFileSizeLimit(newLimit);
+
+            host.SendLog($"Applied RLIMIT_FSIZE cur={newLimit.rlim_cur}");
+
+            return new FileSizeLimitScope(original);
+        }
+
+        public void Dispose()
+        {
+            if (_restored)
+            {
+                return;
+            }
+
+            NativeMethods.SetFileSizeLimit(_original);
+            _restored = true;
+        }
+    }
+
+    private static class NativeMethods
+    {
+        private const int RLimitFileSize = 1;
+        private const int Sigxfsz = 25;
+        private static readonly IntPtr SigIgn = (IntPtr)1;
+        private static readonly IntPtr SigErr = (IntPtr)(-1);
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct RLimit
+        {
+            public ulong rlim_cur;
+            public ulong rlim_max;
+        }
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int getrlimit(int resource, out RLimit rlim);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int setrlimit(int resource, ref RLimit rlim);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern IntPtr signal(int signum, IntPtr handler);
+
+        public static void IgnoreSigxfsz()
+        {
+            var previous = signal(Sigxfsz, SigIgn);
+
+            if (previous == SigErr)
+            {
+                throw new InvalidOperationException($"signal failed (errno={Marshal.GetLastWin32Error()}).");
+            }
+        }
+
+        public static RLimit GetFileSizeLimit()
+        {
+            ThrowOnError(getrlimit(RLimitFileSize, out var limit));
+            return limit;
+        }
+
+        public static void SetFileSizeLimit(RLimit limit)
+        {
+            ThrowOnError(setrlimit(RLimitFileSize, ref limit));
+        }
+
+        private static void ThrowOnError(int result)
+        {
+            if (result != 0)
+            {
+                throw new InvalidOperationException($"Native call failed (errno={Marshal.GetLastWin32Error()}).");
+            }
+        }
+    }
+}

--- a/LiteDB.ReproRunner/Repros/Issue_2614_DiskServiceDispose/README.md
+++ b/LiteDB.ReproRunner/Repros/Issue_2614_DiskServiceDispose/README.md
@@ -1,0 +1,27 @@
+# Issue 2614 – DiskService leaks file handles on initialization failure
+
+This repro enforces a very small per-process file size limit using `setrlimit(RLIMIT_FSIZE)`
+and then attempts to create a new database file. LiteDB writes the header page during
+`DiskService` construction, so exceeding the limit triggers an exception before the engine
+finishes initializing. When the constructor throws, the `DiskService` instance is never
+assigned to the engine field and therefore never disposed.
+
+The expected behaviour is that all file handles opened during the initialization attempt
+are released so the caller can retry after freeing disk space. Instead, LiteDB leaves the
+writer handle open, preventing any subsequent attempt to reopen or delete the data file
+within the same process.
+
+## Running the repro
+
+```bash
+dotnet run --project LiteDB.ReproRunner/LiteDB.ReproRunner.Cli -- run Issue_2614_DiskServiceDispose
+```
+
+The process must run on a Unix-like operating system where `setrlimit` is available.
+The repro succeeds when it observes:
+
+* The initial `LiteDatabase` constructor throws due to the enforced file size limit.
+* The follow-up attempt to reopen the database file exclusively fails because a lingering
+  handle is still holding it open.
+
+Reference: <https://github.com/litedb-org/LiteDB/issues/2614>

--- a/LiteDB.ReproRunner/Repros/Issue_2614_DiskServiceDispose/repro.json
+++ b/LiteDB.ReproRunner/Repros/Issue_2614_DiskServiceDispose/repro.json
@@ -1,0 +1,13 @@
+{
+  "id": "Issue_2614_DiskServiceDispose",
+  "title": "DiskService leaks handles when initialization fails",
+  "issues": ["https://github.com/litedb-org/LiteDB/issues/2614"],
+  "failingSince": "5.0.21",
+  "timeoutSeconds": 120,
+  "requiresParallel": false,
+  "defaultInstances": 1,
+  "sharedDatabaseKey": "issue2614-disk",
+  "args": [],
+  "tags": ["disk", "rlimit", "platform:unix"],
+  "state": "red"
+}


### PR DESCRIPTION
## Summary
- add the Issue_2614_DiskServiceDispose repro project that exercises DiskService disposal when disk writes fail
- document the scenario and wire up the repro manifest for discovery

## Testing
- dotnet run --project LiteDB.ReproRunner/LiteDB.ReproRunner.Cli -- run Issue_2614_DiskServiceDispose --report=-

------
https://chatgpt.com/codex/tasks/task_e_68dcea544924832ab765b64b53061860