### PR TITLE
Implement spatial roadmap milestones

### DIFF
--- a/LiteDB.Benchmarks/Benchmarks/Constants.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Constants.cs
@@ -10,6 +10,7 @@ namespace LiteDB.Benchmarks.Benchmarks
             internal const string QUERIES = nameof(QUERIES);
             internal const string INSERTION = nameof(INSERTION);
             internal const string DELETION = nameof(DELETION);
+            internal const string SPATIAL = nameof(SPATIAL);
         }
     }
 }

--- a/LiteDB.Benchmarks/Benchmarks/Spatial/SpatialQueryBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Spatial/SpatialQueryBenchmark.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using LiteDB;
+using LiteDB.Benchmarks.Models;
+using LiteDB.Spatial;
+using SpatialApi = LiteDB.Spatial.Spatial;
+
+namespace LiteDB.Benchmarks.Benchmarks.Spatial
+{
+    [BenchmarkCategory(Constants.Categories.QUERIES, Constants.Categories.SPATIAL)]
+    public class SpatialQueryBenchmark : BenchmarkBase
+    {
+        private ILiteCollection<GeoPlace> _places = null!;
+        private ILiteCollection<GeoRegion> _regions = null!;
+        private GeoPoint _nearCenter = null!;
+        private double _nearRadius;
+        private GeoBoundingBox _boundingBox;
+        private GeoPolygon _queryPolygon = null!;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            File.Delete(DatabasePath);
+
+            DatabaseInstance = new LiteDatabase(ConnectionString());
+            _places = DatabaseInstance.GetCollection<GeoPlace>("places");
+            _regions = DatabaseInstance.GetCollection<GeoRegion>("regions");
+
+            _nearCenter = new GeoPoint(48.2082, 16.3738);
+            _nearRadius = 1_500d;
+
+            SpatialApi.EnsurePointIndex(_places, x => x.Location);
+            SpatialApi.EnsureShapeIndex(_regions, x => x.Area);
+
+            var places = new List<GeoPlace>(DatasetSize);
+            var regions = new List<GeoRegion>(DatasetSize);
+            var random = new Random(2024);
+
+            for (var i = 0; i < DatasetSize; i++)
+            {
+                var latOffset = (random.NextDouble() - 0.5) * 0.6;
+                var lonOffset = (random.NextDouble() - 0.5) * 0.6;
+                var location = new GeoPoint(_nearCenter.Lat + latOffset, _nearCenter.Lon + lonOffset);
+
+                places.Add(new GeoPlace
+                {
+                    Name = $"P{i}",
+                    Location = location
+                });
+
+                regions.Add(CreateRegion(location, 0.02 + random.NextDouble() * 0.02, i));
+            }
+
+            _places.Insert(places);
+            _regions.Insert(regions);
+
+            DatabaseInstance.Checkpoint();
+
+            _boundingBox = GeoMath.BoundingBoxForCircle(_nearCenter, _nearRadius * 1.5d);
+            _queryPolygon = CreateRegion(_nearCenter, 0.15d, -1).Area;
+        }
+
+        [Benchmark(Baseline = true)]
+        public int NearByMorton()
+        {
+            return SpatialApi.Near(_places, x => x.Location, _nearCenter, _nearRadius).Count();
+        }
+
+        [Benchmark]
+        public int WithinBoundingBox()
+        {
+            return SpatialApi.WithinBoundingBox(_places, x => x.Location, _boundingBox.MinLat, _boundingBox.MinLon, _boundingBox.MaxLat, _boundingBox.MaxLon).Count();
+        }
+
+        [Benchmark]
+        public int IntersectsPolygon()
+        {
+            return SpatialApi.Intersects(_regions, x => x.Area, _queryPolygon).Count();
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            DatabaseInstance?.Checkpoint();
+            DatabaseInstance?.Dispose();
+            DatabaseInstance = null;
+
+            File.Delete(DatabasePath);
+        }
+
+        private static GeoRegion CreateRegion(GeoPoint center, double sizeDegrees, int index)
+        {
+            var half = sizeDegrees / 2d;
+
+            var points = new[]
+            {
+                new GeoPoint(center.Lat + half, center.Lon - half),
+                new GeoPoint(center.Lat + half, center.Lon + half),
+                new GeoPoint(center.Lat - half, center.Lon + half),
+                new GeoPoint(center.Lat - half, center.Lon - half),
+                new GeoPoint(center.Lat + half, center.Lon - half)
+            };
+
+            return new GeoRegion
+            {
+                Name = index >= 0 ? $"R{index}" : "Query",
+                Area = new GeoPolygon(points)
+            };
+        }
+    }
+}

