### PR TITLE
Improve build pipeline

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - dev
+    paths:
+      - 'LiteDB/**'
 
 jobs:
   publish:

--- a/scripts/gitver/create-github-release.ps1
+++ b/scripts/gitver/create-github-release.ps1
@@ -1,0 +1,82 @@
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [string]$Ref = 'HEAD',
+    [switch]$Push
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..' '..')
+
+# Restore tools if needed
+if (-not (Get-Command dotnet-gitversion -ErrorAction SilentlyContinue)) {
+    Write-Host "Restoring .NET tools..."
+    dotnet tool restore
+}
+
+# Get version info
+$jsonText = & "$PSScriptRoot/gitversion.ps1" -Ref $Ref -Json
+$data = $jsonText | ConvertFrom-Json
+
+$majorMinorPatch = $data.MajorMinorPatch
+$preLabel = $data.PreReleaseLabel
+$preNumber = [int]$data.PreReleaseNumber
+$sha = $data.Sha
+
+if ([string]::IsNullOrEmpty($preLabel) -or $preLabel -eq 'null') {
+    throw "Commit $sha is not a prerelease version. Use this script only for prerelease tags."
+}
+
+# Format with zero-padded prerelease number for proper GitHub sorting
+$paddedVersion = '{0}-{1}.{2:0000}' -f $majorMinorPatch, $preLabel, $preNumber
+$tagName = "v$paddedVersion"
+
+Write-Host ""
+Write-Host "Creating prerelease tag:" -ForegroundColor Cyan
+Write-Host "  Commit:  $sha"
+Write-Host "  Tag:     $tagName"
+Write-Host "  Version: $paddedVersion"
+Write-Host ""
+
+# Check if tag already exists
+$existingTag = git -C $repoRoot rev-parse --verify --quiet "refs/tags/$tagName" 2>$null
+if ($existingTag) {
+    # we dont abort because we want to allow to separate creation and pushing of tags
+    Write-Host "Tag $tagName already exists." -ForegroundColor Yellow
+} else{
+    # Create annotated tag
+    $message = "Prerelease $paddedVersion"
+    git -C $repoRoot tag -a $tagName -m $message $sha
+    
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to create tag"
+    }
+    
+    Write-Host "Tag created successfully!" -ForegroundColor Green
+
+}
+
+
+if ($Push) {
+    Write-Host ""
+    Write-Host "Pushing tag to https://github.com/litedb-org/LiteDB..." -ForegroundColor Cyan
+    git -C $repoRoot push https://github.com/litedb-org/LiteDB $tagName
+    
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to push tag"
+    }
+    
+    Write-Host "Tag pushed successfully!" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "You can now create a GitHub release at:" -ForegroundColor Yellow
+    Write-Host "  https://github.com/litedb-org/LiteDB/releases/new?tag=$tagName"
+}
+else {
+    Write-Host ""
+    Write-Host "Tag created locally. To push it, run:" -ForegroundColor Yellow
+    Write-Host "  git push https://github.com/litedb-org/LiteDB $tagName"
+    Write-Host ""
+    Write-Host "Or re-run this script with -Push:"
+    Write-Host "  ./scripts/gitver/tag-prerelease.ps1 -Push"
+}


### PR DESCRIPTION
This pull request introduces improvements to the prerelease publishing workflow and automation scripts. The main changes include restricting the GitHub Actions workflow to only trigger on changes within the `LiteDB` directory and adding a new PowerShell script to automate the creation and optional pushing of prerelease tags, ensuring correct version formatting for GitHub releases.

Workflow configuration improvements:

* Updated `.github/workflows/publish-prerelease.yml` to only trigger the workflow when files under `LiteDB/**` are changed, reducing unnecessary workflow runs.

Release automation enhancements:

* Added a new script, `scripts/gitver/create-github-release.ps1`, which automates the creation of prerelease tags with proper zero-padded version formatting, checks for existing tags, and optionally pushes the tag to GitHub. The script also provides clear instructions for manual or automated release creation.