### PR TITLE
Fix/dotnet 10 expression breaking change

### DIFF
--- a/LiteDB/Client/Mapper/Linq/TypeResolver/MemoryExtensionsResolver.cs
+++ b/LiteDB/Client/Mapper/Linq/TypeResolver/MemoryExtensionsResolver.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+
+namespace LiteDB
+{
+    internal class MemoryExtensionsResolver : ITypeResolver
+    {
+        public string ResolveMethod(MethodInfo method)
+        {
+            if (method.Name == nameof(System.MemoryExtensions.Contains))
+            {
+                var parameters = method.GetParameters();
+
+                if (parameters.Length == 2)
+                {
+                    return "@0 ANY = @1";
+                }
+            }
+
+            return null;
+        }
+
+        public string ResolveMember(MemberInfo member) => null;
+
+        public string ResolveCtor(ConstructorInfo ctor) => null;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/litedb-org/LiteDB/issues/2670 

Ref https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/10.0/csharp-overload-resolution


No new tests because we already had a test which failed under dotnet 10: ``Index_Multikey_Using_Linq``
```
System.NotSupportedException: Method Contains not available to convert to BsonExpression (op_Implicit(x.Phones).Contains(3)).

System.NotSupportedException
Method Contains not available to convert to BsonExpression (op_Implicit(x.Phones).Contains(3)).
   at LiteDB.LinqExpressionVisitor.VisitMethodCall(MethodCallExpression node) in C:\Users\W31rd0\source\repos\External\LiteDB\LiteDB\Client\Mapper\Linq\LinqExpressionVisitor.cs:line 224
   at System.Linq.Expressions.ExpressionVisitor.VisitLambda[T](Expression`1 node)
   at LiteDB.LinqExpressionVisitor.VisitLambda[T](Expression`1 node) in C:\Users\W31rd0\source\repos\External\LiteDB\LiteDB\Client\Mapper\Linq\LinqExpressionVisitor.cs:line 96
   at LiteDB.LinqExpressionVisitor.Resolve(Boolean predicate) in C:\Users\W31rd0\source\repos\External\LiteDB\LiteDB\Client\Mapper\Linq\LinqExpressionVisitor.cs:line 65
   at LiteDB.BsonMapper.GetExpression[T,K](Expression`1 predicate) in C:\Users\W31rd0\source\repos\External\LiteDB\LiteDB\Client\Mapper\BsonMapper.cs:line 174
   at LiteDB.LiteQueryable`1.Where(Expression`1 predicate) in C:\Users\W31rd0\source\repos\External\LiteDB\LiteDB\Client\Database\LiteQueryable.cs:line 98
   at LiteDB.Tests.Database.IndexMultiKeyIndex.Index_Multikey_Using_Linq() in C:\Users\W31rd0\source\repos\External\LiteDB\LiteDB.Tests\Database\IndexMultiKeyLinq_Tests.cs:line 50
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```