--- a/LiteDB.Benchmarks/Models/GeoPlace.cs
+++ b/LiteDB.Benchmarks/Models/GeoPlace.cs
@@ -1,0 +1,18 @@
+using System;
+using LiteDB.Spatial;
+
+namespace LiteDB.Benchmarks.Models
+{
+    public class GeoPlace
+    {
+        public ObjectId Id { get; set; }
+
+        public string Name { get; set; } = string.Empty;
+
+        public GeoPoint Location { get; set; } = new GeoPoint(0, 0);
+
+        internal long _gh { get; set; }
+
+        internal double[] _mbb { get; set; } = Array.Empty<double>();
+    }
+}

--- a/LiteDB.Benchmarks/Models/GeoRegion.cs
+++ b/LiteDB.Benchmarks/Models/GeoRegion.cs
@@ -1,0 +1,23 @@
+using System;
+using LiteDB.Spatial;
+
+namespace LiteDB.Benchmarks.Models
+{
+    public class GeoRegion
+    {
+        public ObjectId Id { get; set; }
+
+        public string Name { get; set; } = string.Empty;
+
+        public GeoPolygon Area { get; set; } = new GeoPolygon(new[]
+        {
+            new GeoPoint(0, 0),
+            new GeoPoint(0, 0.1),
+            new GeoPoint(0.1, 0.1),
+            new GeoPoint(0.1, 0),
+            new GeoPoint(0, 0)
+        });
+
+        internal double[] _mbb { get; set; } = Array.Empty<double>();
+    }
+}

--- a/LiteDB/Client/Database/Collections/Index.cs
+++ b/LiteDB/Client/Database/Collections/Index.cs
@@ -15,12 +15,13 @@ namespace LiteDB
         /// <param name="name">Index name - unique name for this collection</param>
         /// <param name="expression">Create a custom expression function to be indexed</param>
         /// <param name="unique">If is a unique index</param>
-        public bool EnsureIndex(string name, BsonExpression expression, bool unique = false)
+        /// <param name="reservedMetadata">Optional metadata persisted with the index definition.</param>
+        public bool EnsureIndex(string name, BsonExpression expression, bool unique = false, byte? reservedMetadata = null)
         {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
             if (expression == null) throw new ArgumentNullException(nameof(expression));
 
-            return _engine.EnsureIndex(_collection, name, expression, unique);
+            return _engine.EnsureIndex(_collection, name, expression, unique, reservedMetadata);
         }
 
         /// <summary>
@@ -28,13 +29,14 @@ namespace LiteDB
         /// </summary>
         /// <param name="expression">Document field/expression</param>
         /// <param name="unique">If is a unique index</param>
