### PR TITLE
Fix transaction finalizer causing LiteDB.LiteException/System.ObjectDisposedException

### DIFF
--- a/LiteDB.Tests/Engine/Transactions_Tests.cs
+++ b/LiteDB.Tests/Engine/Transactions_Tests.cs
@@ -17,7 +17,7 @@ namespace LiteDB.Tests.Engine
     public class Transactions_Tests
     {
         const int MIN_CPU_COUNT = 2;
-        
+
         [CpuBoundFact(MIN_CPU_COUNT)]
         public async Task Transaction_Write_Lock_Timeout()
         {
@@ -75,7 +75,7 @@ namespace LiteDB.Tests.Engine
             }
         }
 
-        
+
         [CpuBoundFact(MIN_CPU_COUNT)]
         public async Task Transaction_Avoid_Dirty_Read()
         {
@@ -135,7 +135,7 @@ namespace LiteDB.Tests.Engine
                 await Task.WhenAll(ta, tb);
             }
         }
-       
+
 
         [CpuBoundFact(MIN_CPU_COUNT)]
         public async Task Transaction_Read_Version()
@@ -231,6 +231,19 @@ namespace LiteDB.Tests.Engine
 
                 person.Count().Should().Be(20);
             }
+        }
+
+        [CpuBoundFact(MIN_CPU_COUNT)]
+        public void Test_Transaction_Finalizer()
+        {
+            var db = new LiteDatabase(new MemoryStream());
+            db.BeginTrans();
+
+            GC.Collect(0, GCCollectionMode.Forced);
+
+            // Finalizer should not throw exception
+            // If it does, it will be an unhandled exception
+            GC.WaitForPendingFinalizers();
         }
 
 #if DEBUG || TESTING
