### PR TITLE
Add support for GroupBy

### DIFF
--- a/LiteDB.Tests/Query/GroupBy_Tests.cs
+++ b/LiteDB.Tests/Query/GroupBy_Tests.cs
@@ -1,104 +1,412 @@
-﻿using FluentAssertions;
-using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
+
+using FluentAssertions;
+using LiteDB;
+using LiteDB.Engine;
+using LiteDB.Tests;
 using Xunit;
 
 namespace LiteDB.Tests.QueryTest
 {
     public class GroupBy_Tests
     {
-        [Fact(Skip = "Missing implement LINQ for GroupBy")]
+        [Fact]
+        [Trait("Area", "GroupBy")]
+        public void Having_Sees_Group_Key()
+        {
+            using var stream = new MemoryStream();
+            using var db = new LiteDatabase(stream);
+            var col = db.GetCollection<GroupItem>("numbers");
+
+            for (var i = 1; i <= 5; i++)
+            {
+                col.Insert(new GroupItem { Id = i, Value = i, Parity = i % 2 });
+            }
+
+            var results = col.Query()
+                .GroupBy(x => x.Parity)
+                .Having(BsonExpression.Create("@key = 1"))
+                .Select(g => new { g.Key, Count = g.Count() })
+                .ToArray();
+
+            var because = $"HAVING must see @key; got {results.Length} groups.";
+            results.Should().HaveCount(1, because);
+            results[0].Key.Should().Be(1, "HAVING must filter on the grouping key value 1.");
+            results[0].Count.Should().Be(3, "HAVING must aggregate the odd values (1, 3, 5).");
+        }
+
+        [Fact]
+        [Trait("Area", "GroupBy")]
+        public void GroupBy_Respects_Collation_For_Key_Equality()
+        {
+            using var dataStream = new MemoryStream();
+            using var engine = new LiteEngine(new EngineSettings
+            {
+                DataStream = dataStream,
+                Collation = new Collation("en-US/IgnoreCase")
+            });
+            using var db = new LiteDatabase(engine, disposeOnClose: false);
+            var col = db.GetCollection<NamedItem>("names");
+
+            col.Insert(new NamedItem { Id = 1, Name = "ALICE" });
+            col.Insert(new NamedItem { Id = 2, Name = "alice" });
+            col.Insert(new NamedItem { Id = 3, Name = "Alice" });
+
+            var results = col.Query()
+                .GroupBy(x => x.Name)
+                .Select(g => new { g.Key, Count = g.Count() })
+                .ToArray();
+
+            var because = $"Grouping equality must honor the configured case-insensitive collation; got {results.Length} groups.";
+            results.Should().HaveCount(1, because);
+            results[0].Count.Should().Be(3, "Grouping equality must honor the configured case-insensitive collation.");
+        }
+
+        [Fact]
+        [Trait("Area", "GroupBy")]
+        public void OrderBy_Count_Before_Select_Uses_Group_Not_Projection()
+        {
+            using var stream = new MemoryStream();
+            using var db = new LiteDatabase(stream);
+            var col = db.GetCollection<CategoryItem>("items");
+
+            var items = new[] 
+            {
+                new CategoryItem { Id = 1, Category = "A" },
+                new CategoryItem { Id = 2, Category = "A" },
+                new CategoryItem { Id = 3, Category = "A" },
+                new CategoryItem { Id = 4, Category = "B" },
+                new CategoryItem { Id = 5, Category = "B" },
+                new CategoryItem { Id = 6, Category = "C" }
+            };
+            
+            col.InsertBulk(items);
+            
+            var ascending = col.Query()
+                .GroupBy(x => x.Category)
+                .OrderBy(g => g.Count())
+                .Select(g => new { g.Key, Size = g.Count() })
+                .ToArray();
+            
+            var expectedAscending = items
+                .GroupBy(x => x.Category)
+                .OrderBy(g => g.Count())
+                .Select(g => new { g.Key, Size = g.Count() })
+                .ToArray();
+
+            var ascendingSizes = ascending.Select(x => x.Size).ToArray();
+            var expectedAscendingSizes = expectedAscending.Select(x => x.Size).ToArray();
+            ascendingSizes.Should().Equal(expectedAscendingSizes, //new[] { 1, 2, 3 }
+                "OrderBy aggregate must be evaluated over the group source before projection (ascending). Actual: {0}",
+                string.Join(", ", ascendingSizes));
+
+            var ascendingKeys = ascending.Select(x => x.Key).ToArray();
+            var expectedAscendingKeys = expectedAscending.Select(x => x.Key).ToArray();
+            ascendingKeys.Should().Equal(expectedAscendingKeys, //new[] { "C", "B", "A" }
+                "OrderBy aggregate must order groups by their aggregated size (ascending). Actual: {0}",
+                string.Join(", ", ascendingKeys));
+
+            var descending = col.Query()
+                .GroupBy(x => x.Category)
+                .OrderByDescending(g => g.Count())
+                .Select(g => new { g.Key, Size = g.Count() })
+                .ToArray();
+            
+            var expectedDescending = items
+                .GroupBy(x => x.Category)
+                .OrderByDescending(g => g.Count())
+                .Select(g => new { g.Key, Size = g.Count() })
+                .ToArray();
+
+            var descendingSizes = descending.Select(x => x.Size).ToArray();
+            var expectedDescendingSizes = expectedDescending.Select(x => x.Size).ToArray();
+            descendingSizes.Should().Equal(expectedDescendingSizes, // new[] { 3, 2, 1 }
+                "OrderBy aggregate must be evaluated over the group source before projection (descending). Actual: {0}",
+                string.Join(", ", descendingSizes));
+
+            var descendingKeys = descending.Select(x => x.Key).ToArray();
+            var expectedDescendingKeys = expectedDescending.Select(x => x.Key).ToArray();
+            descendingKeys.Should().Equal(expectedDescendingKeys, //new[] { "A", "B", "C" }
+                "OrderBy aggregate must order groups by their aggregated size (descending). Actual: {0}",
+                string.Join(", ", descendingKeys));
+        }
+
+        [Fact]
         public void Query_GroupBy_Age_With_Count()
         {
-            //**using var db = new PersonGroupByData();
-            //**var (collection, local) = db.GetData();
-            //**
-            //**var r0 = local
-            //**    .GroupBy(x => x.Age)
-            //**    .Select(x => new { Age = x.Key, Count = x.Count() })
-            //**    .OrderBy(x => x.Age)
-            //**    .ToArray();
-            //**
-            //**var r1 = collection.Query()
-            //**    .GroupBy("$.Age")
-            //**    .Select(x => new { Age = x.Key, Count = x.Count() })
-            //**    .ToArray();
-            //**
-            //**foreach (var r in r0.Zip(r1, (l, r) => new { left = l, right = r }))
-            //**{
-            //**    r.left.Age.Should().Be(r.right.Age);
-            //**    r.left.Count.Should().Be(r.right.Count);
-            //**}
+            using var db = new PersonGroupByData();
+            var (collection, local) = db.GetData();
+
+            var expected = local
+                .GroupBy(x => x.Age)
+                .Select(g => (Age: g.Key, Count: g.Count()))
+                .OrderBy(x => x.Age)
+                .ToArray();
+
+            var actual = collection.Query()
+                .GroupBy(x => x.Age)
+                .Select
+                (
+                    g => new
+                    {
+                        Age = g.Key,
+                        Count = g.Count()
+                    }
+                )
+                .OrderBy(x => x.Age)
+                .ToArray()
+                .Select(x => (x.Age, x.Count))
+                .ToArray();
+
+            actual.Should().Equal(expected);
         }
 
-        [Fact(Skip = "Missing implement LINQ for GroupBy")]
+        [Fact]
         public void Query_GroupBy_Year_With_Sum_Age()
         {
-            //** var r0 = local
-            //**     .GroupBy(x => x.Date.Year)
-            //**     .Select(x => new { Year = x.Key, Sum = x.Sum(q => q.Age) })
-            //**     .OrderBy(x => x.Year)
-            //**     .ToArray();
-            //**
-            //** var r1 = collection.Query()
-            //**     .GroupBy(x => x.Date.Year)
-            //**     .Select(x => new { Year = x.Key, Sum = x.Sum(q => q.Age) })
-            //**     .ToArray();
-            //**
-            //** foreach (var r in r0.Zip(r1, (l, r) => new { left = l, right = r }))
-            //** {
-            //**     r.left.Year.Should().Be(r.right.Year);
-            //**     r.left.Sum.Should().Be(r.right.Sum);
-            //** }
+            using var db = new PersonGroupByData();
+            var (collection, local) = db.GetData();
+
+            var expected = local
+                .GroupBy(x => x.Date.Year)
+                .Select(g => (Year: g.Key, Sum: g.Sum(p => p.Age)))
+                .OrderBy(x => x.Year)
+                .ToArray();
+
+            var actual = collection.Query()
+                .GroupBy(x => x.Date.Year)
+                .Select
+                (
+                    g => new
+                    {
+                        Year = g.Key,
+                        Sum = g.Sum(p => p.Age)
+                    }
+                )
+                .OrderBy(x => x.Year)
+                .ToArray()
+                .Select(x => (x.Year, x.Sum))
+                .ToArray();
+
+            actual.Should().Equal(expected);
         }
 
-        [Fact(Skip = "Missing implement LINQ for GroupBy")]
-        public void Query_GroupBy_Func()
+        [Fact]
+        public void Query_GroupBy_Order_And_Limit()
         {
-            //** var r0 = local
-            //**     .GroupBy(x => x.Date.Year)
-            //**     .Select(x => new { Year = x.Key, Count = x.Count() })
-            //**     .OrderBy(x => x.Year)
-            //**     .ToArray();
-            //**
-            //** var r1 = collection.Query()
-            //**     .GroupBy(x => x.Date.Year)
-            //**     .Select(x => new { x.Date.Year, Count = x })
-            //**     .ToArray();
-            //**
-            //** foreach (var r in r0.Zip(r1, (l, r) => new { left = l, right = r }))
-            //** {
-            //**     Assert.Equal(r.left.Year, r.right.Year);
-            //**     Assert.Equal(r.left.Count, r.right.Count);
-            //** }
+            using var db = new PersonGroupByData();
+            var (collection, local) = db.GetData();
+
+            var expected = local
+                .GroupBy(x => x.Age)
+                .Select
+                (
+                    g => new
+                    {
+                        Age = g.Key,
+                        Count = g.Count()
+                    }
+                )
+                .OrderByDescending(x => x.Count)
+                .ThenBy(x => x.Age)
+                .Skip(5)
+                .Take(3)
+                .Select(x => (x.Age, x.Count))
+                .ToArray();
+
+            var actual = collection.Query()
+                .GroupBy(x => x.Age)
+                .Select
+                (
+                    g => new
+                    {
+                        Age = g.Key,
+                        Count = g.Count()
+                    }
+                )
+                .OrderByDescending(x => x.Count)
+                .ThenBy(x => x.Age)
+                .Skip(5)
+                .Limit(3)
+                .ToArray()
+                .Select(x => (x.Age, x.Count))
+                .ToArray();
+
+            actual.Should().Equal(expected);
         }
 
-        [Fact(Skip = "Missing implement LINQ for GroupBy")]
-        public void Query_GroupBy_With_Array_Aggregation()
+        [Fact]
+        public void Query_GroupBy_ToList_Materializes_Groupings()
         {
-            //** // quite complex group by query
-            //** var r = collection.Query()
-            //**     .GroupBy(x => x.Email.Substring(x.Email.IndexOf("@") + 1))
-            //**     .Select(x => new
-            //**     {
-            //**         Domain = x.Email.Substring(x.Email.IndexOf("@") + 1),
-            //**         Users = Sql.ToArray(new
-            //**         {
-            //**             Login = x.Email.Substring(0, x.Email.IndexOf("@")).ToLower(),
-            //**             x.Name,
-            //**             x.Age
-            //**         })
-            //**     })
-            //**     .Limit(10)
-            //**     .ToArray();
-            //**
-            //** // test first only
-            //** Assert.Equal(5, r[0].Users.Length);
-            //** Assert.Equal("imperdiet.us", r[0].Domain);
-            //** Assert.Equal("delilah", r[0].Users[0].Login);
-            //** Assert.Equal("Dahlia Warren", r[0].Users[0].Name);
-            //** Assert.Equal(24, r[0].Users[0].Age);
+            using var db = new PersonGroupByData();
+            var (collection, local) = db.GetData();
+
+            var expected = local
+                .GroupBy(x => x.Age)
+                .OrderBy(g => g.Key)
+                .Select
+                (
+                    g => new
+                    {
+                        Key = g.Key,
+                        Names = g.OrderBy(p => p.Name).Select(p => p.Name).ToArray()
+                    }
+                )
+                .ToArray();
+
+            var groupings = collection.Query()
+                .GroupBy(x => x.Age)
+                .ToList();
+
+            groupings.Should().AllBeAssignableTo<IGrouping<int, Person>>();
+
+            var actual = groupings
+                .OrderBy(g => g.Key)
+                .Select
+                (
+                    g => new
+                    {
+                        g.Key,
+                        Names = g.OrderBy(p => p.Name).Select(p => p.Name).ToArray()
+                    }
+                )
+                .ToArray();
+
+            actual.Should().BeEquivalentTo(expected, options => options.WithStrictOrdering());
         }
+
+        [Fact]
+        public void Query_GroupBy_OrderBy_Key_Before_Select_Should_Work()
+        {
+            using var db = new PersonGroupByData();
+            var (collection, local) = db.GetData();
+
+            // This test specifically targets the bug where OrderBy(g => g.Key) before Select()
+            // causes issues with @key parameter binding in the GroupByPipe
+            var expected = local
+                .GroupBy(x => x.Age)
+                .OrderBy(g => g.Key) // Order by key BEFORE projection
+                .Select
+                (
+                    g => new
+                    {
+                        Age = g.Key,
+                        Count = g.Count()
+                    }
+                )
+                .ToArray();
+
+            var actual = collection.Query()
+                .GroupBy(x => x.Age)
+                .OrderBy(g => g.Key) // This should work but currently fails due to @key not being bound
+                .Select
+                (
+                    g => new
+                    {
+                        Age = g.Key,
+                        Count = g.Count()
+                    }
+                )
+                .ToArray();
+
+            actual.Should().BeEquivalentTo(expected, options => options.WithStrictOrdering());
+        }
+
+        [Fact]
+        public void Query_GroupBy_OrderByDescending_Key_Before_Select_Should_Work()
+        {
+            using var db = new PersonGroupByData();
+            var (collection, local) = db.GetData();
+
+            // Test descending order as well to ensure the fix works for both directions
+            var expected = local
+                .GroupBy(x => x.Age)
+                .OrderByDescending(g => g.Key) // Order by key descending BEFORE projection
+                .Select
+                (
+                    g => new
+                    {
+                        Age = g.Key,
+                        Count = g.Count()
+                    }
+                )
+                .ToArray();
+
+            var actual = collection.Query()
+                .GroupBy(x => x.Age)
+                .OrderByDescending(g => g.Key) // This should work but currently fails
+                .Select
+                (
+                    g => new
+                    {
+                        Age = g.Key,
+                        Count = g.Count()
+                    }
+                )
+                .ToArray();
+
+            actual.Should().BeEquivalentTo(expected, options => options.WithStrictOrdering());
+        }
+
+        [Fact]
+        public void Query_GroupBy_Complex_Key_OrderBy_Before_Select_Should_Work()
+        {
+            using var db = new PersonGroupByData();
+            var (collection, local) = db.GetData();
+
+            // Test with a more complex grouping key to ensure the fix works with different key types
+            var expected = local
+                .GroupBy(x => x.Date.Year)
+                .OrderBy(g => g.Key) // Order by year key BEFORE projection
+                .Select
+                (
+                    g => new
+                    {
+                        Year = g.Key,
+                        TotalAge = g.Sum(p => p.Age)
+                    }
+                )
+                .ToArray();
+
+            var actual = collection.Query()
+                .GroupBy(x => x.Date.Year)
+                .OrderBy(g => g.Key) // This should work but currently fails
+                .Select
+                (
+                    g => new
+                    {
+                        Year = g.Key,
+                        TotalAge = g.Sum(p => p.Age)
+                    }
+                )
+                .ToArray();
+
+            actual.Should().BeEquivalentTo(expected, options => options.WithStrictOrdering());
+        }
+
+        private class GroupItem
+        {
+            public int Id { get; set; }
+
+            public int Value { get; set; }
+
+            public int Parity { get; set; }
+        }
+
+        private class NamedItem
+        {
+            public int Id { get; set; }
+
+            public string Name { get; set; } = string.Empty;
+        }
+
+        private class CategoryItem
+        {
+            public int Id { get; set; }
+
+            public string Category { get; set; } = string.Empty;
+        }
+
     }
 }