-        public bool EnsureIndex(BsonExpression expression, bool unique = false)
+        /// <param name="reservedMetadata">Optional metadata persisted with the index definition.</param>
+        public bool EnsureIndex(BsonExpression expression, bool unique = false, byte? reservedMetadata = null)
         {
             if (expression == null) throw new ArgumentNullException(nameof(expression));
 
             var name = Regex.Replace(expression.Source, @"[^a-z0-9]", "", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-            return this.EnsureIndex(name, expression, unique);
+            return this.EnsureIndex(name, expression, unique, reservedMetadata);
         }
 
         /// <summary>
@@ -42,11 +44,12 @@ namespace LiteDB
         /// </summary>
         /// <param name="keySelector">LinqExpression to be converted into BsonExpression to be indexed</param>
         /// <param name="unique">Create a unique keys index?</param>
-        public bool EnsureIndex<K>(Expression<Func<T, K>> keySelector, bool unique = false)
+        /// <param name="reservedMetadata">Optional metadata persisted with the index definition.</param>
+        public bool EnsureIndex<K>(Expression<Func<T, K>> keySelector, bool unique = false, byte? reservedMetadata = null)
         {
             var expression = this.GetIndexExpression(keySelector);
 
-            return this.EnsureIndex(expression, unique);
+            return this.EnsureIndex(expression, unique, reservedMetadata);
         }
 
         /// <summary>
@@ -55,11 +58,12 @@ namespace LiteDB
         /// <param name="name">Index name - unique name for this collection</param>
         /// <param name="keySelector">LinqExpression to be converted into BsonExpression to be indexed</param>
         /// <param name="unique">Create a unique keys index?</param>
-        public bool EnsureIndex<K>(string name, Expression<Func<T, K>> keySelector, bool unique = false)
+        /// <param name="reservedMetadata">Optional metadata persisted with the index definition.</param>
+        public bool EnsureIndex<K>(string name, Expression<Func<T, K>> keySelector, bool unique = false, byte? reservedMetadata = null)
         {
             var expression = this.GetIndexExpression(keySelector);
 
-            return this.EnsureIndex(name, expression, unique);
+            return this.EnsureIndex(name, expression, unique, reservedMetadata);
         }
 
         /// <summary>

--- a/LiteDB/Client/Database/ILiteCollection.cs
+++ b/LiteDB/Client/Database/ILiteCollection.cs
@@ -101,21 +101,24 @@ namespace LiteDB
         /// <param name="name">Index name - unique name for this collection</param>
         /// <param name="expression">Create a custom expression function to be indexed</param>
         /// <param name="unique">If is a unique index</param>
-        bool EnsureIndex(string name, BsonExpression expression, bool unique = false);
+        /// <param name="reservedMetadata">Optional metadata persisted with the index definition.</param>
+        bool EnsureIndex(string name, BsonExpression expression, bool unique = false, byte? reservedMetadata = null);
 
         /// <summary>
         /// Create a new permanent index in all documents inside this collections if index not exists already. Returns true if index was created or false if already exits
         /// </summary>
         /// <param name="expression">Document field/expression</param>
         /// <param name="unique">If is a unique index</param>
-        bool EnsureIndex(BsonExpression expression, bool unique = false);
+        /// <param name="reservedMetadata">Optional metadata persisted with the index definition.</param>
+        bool EnsureIndex(BsonExpression expression, bool unique = false, byte? reservedMetadata = null);
 
         /// <summary>
         /// Create a new permanent index in all documents inside this collections if index not exists already.
         /// </summary>
         /// <param name="keySelector">LinqExpression to be converted into BsonExpression to be indexed</param>
         /// <param name="unique">Create a unique keys index?</param>
-        bool EnsureIndex<K>(Expression<Func<T, K>> keySelector, bool unique = false);
+        /// <param name="reservedMetadata">Optional metadata persisted with the index definition.</param>
+        bool EnsureIndex<K>(Expression<Func<T, K>> keySelector, bool unique = false, byte? reservedMetadata = null);
 
         /// <summary>
         /// Create a new permanent index in all documents inside this collections if index not exists already.
@@ -123,7 +126,8 @@ namespace LiteDB
         /// <param name="name">Index name - unique name for this collection</param>
         /// <param name="keySelector">LinqExpression to be converted into BsonExpression to be indexed</param>
         /// <param name="unique">Create a unique keys index?</param>
-        bool EnsureIndex<K>(string name, Expression<Func<T, K>> keySelector, bool unique = false);
+        /// <param name="reservedMetadata">Optional metadata persisted with the index definition.</param>
+        bool EnsureIndex<K>(string name, Expression<Func<T, K>> keySelector, bool unique = false, byte? reservedMetadata = null);
 
         /// <summary>
         /// Drop index and release slot for another index

--- a/LiteDB/Client/Shared/SharedEngine.cs
+++ b/LiteDB/Client/Shared/SharedEngine.cs
@@ -230,9 +230,14 @@ namespace LiteDB
             return QueryDatabase(() => _engine.DropIndex(collection, name));
         }
 
