### PR TITLE
Add macOS coverage to CI workflow

### DIFF
--- a/.github/workflows/_reusable-ci.yml
+++ b/.github/workflows/_reusable-ci.yml
@@ -94,6 +94,86 @@ jobs:
           --logger "console;verbosity=detailed"
           ${{ matrix.item.msbuildProps }}
 
+  build-macos:
+    name: Build (macOS)
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore
+        run: dotnet restore LiteDB.sln
+
+      - name: Build
+        run: dotnet build LiteDB.sln --configuration Release --no-restore /p:TestingEnabled=true
+
+      - name: Package build outputs
+        run: tar -czf tests-build-macos.tar.gz LiteDB/bin/Release LiteDB/obj/Release LiteDB.Tests/bin/Release LiteDB.Tests/obj/Release
+
+      - name: Upload macOS test build
+        uses: actions/upload-artifact@v4
+        with:
+          name: tests-build-macos
+          path: tests-build-macos.tar.gz
+
+  test-macos:
+    name: Test (macOS ${{ matrix.item.display }})
+    runs-on: macos-latest
+    needs: build-macos
+    strategy:
+      fail-fast: false
+      matrix:
+        item: ${{ fromJson(inputs.sdk-matrix) }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up .NET SDK ${{ matrix.item.display }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.item.sdk }}
+          include-prerelease: ${{ matrix.item.includePrerelease }}
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: tests-build-macos
+
+      - name: Extract build artifacts
+        run: tar -xzf tests-build-macos.tar.gz
+
+      - name: Build test project for target framework
+        run: >-
+          dotnet build LiteDB.Tests/LiteDB.Tests.csproj
+          --configuration Release
+          --framework ${{ matrix.item.framework }}
+          --no-dependencies
+          ${{ matrix.item.msbuildProps }}
+
+      - name: Run tests
+        timeout-minutes: 5
+        run: >-
+          dotnet test LiteDB.Tests/LiteDB.Tests.csproj
+          --configuration Release
+          --no-build
+          --framework ${{ matrix.item.framework }}
+          --verbosity normal
+          --settings tests.runsettings
+          --logger "trx;LogFileName=TestResults.trx"
+          --logger "console;verbosity=detailed"
+          ${{ matrix.item.msbuildProps }}
+
   build-windows:
     name: Build (Windows)
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
- add macOS build and test jobs to reusable CI pipeline
- reuse packaged artifacts and reporting flow to mirror linux coverage

## Testing
- not run locally