--- a/LiteDB/Client/Database/ILiteQueryable.cs
+++ b/LiteDB/Client/Database/ILiteQueryable.cs
@@ -25,12 +25,12 @@ namespace LiteDB
         ILiteQueryable<T> ThenByDescending(BsonExpression keySelector);
         ILiteQueryable<T> ThenByDescending<K>(Expression<Func<T, K>> keySelector);
 
+        ILiteQueryable<IGrouping<K, T>> GroupBy<K>(Expression<Func<T, K>> keySelector);
         ILiteQueryable<T> GroupBy(BsonExpression keySelector);
         ILiteQueryable<T> Having(BsonExpression predicate);
 
-        ILiteQueryableResult<BsonDocument> Select(BsonExpression selector);
-        ILiteQueryableResult<K> Select<K>(Expression<Func<T, K>> selector);
-
+        ILiteQueryable<BsonDocument> Select(BsonExpression selector);
+        ILiteQueryable<K> Select<K>(Expression<Func<T, K>> selector);
     }
 
     public interface ILiteQueryableResult<T>

--- a/LiteDB/Client/Database/LiteGrouping.cs
+++ b/LiteDB/Client/Database/LiteGrouping.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LiteDB
+{
+    internal static class LiteGroupingFieldNames
+    {
+        public const string Key = "key";
+        public const string Items = "items";
+    }
+
+    /// <summary>
+    /// Concrete <see cref="IGrouping{TKey, TElement}"/> implementation used to materialize
+    /// grouping results coming from query execution.
+    /// </summary>
+    internal sealed class LiteGrouping<TKey, TElement> : IGrouping<TKey, TElement>
+    {
+        internal const string KeyField = LiteGroupingFieldNames.Key;
+        internal const string ItemsField = LiteGroupingFieldNames.Items;
+
+        private readonly IReadOnlyList<TElement> _items;
+
+        public LiteGrouping(TKey key, IReadOnlyList<TElement> items)
+        {
+            Key = key;
+            _items = items;
+        }
+
+        public TKey Key { get; }
+
+        public IEnumerator<TElement> GetEnumerator() => _items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    }
+}