-        public bool EnsureIndex(string collection, string name, BsonExpression expression, bool unique)
+        public bool EnsureIndex(string collection, string name, BsonExpression expression, bool unique, byte? reservedMetadata = null)
         {
-            return QueryDatabase(() => _engine.EnsureIndex(collection, name, expression, unique));
+            return QueryDatabase(() => _engine.EnsureIndex(collection, name, expression, unique, reservedMetadata));
+        }
+
+        public byte? GetIndexMetadata(string collection, string name)
+        {
+            return QueryDatabase(() => _engine.GetIndexMetadata(collection, name));
         }
 
         #endregion

--- a/LiteDB/Document/Expression/Methods/Spatial.cs
+++ b/LiteDB/Document/Expression/Methods/Spatial.cs
@@ -1,0 +1,122 @@
+using System;
+using LiteDB.Spatial;
+
+namespace LiteDB
+{
+    internal partial class BsonExpressionMethods
+    {
+        public static BsonValue SPATIAL_INTERSECTS(BsonValue bboxValue, BsonValue minLat, BsonValue minLon, BsonValue maxLat, BsonValue maxLon)
+        {
+            if (!TryCreateBoundingBox(bboxValue, out var bbox))
+            {
+                return new BsonValue(false);
+            }
+
+            var queryBox = new GeoBoundingBox(minLat.AsDouble, minLon.AsDouble, maxLat.AsDouble, maxLon.AsDouble);
+
+            return new BsonValue(bbox.Intersects(queryBox));
+        }
+
+        public static BsonValue SPATIAL_CONTAINS_POINT(BsonValue bboxValue, BsonValue lat, BsonValue lon)
+        {
+            if (!TryCreateBoundingBox(bboxValue, out var bbox))
+            {
+                return new BsonValue(false);
+            }
+
+            if (!lat.IsNumber || !lon.IsNumber)
+            {
+                return new BsonValue(false);
+            }
+
+            var point = new GeoPoint(lat.AsDouble, lon.AsDouble);
+
+            return new BsonValue(bbox.Contains(point));
+        }
+
+        public static BsonValue SPATIAL_NEAR(BsonValue bboxValue, BsonValue lat, BsonValue lon, BsonValue radiusMeters, BsonValue formula = null)
+        {
+            if (!TryCreateBoundingBox(bboxValue, out var bbox))
+            {
+                return new BsonValue(false);
+            }
+
+            if (!lat.IsNumber || !lon.IsNumber || !radiusMeters.IsNumber)
+            {
+                return new BsonValue(false);
+            }
+
+            var center = new GeoPoint(lat.AsDouble, lon.AsDouble);
+            var radius = radiusMeters.AsDouble;
+
+            if (radius < 0d)
+            {
+                return new BsonValue(false);
+            }
+
+            var distanceFormula = GetFormula(formula);
+
+            if (Math.Abs(bbox.MinLat - bbox.MaxLat) < GeoMath.EpsilonDegrees && Math.Abs(bbox.MinLon - bbox.MaxLon) < GeoMath.EpsilonDegrees)
+            {
+                var candidate = new GeoPoint(bbox.MinLat, bbox.MinLon);
+                var distance = GeoMath.DistanceMeters(center, candidate, distanceFormula);
+                return new BsonValue(distance <= radius);
+            }
+
+            var circleBox = GeoMath.BoundingBoxForCircle(center, radius);
+            return new BsonValue(bbox.Intersects(circleBox));
+        }
+
+        private static bool TryCreateBoundingBox(BsonValue value, out GeoBoundingBox bbox)
+        {
+            bbox = default;
+
+            if (value == null || value.IsNull || !value.IsArray)
+            {
+                return false;
+            }
+
+            var array = value.AsArray;
+
+            if (array.Count < 4)
+            {
+                return false;
+            }
+
+            if (!array[0].IsNumber || !array[1].IsNumber || !array[2].IsNumber || !array[3].IsNumber)
+            {
+                return false;
+            }
+
+            bbox = new GeoBoundingBox(array[0].AsDouble, array[1].AsDouble, array[2].AsDouble, array[3].AsDouble);
+            return true;
+        }
+
+        private static DistanceFormula GetFormula(BsonValue value)
+        {
+            if (value == null || value.IsNull)
+            {
+                return DistanceFormula.Haversine;
+            }
+
+            if (value.IsString && Enum.TryParse<DistanceFormula>(value.AsString, true, out var parsed))
+            {
+                return parsed;
+            }
+
+            if (value.IsNumber)
+            {
+                try
+                {
+                    return (DistanceFormula)value.AsInt32;
+                }
+                catch
+                {
+                    return DistanceFormula.Haversine;
+                }
+            }
+
+            return DistanceFormula.Haversine;
+        }
+    }
+}