@@ -339,9 +352,9 @@ namespace LiteDB.Tests.Engine
 
         private class BlockingStream : MemoryStream
         {
-            public readonly AutoResetEvent   Blocked       = new AutoResetEvent(false);
+            public readonly AutoResetEvent Blocked = new AutoResetEvent(false);
             public readonly ManualResetEvent ShouldUnblock = new ManualResetEvent(false);
-            public          bool             ShouldBlock;
+            public bool ShouldBlock;
 
             public override void Write(byte[] buffer, int offset, int count)
             {
@@ -358,10 +371,10 @@ namespace LiteDB.Tests.Engine
         [CpuBoundFact(MIN_CPU_COUNT)]
         public void Test_Transaction_ReleaseWhenFailToStart()
         {
-            var    blockingStream             = new BlockingStream();
-            var    db                         = new LiteDatabase(blockingStream);
+            var blockingStream = new BlockingStream();
+            var db = new LiteDatabase(blockingStream);
             SetEngineTimeout(db, TimeSpan.FromMilliseconds(50));
-            Thread lockerThread               = null;
+            Thread lockerThread = null;
             try
             {
                 lockerThread = new Thread(() =>
@@ -432,11 +445,11 @@ namespace LiteDB.Tests.Engine
             var engine = GetLiteEngine(database);
 
             var headerField = typeof(LiteEngine).GetField("_header", BindingFlags.Instance | BindingFlags.NonPublic);
-            var header      = headerField?.GetValue(engine) ?? throw new InvalidOperationException("LiteEngine header not available.");
+            var header = headerField?.GetValue(engine) ?? throw new InvalidOperationException("LiteEngine header not available.");
             var pragmasProp = header.GetType().GetProperty("Pragmas", BindingFlags.Instance | BindingFlags.Public) ?? throw new InvalidOperationException("Engine pragmas not accessible.");
-            var pragmas     = pragmasProp.GetValue(header) ?? throw new InvalidOperationException("Engine pragmas not available.");
+            var pragmas = pragmasProp.GetValue(header) ?? throw new InvalidOperationException("Engine pragmas not available.");
             var timeoutProp = pragmas.GetType().GetProperty("Timeout", BindingFlags.Instance | BindingFlags.Public) ?? throw new InvalidOperationException("Timeout property not found.");
-            var setter      = timeoutProp.GetSetMethod(true) ?? throw new InvalidOperationException("Timeout setter not accessible.");
+            var setter = timeoutProp.GetSetMethod(true) ?? throw new InvalidOperationException("Timeout setter not accessible.");
 
             setter.Invoke(pragmas, new object[] { timeout });
         }

--- a/LiteDB/Engine/Services/TransactionMonitor.cs
+++ b/LiteDB/Engine/Services/TransactionMonitor.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using static LiteDB.Constants;
 
@@ -105,9 +103,10 @@ namespace LiteDB.Engine
         }
 
         /// <summary>
-        /// Release current thread transaction
+        /// Dispose and remove transaction from monitor
+        /// without releasing thread lock
         /// </summary>
-        public void ReleaseTransaction(TransactionService transaction)
+        public bool RemoveTransaction(TransactionService transaction)
         {
             // dispose current transaction
             transaction.Dispose();
@@ -123,8 +122,16 @@ namespace LiteDB.Engine
                 _freePages += transaction.MaxTransactionSize;
 
                 // check if current thread contains more query transactions
-                keepLocked = _transactions.Values.Any(x => x.ThreadID == Environment.CurrentManagedThreadId);
+                return keepLocked = _transactions.Values.Any(x => x.ThreadID == Environment.CurrentManagedThreadId);
             }
+        }
+
+        /// <summary>
+        /// Release current thread transaction
+        /// </summary>
+        public void ReleaseTransaction(TransactionService transaction)
+        {
+            var keepLocked = RemoveTransaction(transaction);
 
             // unlock thread-transaction only if there is no more transactions
             if (keepLocked == false)
@@ -150,7 +157,7 @@ namespace LiteDB.Engine
         {
             lock (_transactions)
             {
-                return 
+                return
                     _slot.Value ??
                     _transactions.Values.FirstOrDefault(x => x.ThreadID == Environment.CurrentManagedThreadId);
             }
@@ -191,7 +198,7 @@ namespace LiteDB.Engine
         /// </summary>
         private bool TryExtend(TransactionService trans)
         {
-            lock(_transactions)
+            lock (_transactions)
             {
                 if (_freePages >= _initialSize)
                 {
@@ -211,7 +218,7 @@ namespace LiteDB.Engine
         /// </summary>
         public bool CheckSafepoint(TransactionService trans)
         {
-            return 
+            return
                 trans.Pages.TransactionSize >= trans.MaxTransactionSize &&
                 this.TryExtend(trans) == false;
         }

--- a/LiteDB/Engine/Services/TransactionService.cs
+++ b/LiteDB/Engine/Services/TransactionService.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Threading;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -444,7 +441,7 @@ namespace LiteDB.Engine
             if (!dispose)
             {
                 // Remove transaction monitor's dictionary
-                _monitor.ReleaseTransaction(this);
+                _monitor.RemoveTransaction(this);
             }
         }
     }


### PR DESCRIPTION
I believe that when #1906 was introduced, a bug was also added. 

When the transaction is finalized, the code is calling `_monitor.ReleaseTransaction`, and will eventually do:
https://github.com/litedb-org/LiteDB/blob/48d89fd515f3ee348b13c5248d636bedd3a71611/LiteDB/Engine/Services/TransactionMonitor.cs#L116-L119

The finalizers always run on a specific thread controlled by the Garbage Collector, so the thread that is releasing the transaction will never have acquired a lock. 

I was running version `5.0.15`, which is before this band-aid fix #2280 (two of the referenced issues also contain stack traces starting on a `Finalize`), so I was able to consistently get an exception anytime the `Finalize` was called.

~~Even though the exception is hidden on newer versions, it still makes sense to me to have this fixed.~~
Edit: The new version will still throw an exception in another place, so this PR is still required to fix problems calling finalizers.
2 exceptions still come up without this fix:
```
Unhandled exception. System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'System.Threading.ThreadLocal`1[[LiteDB.Engine.TransactionService, LiteDB, Version=6.0.0.0, Culture=neutral, PublicKeyToken=null]]'.
   at System.Threading.ThreadLocal`1.GetValueSlow()
   at LiteDB.Engine.TransactionMonitor.ReleaseTransaction(TransactionService transaction) in /home/edureis95/repo/LiteDB/LiteDB/Engine/Services/TransactionMonitor.cs:line 145
   at LiteDB.Engine.TransactionService.Dispose(Boolean dispose) in /home/edureis95/repo/LiteDB/LiteDB/Engine/Services/TransactionService.cs:line 446
   at LiteDB.Engine.TransactionService.Finalize() in /home/edureis95/repo/LiteDB/LiteDB/Engine/Services/TransactionService.cs:line 79
   at System.GC.RunFinalizers()

```
```
Unhandled exception. LiteDB.LiteException: current thread must contains transaction parameter
   at LiteDB.Constants.ENSURE(Boolean conditional, String message) in /home/edureis95/repo/LiteDB/LiteDB/Utils/Constants.cs:line 146
   at LiteDB.Engine.TransactionMonitor.ReleaseTransaction(TransactionService transaction) in /home/edureis95/repo/LiteDB/LiteDB/Engine/Services/TransactionMonitor.cs:line 145
   at LiteDB.Engine.TransactionService.Dispose(Boolean dispose) in /home/edureis95/repo/LiteDB/LiteDB/Engine/Services/TransactionService.cs:line 446
   at LiteDB.Engine.TransactionService.Finalize() in /home/edureis95/repo/LiteDB/LiteDB/Engine/Services/TransactionService.cs:line 79
   at System.GC.RunFinalizers()

```