--- a/LiteDB/Client/Database/LiteQueryable.cs
+++ b/LiteDB/Client/Database/LiteQueryable.cs
@@ -176,6 +176,20 @@ namespace LiteDB
         /// <summary>
         /// Groups the documents of resultset according to a specified key selector expression (support only one GroupBy)
         /// </summary>
+        public ILiteQueryable<IGrouping<K, T>> GroupBy<K>(Expression<Func<T, K>> keySelector)
+        {
+            var expression = _mapper.GetExpression(keySelector);
+
+            this.GroupBy(expression);
+
+            _mapper.RegisterGroupingType<K, T>();
+
+            return new LiteQueryable<IGrouping<K, T>>(_engine, _mapper, _collection, _query);
+        }
+
+        /// <summary>
+        /// Groups the documents of resultset according to a specified key selector expression (support only one GroupBy)
+        /// </summary>
         public ILiteQueryable<T> GroupBy(BsonExpression keySelector)
         {
             if (_query.GroupBy != null) throw new ArgumentException("GROUP BY already defined in this query");
@@ -206,7 +220,7 @@ namespace LiteDB
         /// <summary>
         /// Transform input document into a new output document. Can be used with each document, group by or all source
         /// </summary>
-        public ILiteQueryableResult<BsonDocument> Select(BsonExpression selector)
+        public ILiteQueryable<BsonDocument> Select(BsonExpression selector)
         {
             _query.Select = selector;
 
@@ -216,10 +230,8 @@ namespace LiteDB
         /// <summary>
         /// Project each document of resultset into a new document/value based on selector expression
         /// </summary>
-        public ILiteQueryableResult<K> Select<K>(Expression<Func<T, K>> selector)
+        public ILiteQueryable<K> Select<K>(Expression<Func<T, K>> selector)
         {
-            if (_query.GroupBy != null) throw new ArgumentException("Use Select(BsonExpression selector) when using GroupBy query");
-
             _query.Select = _mapper.GetExpression(selector);
 
             return new LiteQueryable<K>(_engine, _mapper, _collection, _query);

--- a/LiteDB/Client/Mapper/BsonMapper.Grouping.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Grouping.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LiteDB
+{
+    public partial class BsonMapper
+    {
+        internal void RegisterGroupingType<TKey, TElement>()
+        {
+            var interfaceType = typeof(IGrouping<TKey, TElement>);
+            var concreteType = typeof(LiteGrouping<TKey, TElement>);
+
+            if (_customDeserializer.ContainsKey(interfaceType))
+            {
+                return;
+            }
+
+            BsonValue SerializeGrouping(object value)
+            {
+                var grouping = (IGrouping<TKey, TElement>)value;
+                var items = new BsonArray();
+
+                foreach (var item in grouping)
+                {
+                    items.Add(this.Serialize(typeof(TElement), item));
+                }
+
+                return new BsonDocument
+                {
+                    [LiteGroupingFieldNames.Key] = this.Serialize(typeof(TKey), grouping.Key),
+                    [LiteGroupingFieldNames.Items] = items
+                };
+            }
+
+            object DeserializeGrouping(BsonValue value)
+            {
+                var document = value.AsDocument;
+
+                var key = (TKey)this.Deserialize(typeof(TKey), document[LiteGroupingFieldNames.Key]);
+
+                var itemsArray = document[LiteGroupingFieldNames.Items].AsArray;
+                var items = new List<TElement>(itemsArray.Count);
+
+                foreach (var item in itemsArray)
+                {
+                    items.Add((TElement)this.Deserialize(typeof(TElement), item));
+                }
+
+                return new LiteGrouping<TKey, TElement>(key, items);
+            }
+
+            this.RegisterType(interfaceType, SerializeGrouping, DeserializeGrouping);
+
+            if (!_customDeserializer.ContainsKey(concreteType))
+            {
+                this.RegisterType(concreteType, SerializeGrouping, DeserializeGrouping);
+            }
+        }
+    }
+}

--- a/LiteDB/Client/Mapper/Linq/TypeResolver/GroupingResolver.cs
+++ b/LiteDB/Client/Mapper/Linq/TypeResolver/GroupingResolver.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections;
+using System.Linq;
+using System.Reflection;
+
+namespace LiteDB
+{
+    internal class GroupingResolver : EnumerableResolver
+    {
+        public override string ResolveMethod(MethodInfo method)
+        {
+            var name = Reflection.MethodName(method, 1);
+            switch (name)
+            {
+                case "AsEnumerable()": return "*";
+                case "Where(Func<T,TResult>)": return "FILTER(* => @1)";
+                case "Select(Func<T,TResult>)": return "MAP(* => @1)";
+                case "Count()": return "COUNT(*)";
+                case "Count(Func<T,TResult>)": return "COUNT(FILTER(* => @1))";
+                case "Any()": return "COUNT(*) > 0";
+                case "Any(Func<T,TResult>)": return "FILTER(* => @1) ANY %";
+                case "All(Func<T,TResult>)": return "FILTER(* => @1) ALL %";
+                case "Sum()": return "SUM(*)";
+                case "Sum(Func<T,TResult>)": return "SUM(MAP(* => @1))";
+                case "Average()": return "AVG(*)";
+                case "Average(Func<T,TResult>)": return "AVG(MAP(* => @1))";
+                case "Max()": return "MAX(*)";
+                case "Max(Func<T,TResult>)": return "MAX(MAP(* => @1))";
+                case "Min()": return "MIN(*)";
+                case "Min(Func<T,TResult>)": return "MIN(MAP(* => @1))";
+            }
+
+            return base.ResolveMethod(method);
+        }
+
+        public override string ResolveMember(MemberInfo member)
+        {
+            if (member.Name == nameof(IGrouping<object, object>.Key))
+            {
+                return "@key";
+            }
+
+            if (member.Name == nameof(ICollection.Count))
+            {
+                return "COUNT(*)";
+            }
+
+            return base.ResolveMember(member);
+        }
+    }
+}

--- a/LiteDB/Engine/Query/Pipeline/GroupByPipe.cs
+++ b/LiteDB/Engine/Query/Pipeline/GroupByPipe.cs
@@ -36,17 +36,23 @@ namespace LiteDB.Engine
                 source = this.Filter(source, expr);
             }
 
-            // run orderBy used in GroupBy (if not already ordered by index)
-            if (query.OrderBy != null)
+            // run orderBy used to prepare data for grouping (if not already ordered by index)
+            if (query.GroupBy.OrderBy != null)
             {
-                source = this.OrderBy(source, query.OrderBy, 0, int.MaxValue);
+                source = this.OrderBy(source, query.GroupBy.OrderBy, 0, int.MaxValue);
             }
 
             // apply groupby
             var groups = this.GroupBy(source, query.GroupBy);
 
             // apply group filter and transform result
-            var result = this.SelectGroupBy(groups, query.GroupBy);
+            var result = this.SelectGroupBy(groups, query.GroupBy, query.OrderBy);
+
+            if (query.OrderBy != null)
+            {
+                return this.OrderGroupedResult(result, query.OrderBy, query.Offset, query.Limit)
+                    .Select(x => x.Document);
+            }
 
             // apply offset
             if (query.Offset > 0) result = result.Skip(query.Offset);
@@ -54,13 +60,26 @@ namespace LiteDB.Engine
             // apply limit
             if (query.Limit < int.MaxValue) result = result.Take(query.Limit);
 
-            return result;
+            return result.Select(x => x.Document);
         }
 
         /// <summary>
         /// GROUP BY: Apply groupBy expression and aggregate results in DocumentGroup
         /// </summary>
-        private IEnumerable<DocumentCacheEnumerable> GroupBy(IEnumerable<BsonDocument> source, GroupBy groupBy)
+        private readonly struct GroupSource
+        {
+            public GroupSource(BsonValue key, DocumentCacheEnumerable documents)
+            {
+                this.Key = key;
+                this.Documents = documents;
+            }
+
+            public BsonValue Key { get; }
+
+            public DocumentCacheEnumerable Documents { get; }
+        }
+
+        private IEnumerable<GroupSource> GroupBy(IEnumerable<BsonDocument> source, GroupBy groupBy)
         {
             using (var enumerator = source.GetEnumerator())
             {
@@ -70,11 +89,9 @@ namespace LiteDB.Engine
                 {
                     var key = groupBy.Expression.ExecuteScalar(enumerator.Current, _pragmas.Collation);
 
-                    groupBy.Select.Parameters["key"] = key;
-
                     var group = YieldDocuments(key, enumerator, groupBy, done);
 
-                    yield return new DocumentCacheEnumerable(group, _lookup);
+                    yield return new GroupSource(key, new DocumentCacheEnumerable(group, _lookup));
                 }
             }
         }
@@ -90,15 +107,13 @@ namespace LiteDB.Engine
             {
                 var current = groupBy.Expression.ExecuteScalar(enumerator.Current, _pragmas.Collation);
 
-                if (key == current)
+                if (_pragmas.Collation.Equals(key, current))
                 {
                     // yield return document in same key (group)
                     yield return enumerator.Current;
                 }
                 else
                 {
-                    groupBy.Select.Parameters["key"] = current;
-
                     // stop current sequence
                     yield break;
                 }
@@ -109,38 +124,163 @@ namespace LiteDB.Engine
         /// Run Select expression over a group source - each group will return a single value
         /// If contains Having expression, test if result = true before run Select
         /// </summary>
-        private IEnumerable<BsonDocument> SelectGroupBy(IEnumerable<DocumentCacheEnumerable> groups, GroupBy groupBy)
+        private readonly struct GroupedResult
+        {
+            public GroupedResult(BsonValue key, BsonDocument document, BsonValue[] orderValues)
+            {
+                this.Key = key;
+                this.Document = document;
+                this.OrderValues = orderValues;
+            }
+
+            public BsonValue Key { get; }
+
+            public BsonDocument Document { get; }
+
+            public BsonValue[] OrderValues { get; }
+        }
+
+        private static void SetKeyParameter(BsonExpression expression, BsonValue key)
+        {
+            if (expression?.Parameters != null)
+            {
+                expression.Parameters["key"] = key;
+            }
+        }
+
+        private IEnumerable<GroupedResult> SelectGroupBy(IEnumerable<GroupSource> groups, GroupBy groupBy, OrderBy resultOrderBy)
         {
             var defaultName = groupBy.Select.DefaultFieldName();
 
             foreach (var group in groups)
             {
-                // transfom group result if contains select expression
-                BsonValue value;
+                var key = group.Key;
+                var cache = group.Documents;
+
+                SetKeyParameter(groupBy.Select, key);
+                SetKeyParameter(groupBy.Having, key);
+
+                BsonDocument document = null;
+                BsonValue[] orderValues = null;
 
                 try
                 {
                     if (groupBy.Having != null)
                     {
-                        var filter = groupBy.Having.ExecuteScalar(group, null, null, _pragmas.Collation);
+                        var filter = groupBy.Having.ExecuteScalar(cache, null, null, _pragmas.Collation);
 
-                        if (!filter.IsBoolean || !filter.AsBoolean) continue;
+                        if (!filter.IsBoolean || !filter.AsBoolean)
+                        {
+                            continue;
+                        }
                     }
 
-                    value = groupBy.Select.ExecuteScalar(group, null, null, _pragmas.Collation);
+                    BsonValue value;
+
+                    if (ReferenceEquals(groupBy.Select, BsonExpression.Root))
+                    {
+                        var items = new BsonArray();
+
+                        foreach (var groupDocument in cache)
+                        {
+                            items.Add(groupDocument);
+                        }
+
+                        value = new BsonDocument
+                        {
+                            [LiteGroupingFieldNames.Key] = key,
+                            [LiteGroupingFieldNames.Items] = items
+                        };
+                    }
+                    else
+                    {
+                        value = groupBy.Select.ExecuteScalar(cache, null, null, _pragmas.Collation);
+                    }
+
+                    if (value.IsDocument)
+                    {
+                        document = value.AsDocument;
+                    }
+                    else
+                    {
+                        document = new BsonDocument { [defaultName] = value };
+                    }
+
+                    if (resultOrderBy != null)
+                    {
+                        var segments = resultOrderBy.Segments;
+
+                        orderValues = new BsonValue[segments.Count];
+
+                        for (var i = 0; i < segments.Count; i++)
+                        {
+                            var expression = segments[i].Expression;
+
+                            SetKeyParameter(expression, key);
+
+                            orderValues[i] = expression.ExecuteScalar(cache, document, null, _pragmas.Collation);
+                        }
+                    }
                 }
                 finally
                 {
-                    group.Dispose();
+                    cache.Dispose();
                 }
 
-                if (value.IsDocument)
+                yield return new GroupedResult(key, document, orderValues);
+            }
+        }
+
+        /// <summary>
+        /// Apply ORDER BY over grouped projection using in-memory sorting.
+        /// </summary>
+        private IEnumerable<GroupedResult> OrderGroupedResult(IEnumerable<GroupedResult> source, OrderBy orderBy, int offset, int limit)
+        {
+            var segments = orderBy.Segments;
+            var orders = segments.Select(x => x.Order).ToArray();
+            var buffer = new List<(SortKey Key, GroupedResult Result)>();
+
+            foreach (var item in source)
+            {
+                var values = item.OrderValues ?? new BsonValue[segments.Count];
+
+                if (item.OrderValues == null)
                 {
-                    yield return value.AsDocument;
+                    for (var i = 0; i < segments.Count; i++)
+                    {
+                        var expression = segments[i].Expression;
+
+                        SetKeyParameter(expression, item.Key);
+
+                        values[i] = expression.ExecuteScalar(item.Document, _pragmas.Collation);
+                    }
                 }
-                else
+
+                var key = SortKey.FromValues(values, orders);
+
+                buffer.Add((key, item));
+            }
+
+            buffer.Sort((left, right) => left.Key.CompareTo(right.Key, _pragmas.Collation));
+
+            var skipped = 0;
+            var returned = 0;
+
+            foreach (var item in buffer)
+            {
+                if (skipped < offset)
                 {
-                    yield return new BsonDocument { [defaultName] = value };
+                    skipped++;
+                    continue;
+                }
+
+                yield return item.Result;
+
+                returned++;
+
+                if (limit != int.MaxValue && returned >= limit)
+                {
+                    yield break;
                 }
             }
         }

--- a/LiteDB/Engine/Query/QueryOptimization.cs
+++ b/LiteDB/Engine/Query/QueryOptimization.cs
@@ -560,25 +560,25 @@ namespace LiteDB.Engine
         {
             if (_query.GroupBy == null) return;
 
-            if (_query.OrderBy.Count > 0) throw new NotSupportedException("GROUP BY expression do not support ORDER BY");
             if (_query.Includes.Count > 0) throw new NotSupportedException("GROUP BY expression do not support INCLUDE");
 
-            var groupBy = new GroupBy(_query.GroupBy, _queryPlan.Select.Expression, _query.Having);
-            var orderBy = (OrderBy)null;
+            var expression = _query.GroupBy;
+            var select = _queryPlan.Select.Expression;
+            var having = _query.Having;
+            var groupOrderBy = (OrderBy)null;
 
-            // if groupBy use same expression in index, set group by order to MaxValue to not run
-            if (groupBy.Expression.Source == _queryPlan.IndexExpression)
+            // if groupBy use same expression in index, no additional ordering is required before grouping
+            if (expression.Source == _queryPlan.IndexExpression)
             {
-                // great - group by expression are same used in index - no changes here
+                // index already provides grouped ordering
             }
             else
             {
                 // create orderBy expression
-                orderBy = new OrderBy(new[] { new OrderByItem(groupBy.Expression, Query.Ascending) });
+                groupOrderBy = new OrderBy(new[] { new OrderByItem(expression, Query.Ascending) });
             }
 
-            _queryPlan.GroupBy = groupBy;
-            _queryPlan.OrderBy = orderBy;
+            _queryPlan.GroupBy = new GroupBy(expression, select, having, groupOrderBy);
         }
 
         #endregion

--- a/LiteDB/Engine/Query/Structures/GroupBy.cs
+++ b/LiteDB/Engine/Query/Structures/GroupBy.cs
@@ -18,11 +18,14 @@ namespace LiteDB.Engine
 
         public BsonExpression Having { get; }
 
-        public GroupBy(BsonExpression expression, BsonExpression select, BsonExpression having)
+        public OrderBy OrderBy { get; }
+
+        public GroupBy(BsonExpression expression, BsonExpression select, BsonExpression having, OrderBy orderBy)
         {
             this.Expression = expression;
             this.Select = select;
             this.Having = having;
+            this.OrderBy = orderBy;
         }
     }
 }