--- a/LiteDB/Engine/ILiteEngine.cs
+++ b/LiteDB/Engine/ILiteEngine.cs
@@ -24,8 +24,10 @@ namespace LiteDB.Engine
         bool DropCollection(string name);
         bool RenameCollection(string name, string newName);
 
-        bool EnsureIndex(string collection, string name, BsonExpression expression, bool unique);
+        bool EnsureIndex(string collection, string name, BsonExpression expression, bool unique, byte? reservedMetadata = null);
         bool DropIndex(string collection, string name);
+
+        byte? GetIndexMetadata(string collection, string name);
 
         BsonValue Pragma(string name);
         bool Pragma(string name, BsonValue value);

--- a/LiteDB/Engine/Query/QueryOptimization.cs
+++ b/LiteDB/Engine/Query/QueryOptimization.cs
@@ -85,7 +85,7 @@ namespace LiteDB.Engine
                 }
 
                 // add expression in where list breaking AND statments
-                if (predicate.IsPredicate || predicate.Type == BsonExpressionType.Or)
+                if (predicate.IsPredicate || predicate.Type == BsonExpressionType.Or || IsSpatialPredicate(predicate))
                 {
                     _terms.Add(predicate);
                 }
@@ -107,6 +107,28 @@ namespace LiteDB.Engine
             foreach(var predicate in _query.Where)
             {
                 add(predicate);
+            }
+        }
+
+        private static bool IsSpatialPredicate(BsonExpression expression)
+        {
+            if (expression == null || expression.Type != BsonExpressionType.Call)
+            {
+                return false;
+            }
+
+            var source = expression.Source?.Trim() ?? string.Empty;
+            var nameEnd = source.IndexOf('(');
+            var name = nameEnd > 0 ? source.Substring(0, nameEnd) : source;
+
+            switch (name.ToUpperInvariant())
+            {
+                case "SPATIAL_INTERSECTS":
+                case "SPATIAL_CONTAINS_POINT":
+                case "SPATIAL_NEAR":
+                    return true;
+                default:
+                    return false;
             }
         }
 

--- a/LiteDB/Spatial/SpatialOptions.cs
+++ b/LiteDB/Spatial/SpatialOptions.cs
@@ -21,5 +21,9 @@ namespace LiteDB.Spatial
         public int MaxCoveringCells { get; set; } = 32;
 
         public AngleUnit AngleUnit { get; set; } = AngleUnit.Degrees;
+
+        public int IndexPrecisionBits { get; set; } = 52;
+
+        public double ToleranceDegrees { get; set; } = GeoMath.EpsilonDegrees;
     }
 }

