### PR TITLE
Fix/2670 memoryextensions net10 followup

### DIFF
--- a/.github/workflows/_reusable-ci.yml
+++ b/.github/workflows/_reusable-ci.yml
@@ -8,9 +8,9 @@ on:
         type: string
         default: |
           [
-            { "display": ".NET 8",  "sdk": "8.0.x",           "framework": "net8.0", "includePrerelease": false },
-            { "display": ".NET 9",  "sdk": "9.0.x\n8.0.x",    "framework": "net8.0", "includePrerelease": true  },
-            { "display": ".NET 10", "sdk": "10.0.x\n8.0.x",   "framework": "net8.0", "includePrerelease": true  }
+            { "display": ".NET 8",  "sdk": "8.0.x",           "framework": "net8.0", "includePrerelease": false, "msbuildProps": "" },
+            { "display": ".NET 9",  "sdk": "9.0.x\n8.0.x",    "framework": "net8.0", "includePrerelease": true,  "msbuildProps": "" },
+            { "display": ".NET 10", "sdk": "10.0.x\n8.0.x",   "framework": "net10.0", "includePrerelease": true, "msbuildProps": "-p:LiteDBTestsEnableNet10=true" }
           ]
 
 jobs:
@@ -79,6 +79,7 @@ jobs:
           --configuration Release
           --framework ${{ matrix.item.framework }}
           --no-dependencies
+          ${{ matrix.item.msbuildProps }}
 
       - name: Run tests
         timeout-minutes: 5
@@ -91,6 +92,7 @@ jobs:
           --settings tests.runsettings
           --logger "trx;LogFileName=TestResults.trx"
           --logger "console;verbosity=detailed"
+          ${{ matrix.item.msbuildProps }}
 
   repro-runner:
     runs-on: ubuntu-latest

--- a/LiteDB.Tests/LiteDB.Tests.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net481;net8.0</TargetFrameworks>
+    <TargetFrameworks>net461;net481;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AssemblyName>LiteDB.Tests</AssemblyName>
     <RootNamespace>LiteDB.Tests</RootNamespace>

--- a/LiteDB.Tests/LiteDB.Tests.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net481;net8.0;net10.0</TargetFrameworks>
+    <LiteDBTestsEnableNet10 Condition="'$(LiteDBTestsEnableNet10)' == ''">false</LiteDBTestsEnableNet10>
+    <TargetFrameworks>net461;net481;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(LiteDBTestsEnableNet10)' == 'true'">$(TargetFrameworks);net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AssemblyName>LiteDB.Tests</AssemblyName>
     <RootNamespace>LiteDB.Tests</RootNamespace>

--- a/LiteDB/Client/Mapper/Linq/TypeResolver/MemoryExtensionsResolver.cs
+++ b/LiteDB/Client/Mapper/Linq/TypeResolver/MemoryExtensionsResolver.cs
@@ -6,11 +6,21 @@ namespace LiteDB
     {
         public string ResolveMethod(MethodInfo method)
         {
-            if (method.Name == nameof(System.MemoryExtensions.Contains))
-            {
-                var parameters = method.GetParameters();
+            if (method.Name != nameof(System.MemoryExtensions.Contains))
+                return null;
+            var parameters = method.GetParameters();
 
-                if (parameters.Length == 2)
+            if (parameters.Length == 2)
+            {
+                return "@0 ANY = @1";
+            }
+
+            // Support the 3-parameter overload only when comparer defaults to null.
+            if (parameters.Length == 3)
+            {
+                var third = parameters[2];
+
+                if (third.HasDefaultValue && third.DefaultValue == null)
                 {
                     return "@0 ANY = @1";
                 }


### PR DESCRIPTION
This PR is a follow-up to #2670.

The previous patch on `dev` addressed part of the issue, but missed an additional case.

No new test was added, since `LinqBsonExpression_Tests.Linq_Enumerables` was already failing under .NET 10 and now passes with this fix.

The root cause: `Contains` can be invoked with 3 parameters. When the element type does not implement `IEquatable<T>`, a default comparer (`null`) is passed as the third parameter. This scenario was not handled by the previous patch.

Changes:
- Added .NET 10 target framework to the test project
- Added support for 3-parameter `Contains`

Refs #2670