--- a/LiteDB/Engine/Query/Structures/QueryPlan.cs
+++ b/LiteDB/Engine/Query/Structures/QueryPlan.cs
@@ -203,12 +203,23 @@ namespace LiteDB.Engine
 
             if (this.GroupBy != null)
             {
-                doc["groupBy"] = new BsonDocument
+                var group = new BsonDocument
                 {
                     ["expr"] = this.GroupBy.Expression.Source,
                     ["having"] = this.GroupBy.Having?.Source,
                     ["select"] = this.GroupBy.Select?.Source
                 };
+
+                if (this.GroupBy.OrderBy != null)
+                {
+                    group["orderBy"] = new BsonArray(this.GroupBy.OrderBy.Segments.Select(x => new BsonDocument
+                    {
+                        ["expr"] = x.Expression.Source,
+                        ["order"] = x.Order
+                    }));
+                }
+
+                doc["groupBy"] = group;
             }
             else
             {


### PR DESCRIPTION
This pull request introduces comprehensive support for LINQ-style `GroupBy` queries in LiteDB, enabling users to group query results using strongly-typed expressions and work with `IGrouping<TKey, TElement>` results. The changes span the query interface, query pipeline, expression visitor, and type mapping to provide a seamless and efficient grouping experience.

**Key changes:**

### LINQ GroupBy Support and Interface Updates

* Added a strongly-typed `GroupBy<K>(Expression<Func<T, K>> keySelector)` method to the `ILiteQueryable<T>` interface, allowing users to group results and receive `IGrouping<K, T>` objects. The `Select` methods were also updated to return `ILiteQueryable` instead of `ILiteQueryableResult` for consistency. [[1]](diffhunk://#diff-a07a996a9d353dc6e776893fa3488c5cf7918c0dac423762c1ad2fb3b213659eR28-R33) [[2]](diffhunk://#diff-abeb070f07ebf2ff584f4e6ffdd108467ff216610c0fc2fe25d7330c87ec4523R176-R189) [[3]](diffhunk://#diff-abeb070f07ebf2ff584f4e6ffdd108467ff216610c0fc2fe25d7330c87ec4523L209-R223) [[4]](diffhunk://#diff-abeb070f07ebf2ff584f4e6ffdd108467ff216610c0fc2fe25d7330c87ec4523L219-L222)

### Grouping Implementation

* Introduced the `LiteGrouping<TKey, TElement>` class as a concrete implementation of `IGrouping<TKey, TElement>`, enabling materialization of grouping results.
* Added `BsonMapper.RegisterGroupingType` to handle serialization and deserialization of groupings, ensuring correct mapping between BSON and .NET groupings.

### Query Pipeline and Execution Enhancements

* Refactored the query pipeline to support grouping, including proper ordering before grouping, handling of `Having`, and in-memory ordering of grouped results. Added new internal structures (`GroupSource`, `GroupedResult`) and logic for efficient grouping and ordering. [[1]](diffhunk://#diff-c886a057f90e8eafb7fb2d8e1d214a8dfbbd7904d6febc27efc5ce544d401c6bL39-R82) [[2]](diffhunk://#diff-c886a057f90e8eafb7fb2d8e1d214a8dfbbd7904d6febc27efc5ce544d401c6bL73-R94) [[3]](diffhunk://#diff-c886a057f90e8eafb7fb2d8e1d214a8dfbbd7904d6febc27efc5ce544d401c6bL93-L101) [[4]](diffhunk://#diff-c886a057f90e8eafb7fb2d8e1d214a8dfbbd7904d6febc27efc5ce544d401c6bL112-R283)
* Updated query optimization to allow `ORDER BY` after grouping and to avoid redundant ordering when the grouping expression matches the index.

### Expression Visitor and Resolver Improvements

* Enhanced the LINQ expression visitor to recognize and correctly resolve `IGrouping<,>` types, enabling support for LINQ methods such as `Select`, `Where`, and aggregation functions on groupings. [[1]](diffhunk://#diff-3c0fe38931db10bc4ee1b883bd5b886ebcb6237f6ca58fd873da44c2eda8dbd5R27) [[2]](diffhunk://#diff-3c0fe38931db10bc4ee1b883bd5b886ebcb6237f6ca58fd873da44c2eda8dbd5L205-R219) [[3]](diffhunk://#diff-3c0fe38931db10bc4ee1b883bd5b886ebcb6237f6ca58fd873da44c2eda8dbd5R746-R752)
* Introduced `GroupingResolver` to map LINQ methods and properties on `IGrouping` to LiteDB expressions.

---

These changes collectively enable robust, efficient, and type-safe group-by queries in LiteDB, aligning its LINQ capabilities more closely with standard .NET query patterns.