--- a/LiteDB/Spatial/SpatialQueryHelper.cs
+++ b/LiteDB/Spatial/SpatialQueryHelper.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using LiteDB;
+
+namespace LiteDB.Spatial
+{
+    internal readonly struct SpatialQuerySegment
+    {
+        public GeoBoundingBox BoundingBox { get; }
+
+        public (long Start, long End)? MortonRange { get; }
+
+        public SpatialQuerySegment(GeoBoundingBox boundingBox, (long Start, long End)? mortonRange)
+        {
+            BoundingBox = boundingBox;
+            MortonRange = mortonRange;
+        }
+    }
+
+    internal static class SpatialQueryHelper
+    {
+        public static IEnumerable<SpatialQuerySegment> CreateSegments(GeoBoundingBox boundingBox, int? precisionBits)
+        {
+            if (precisionBits.HasValue && (precisionBits.Value <= 0 || precisionBits.Value > 60))
+            {
+                throw new ArgumentOutOfRangeException(nameof(precisionBits), "Precision must be between 1 and 60 bits");
+            }
+
+            foreach (var split in SplitBoundingBox(boundingBox))
+            {
+                (long Start, long End)? range = null;
+
+                if (precisionBits.HasValue)
+                {
+                    range = ComputeMortonRange(split, precisionBits.Value);
+                }
+
+                yield return new SpatialQuerySegment(split, range);
+            }
+        }
+
+        public static IEnumerable<T> QueryCandidates<T>(LiteCollection<T> collection, IEnumerable<SpatialQuerySegment> segments, Func<T, BsonValue> idAccessor)
+        {
+            var seen = new HashSet<BsonValue>();
+
+            foreach (var segment in segments)
+            {
+                var predicate = BuildPredicate(segment, out var args);
+
+                foreach (var candidate in collection.Query().Where(predicate, args).ToEnumerable())
+                {
+                    var id = idAccessor(candidate);
+
+                    if (!seen.Add(id))
+                    {
+                        continue;
+                    }
+
+                    yield return candidate;
+                }
+            }
+        }
+
+        private static IEnumerable<GeoBoundingBox> SplitBoundingBox(GeoBoundingBox box)
+        {
+            if (box.MinLon <= box.MaxLon)
+            {
+                yield return box;
+                yield break;
+            }
+
+            yield return new GeoBoundingBox(box.MinLat, box.MinLon, box.MaxLat, 180d);
+            yield return new GeoBoundingBox(box.MinLat, -180d, box.MaxLat, box.MaxLon);
+        }
+
+        private static (long Start, long End) ComputeMortonRange(GeoBoundingBox box, int precisionBits)
+        {
+            var corners = new[]
+            {
+                new GeoPoint(box.MinLat, box.MinLon),
+                new GeoPoint(box.MinLat, box.MaxLon),
+                new GeoPoint(box.MaxLat, box.MinLon),
+                new GeoPoint(box.MaxLat, box.MaxLon)
+            };
+
+            long min = long.MaxValue;
+            long max = long.MinValue;
+
+            foreach (var corner in corners)
+            {
+                var morton = SpatialIndexing.ComputeMorton(corner, precisionBits);
+
+                if (morton < min)
+                {
+                    min = morton;
+                }
+
+                if (morton > max)
+                {
+                    max = morton;
+                }
+            }
+
+            return (min, max);
+        }
+
+        private static string BuildPredicate(SpatialQuerySegment segment, out BsonValue[] parameters)
+        {
+            if (segment.MortonRange.HasValue)
+            {
+                parameters = new[]
+                {
+                    new BsonValue(segment.MortonRange.Value.Start),
+                    new BsonValue(segment.MortonRange.Value.End),
+                    new BsonValue(segment.BoundingBox.MinLat),
+                    new BsonValue(segment.BoundingBox.MinLon),
+                    new BsonValue(segment.BoundingBox.MaxLat),
+                    new BsonValue(segment.BoundingBox.MaxLon)
+                };
+
+                return "($._gh BETWEEN @0 AND @1) AND SPATIAL_INTERSECTS($._mbb, @2, @3, @4, @5)";
+            }
+
+            parameters = new[]
+            {
+                new BsonValue(segment.BoundingBox.MinLat),
+                new BsonValue(segment.BoundingBox.MinLon),
+                new BsonValue(segment.BoundingBox.MaxLat),
+                new BsonValue(segment.BoundingBox.MaxLon)
+            };
+
+            return "SPATIAL_INTERSECTS($._mbb, @0, @1, @2, @3)";
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ New UI to manage and visualize your database:
 
 Visit [the Wiki](https://github.com/mbdavid/LiteDB/wiki) for full documentation. For simplified chinese version, [check here](https://github.com/lidanger/LiteDB.wiki_Translation_zh-cn).
 
+- New: [Spatial Queries & Indexing Guide](docs/spatial-getting-started.md) covers the spatial roadmap milestones, the BenchmarkDotNet suite, and the REST sample in `samples/SpatialApi`.
+
 ## LiteDB Community
 
 Help LiteDB grow its user community by answering this [simple survey](https://docs.google.com/forms/d/e/1FAIpQLSc4cNG7wyLKXXcOLIt7Ea4TlXCG6s-51_EfHPu2p5WZ2dIx7A/viewform?usp=sf_link)

--- a/docs/spatial-getting-started.md
+++ b/docs/spatial-getting-started.md
@@ -1,0 +1,84 @@
+# Spatial Queries & Indexing Guide
+
+LiteDB 6 introduces a spatial subsystem that now supports index-aware execution, queryable operators, and ready-to-run samples. This guide walks through the new capabilities and how to compose them in your applications.
+
+## Configure Spatial Defaults
+
+The global `LiteDB.Spatial.Spatial.Options` object now exposes additional knobs:
+
+- `IndexPrecisionBits` controls the number of Morton hash bits used for point indexes (default `52`).
+- `ToleranceDegrees` defines the angular tolerance used when comparing coordinates and bounding boxes (default `1e-9`).
+- `Distance` still selects the great-circle formula (Haversine or Vincenty).
+
+```csharp
+Spatial.Options.IndexPrecisionBits = 48;
+Spatial.Options.ToleranceDegrees = 1e-8;
+```
+
+These values are persisted with `_gh` indexes so re-opening the database continues to use the same precision automatically.【F:LiteDB/Spatial/Spatial.cs†L33-L55】【F:LiteDB/Engine/Engine/Index.cs†L14-L120】
+
+## Ensuring Spatial Indexes
+
+`Spatial.EnsurePointIndex` and `Spatial.EnsureShapeIndex` register computed members (`_gh` for Morton hashes and `_mbb` for bounding boxes) and now record metadata alongside the index definition. Index-aware queries reuse this precision when building Morton ranges.【F:LiteDB/Spatial/Spatial.cs†L15-L122】【F:LiteDB/Spatial/SpatialQueryHelper.cs†L1-L97】
+
+```csharp
+var places = db.GetCollection<Place>("places");
+Spatial.EnsurePointIndex(places, x => x.Location); // precision pulled from Spatial.Options.IndexPrecisionBits
+```
+
+## Bson Expression Operators
+
+Three spatial operators are available inside `BsonExpression` strings and the SQL-like API:
+
+- `SPATIAL_INTERSECTS($._mbb, minLat, minLon, maxLat, maxLon)` filters documents whose bounding boxes intersect the query window.
+- `SPATIAL_CONTAINS_POINT($._mbb, lat, lon)` checks whether a bounding box encloses a point.
+- `SPATIAL_NEAR($._mbb, lat, lon, radiusMeters [, formula])` approximates radius searches using bounding boxes or exact distances for points.【F:LiteDB/Document/Expression/Methods/Spatial.cs†L1-L79】
+
+You can mix these functions with the standard query API:
+
+```csharp
+var candidates = places.Query()
+    .Where("SPATIAL_INTERSECTS($._mbb, @0, @1, @2, @3)", minLat, minLon, maxLat, maxLon)
+    .ToEnumerable();
+```
+
+## Index-Aware Spatial Helpers
+
+The high-level helpers (`Near`, `WithinBoundingBox`, `Within`, `Intersects`, `Contains`) now translate shape constraints into `_gh` range scans plus `_mbb` filters. They reuse the registered metadata, deduplicate matches, and apply tolerances before final geometry checks.【F:LiteDB/Spatial/Spatial.cs†L57-L221】【F:LiteDB/Spatial/SpatialQueryHelper.cs†L1-L97】
+
+```csharp
+var results = Spatial.Near(
+    places,
+    x => x.Location,
+    new GeoPoint(48.2082, 16.3738),
+    radiusMeters: 1500,
+    limit: 25);
+```
+
+## REST Sample
+
+A minimal API showcasing radius searches and bounding-box filters lives in `samples/SpatialApi`. Run it with:
+
+```bash
+dotnet run --project samples/SpatialApi/SpatialApi.csproj
+```
+
+It seeds random points, exposes `/places/near` and `/places/within`, and demonstrates how the spatial helpers plug into HTTP handlers.【F:samples/SpatialApi/Program.cs†L1-L71】
+
+## Benchmarks
+
+`LiteDB.Benchmarks` now includes `SpatialQueryBenchmark`, a BenchmarkDotNet suite that measures `Near`, `WithinBoundingBox`, and `Intersects` operations across dataset sizes. Each run seeds random points and polygons to stress the new index-aware pipeline.【F:LiteDB.Benchmarks/Benchmarks/Spatial/SpatialQueryBenchmark.cs†L1-L97】
+
+Invoke the benchmark harness as usual:
+
+```bash
+dotnet run -c Release --project LiteDB.Benchmarks
+```
+
+This produces allocation and wall-clock measurements for the spatial scenarios next to the existing query suites.
+
+## Next Steps
+
+- Combine spatial expressions with other query predicates (e.g., category filters) to narrow result sets further.
+- Explore the `Spatial.Options` tolerance values when working near the anti-meridian or poles.
+- Contribute additional samples or benchmarks (e.g., nearest-neighbour paging) as your scenarios evolve.

--- a/samples/SpatialApi/Program.cs
+++ b/samples/SpatialApi/Program.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+using LiteDB;
+using LiteDB.Spatial;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+var database = new LiteDatabase("Filename=spatial-sample.db;Connection=shared");
+var places = database.GetCollection<Place>("places");
+
+Spatial.EnsurePointIndex(places, x => x.Location);
+
+if (places.Count() == 0)
+{
+    var seed = SeedPlaces();
+    places.Insert(seed);
+}
+
+app.MapGet("/places/near", (double lat, double lon, double radius, int? limit) =>
+{
+    var center = new GeoPoint(lat, lon);
+    var results = Spatial.Near(places, x => x.Location, center, radius, limit);
+
+    return results.Select(place => new
+    {
+        place.Name,
+        Latitude = place.Location.Lat,
+        Longitude = place.Location.Lon
+    });
+});
+
+app.MapGet("/places/within", (double minLat, double minLon, double maxLat, double maxLon) =>
+{
+    return Spatial.WithinBoundingBox(places, x => x.Location, minLat, minLon, maxLat, maxLon)
+        .Select(place => new
+        {
+            place.Name,
+            Latitude = place.Location.Lat,
+            Longitude = place.Location.Lon
+        });
+});
+
+app.Lifetime.ApplicationStopping.Register(() => database.Dispose());
+
+app.Run();
+
+static IEnumerable<Place> SeedPlaces()
+{
+    var random = new Random(1234);
+    var center = new GeoPoint(48.2082, 16.3738);
+
+    for (var i = 0; i < 200; i++)
+    {
+        var latOffset = (random.NextDouble() - 0.5) * 0.6;
+        var lonOffset = (random.NextDouble() - 0.5) * 0.6;
+
+        yield return new Place
+        {
+            Name = $"Place {i + 1}",
+            Location = new GeoPoint(center.Lat + latOffset, center.Lon + lonOffset)
+        };
+    }
+}
+
+public class Place
+{
+    public ObjectId Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public GeoPoint Location { get; set; } = new GeoPoint(0, 0);
+
+    internal long _gh { get; set; }
+
+    internal double[] _mbb { get; set; } = Array.Empty<double>();
+}

--- a/samples/SpatialApi/SpatialApi.csproj
+++ b/samples/SpatialApi/SpatialApi.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\LiteDB\LiteDB.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add index-aware spatial query helpers that reuse morton metadata and tolerance-aware filtering
- expose spatial bson expression operators and surface precision metadata through the engine
- document the new workflow, add benchmarks, and provide a REST sample for spatial queries

## Testing
- dotnet test LiteDB.Tests/LiteDB.Tests.csproj -f net8.0 --filter FullyQualifiedName~Spatial

------
https://chatgpt.com/codex/tasks/task_e_68d8f6c4a59c832aa21768e0ab4255a1