### PR TITLE
Added BsonRefId<T> to allow explicit DbRefs in LINQ expressions

### DIFF
--- a/LiteDB.Tests/Mapper/LinqBsonExpression_Tests.cs
+++ b/LiteDB.Tests/Mapper/LinqBsonExpression_Tests.cs
@@ -83,7 +83,12 @@ namespace LiteDB.Tests.Mapper
 
             [BsonRef("users")]
             public List<User> Users { get; set; }
+
+            [BsonRef("products")]
+            public Product[] Products { get; set; }
         }
+
+        public class OrderCustomer : Customer;
 
         public class Account
         {
@@ -522,6 +527,56 @@ namespace LiteDB.Tests.Mapper
             Test<User, bool>(expr, "(($._id>=@p0) AND ($._id<=@p1))", 1, 10);
             Test<User, bool>(exprMerged, "(($._id>=@p0) AND (((@._id<=@p1))=true))", 1, 10);
             //the right expr of exprMerged uses @ (instead of $) because the rootParameter is different for exprLeft and exprRight
+        }
+
+        [Fact]
+        public void Linq_MemberInit_DbRef()
+        {
+            var p1Id = ObjectId.NewObjectId();
+            var p2Id = ObjectId.NewObjectId();
+
+            TestExpr<Order>(
+                x => new Order
+                {
+                    OrderNumber = 1,
+                    Customer = new BsonRefId<OrderCustomer>(10),
+                    Users = new List<User>
+                    {
+                        new BsonRefId<User>(101),
+                        new BsonRefId<User>(x.Users[0].Id + 100),
+                    },
+                    Products = new Product[]
+                    {
+                        new BsonRefId<Product>(p1Id),
+                        new BsonRefId<Product>(p2Id),
+                    },
+                },
+                @"{
+                    _id: @p0,
+                    Customer: { $id: @p1, $ref: @p2, $type: @p3 },
+                    Users:[
+                        { $id: @p4, $ref: @p5 },
+                        { $id: ($.Users[0].$id + @p6), $ref: @p7 }
+                    ],
+                    Products: [
+                        { $id: @p8, $ref: @p9 },
+                        { $id: @p10, $ref: @p11 }
+                    ]
+                }",
+                [
+                    1,
+                    10,
+                    "customers",
+                    DefaultTypeNameBinder.Instance.GetName(typeof(OrderCustomer)),
+                    101,
+                    "users",
+                    100,
+                    "users",
+                    p1Id,
+                    "products",
+                    p2Id,
+                    "products",
+                ]);
         }
 
         #region Test helper

--- a/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
@@ -186,7 +186,7 @@ namespace LiteDB
             // adding _type only where property Type is not same as object instance type
             if (type != t)
             {
-                doc["_type"] = new BsonValue(_typeNameBinder.GetName(t));
+                doc["_type"] = SerializeTypeName(t);
             }
 
             foreach (var member in entity.Members.Where(x => x.Getter != null))
@@ -208,6 +208,14 @@ namespace LiteDB
             }
 
             return doc;
+        }
+
+        /// <summary>
+        /// Returns the name of the given type for serialization (type discriminator).
+        /// </summary>
+        internal BsonValue SerializeTypeName(Type type)
+        {
+            return new BsonValue(_typeNameBinder.GetName(type));
         }
     }
 }

--- a/LiteDB/Client/Mapper/BsonMapper.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.cs
@@ -227,22 +227,22 @@ namespace LiteDB
         /// </summary>
         internal static void RegisterDbRef(BsonMapper mapper, MemberMapper member, ITypeNameBinder typeNameBinder, string collection)
         {
-            member.IsDbRef = true;
+            member.DbRefCollectionName = collection;
 
             if (member.IsEnumerable)
             {
-                RegisterDbRefList(mapper, member, typeNameBinder, collection);
+                RegisterDbRefList(mapper, member, typeNameBinder);
             }
             else
             {
-                RegisterDbRefItem(mapper, member, typeNameBinder, collection);
+                RegisterDbRefItem(mapper, member, typeNameBinder);
             }
         }
 
         /// <summary>
         /// Register a property as a DbRef - implement a custom Serialize/Deserialize actions to convert entity to $id, $ref only
         /// </summary>
-        private static void RegisterDbRefItem(BsonMapper mapper, MemberMapper member, ITypeNameBinder typeNameBinder, string collection)
+        private static void RegisterDbRefItem(BsonMapper mapper, MemberMapper member, ITypeNameBinder typeNameBinder)
         {
             // get entity
             var entity = mapper.GetEntityMapper(member.DataType);
@@ -263,12 +263,12 @@ namespace LiteDB
                 var bsonDocument = new BsonDocument
                 {
                     ["$id"] = m.Serialize(id.GetType(), id, 0),
-                    ["$ref"] = collection
+                    ["$ref"] = member.DbRefCollectionName
                 };
 
                 if (member.DataType != obj.GetType())
                 {
-                    bsonDocument["$type"] = typeNameBinder.GetName(obj.GetType());
+                    bsonDocument["$type"] = mapper.SerializeTypeName(obj.GetType());
                 }
 
                 return bsonDocument;
@@ -311,7 +311,7 @@ namespace LiteDB
         /// <summary>
         /// Register a property as a DbRefList - implement a custom Serialize/Deserialize actions to convert entity to $id, $ref only
         /// </summary>
-        private static void RegisterDbRefList(BsonMapper mapper, MemberMapper member, ITypeNameBinder typeNameBinder, string collection)
+        private static void RegisterDbRefList(BsonMapper mapper, MemberMapper member, ITypeNameBinder typeNameBinder)
         {
             // get entity from list item type
             var entity = mapper.GetEntityMapper(member.UnderlyingType);
@@ -334,12 +334,12 @@ namespace LiteDB
                     var bsonDocument = new BsonDocument
                     {
                         ["$id"] = m.Serialize(id.GetType(), id, 0),
-                        ["$ref"] = collection
+                        ["$ref"] = member.DbRefCollectionName
                     };
 
                     if (member.UnderlyingType != item.GetType())
                     {
-                        bsonDocument["$type"] = typeNameBinder.GetName(item.GetType());
+                        bsonDocument["$type"] = mapper.SerializeTypeName(item.GetType());
                     }
 
                     result.Add(bsonDocument);

--- a/LiteDB/Client/Mapper/BsonRefId.cs
+++ b/LiteDB/Client/Mapper/BsonRefId.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace LiteDB;
+
+/// <summary>
+/// Helper to assign the ID of a DbRef property (see <see cref="BsonRefAttribute"/>) in expression trees.
+/// </summary>
+/// <typeparam name="T">The type of the referenced entity.</typeparam>
+/// <example><code>
+/// db.GetCollection&lt;A&gt;()
+///   .UpdateMany(
+///     x => new A
+///     {
+///       Id = x.Id,
+///       Bref = new BsonRefId&lt;B&gt;(100),
+///     },
+///     x => x.Id == 11);
+/// </code></example>
+public sealed class BsonRefId<T>
+{
+    /// <summary>
+    /// Assigns the ID of the referenced entity of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="id">The ID to assign.</param>
+    public BsonRefId(BsonValue id)
+    {
+    }
+
+    public static implicit operator T(BsonRefId<T> _)
+    {
+        throw new NotSupportedException($"The type {nameof(BsonRefId<>)} can only be used in LiteDB LINQ expressions.");
+    }
+}

--- a/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
+++ b/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
@@ -42,7 +42,7 @@ namespace LiteDB
         private Type _dbRefType = null;
 
         private readonly StringBuilder _builder = new StringBuilder();
-        private readonly Stack<Expression> _nodes = new Stack<Expression>();
+        private readonly Stack<MemberExpression> _memberAccessNodes = new();
 
         public LinqExpressionVisitor(BsonMapper mapper, Expression expr)
         {
@@ -63,7 +63,7 @@ namespace LiteDB
         {
             this.Visit(_expr);
 
-            ENSURE(_nodes.Count == 0, "node stack must be empty when finish expression resolve");
+            ENSURE(_memberAccessNodes.Count == 0, "Member access node stack must be empty when finish expression resolve");
 
             var expression = _builder.ToString();
 
@@ -134,7 +134,7 @@ namespace LiteDB
             var member = node.Member;
 
             // special types contains method access: string.Length, DateTime.Day, ...
-            if (this.TryGetResolver(member.DeclaringType, out var type))
+            if (TryGetResolver(member.DeclaringType, out var type))
             {
                 var pattern = type.ResolveMember(member);
 
@@ -147,16 +147,18 @@ namespace LiteDB
                 // for static member, Expression == null
                 if (node.Expression != null)
                 {
-                    _nodes.Push(node);
+                    _memberAccessNodes.Push(node);
 
                     base.Visit(node.Expression);
 
                     if (isParam)
                     {
-                        var name = this.ResolveMember(member);
+                        var name = this.ResolveMember(member, out _);
 
                         _builder.Append(name);
                     }
+
+                    _memberAccessNodes.Pop();
                 }
                 // static member is not parameter expression - compile and execute as constant
                 else
@@ -166,12 +168,6 @@ namespace LiteDB
                     base.Visit(Expression.Constant(value));
                 }
             }
-
-            if (_nodes.Count > 0)
-            {
-                _nodes.Pop();
-            }
-
 
             return node;
         }
@@ -202,7 +198,7 @@ namespace LiteDB
             }
 
             // if not found in resolver, try run method
-            if (!this.TryGetResolver(node.Method.DeclaringType, out var type))
+            if (!TryGetResolver(node.Method.DeclaringType, out var type))
             {
                 // if method are called by parameter expression and it's not exists, throw error
                 var isParam = ParameterExpressionVisitor.Test(node);
@@ -233,25 +229,20 @@ namespace LiteDB
         /// </summary>
         protected override Expression VisitConstant(ConstantExpression node)
         {
-            MemberExpression prevNode;
             var value = node.Value;
 
             // https://stackoverflow.com/a/29708655/3286260
-            while (_nodes.Count > 0 && (prevNode = _nodes.Peek() as MemberExpression) != null)
+            foreach (var memberAccessNode in _memberAccessNodes)
             {
-                if (prevNode.Member is FieldInfo fieldInfo)
+                if (memberAccessNode.Member is FieldInfo fieldInfo)
                 {
                     value = fieldInfo.GetValue(value);
                 }
-                else if (prevNode.Member is PropertyInfo propertyInfo)
+                else if (memberAccessNode.Member is PropertyInfo propertyInfo)
                 {
                     value = propertyInfo.GetValue(value);
                 }
-
-                _nodes.Pop();
             }
-
-            ENSURE(_nodes.Count == 0, "counter stack must be zero to eval all properties/field over object");
 
             var parameter = "p" + (_paramIndex++);
 
@@ -340,7 +331,7 @@ namespace LiteDB
         {
             if (node.Members == null)
             {
-                if (this.TryGetResolver(node.Type, out var type))
+                if (TryGetResolver(node.Type, out var type))
                 {
                     var pattern = type.ResolveCtor(node.Constructor);
 
@@ -387,13 +378,16 @@ namespace LiteDB
             for (var i = 0; i < node.Bindings.Count; i++)
             {
                 var bind = node.Bindings[i] as MemberAssignment;
-                var member = this.ResolveMember(bind.Member);
+                var member = this.ResolveMember(bind.Member, out var memberMapper);
 
                 _builder.Append(i > 0 ? ", " : "");
                 _builder.Append(member.Substring(1));
                 _builder.Append(":");
 
-                this.Visit(bind.Expression);
+                if (!TryVisitDbRefIdExpression(bind.Expression, memberMapper))
+                {
+                    this.Visit(bind.Expression);
+                }
             }
 
             _builder.Append("}");
@@ -561,7 +555,7 @@ namespace LiteDB
                 if (met.Object.NodeType != ExpressionType.Parameter) throw new NotSupportedException("Any/All requires simple parameter on left side. Eg: `x.Customers.Select(c => c.Name).Any(n => n.StartsWith('J'))`");
 
                 // if not found in resolver, try run method
-                if (!this.TryGetResolver(met.Method.DeclaringType, out var type))
+                if (!TryGetResolver(met.Method.DeclaringType, out var type))
                 {
                     throw new NotSupportedException($"Method {met.Method.Name} not available to convert to BsonExpression inside Any/All call.");
                 }
@@ -610,7 +604,7 @@ namespace LiteDB
         /// <summary>
         /// Returns document field name for some type member
         /// </summary>
-        private string ResolveMember(MemberInfo member)
+        private string ResolveMember(MemberInfo member, out MemberMapper memberMapper)
         {
             var name = member.Name;
 
@@ -624,7 +618,7 @@ namespace LiteDB
             // get mapped field from entity
             var field = entity.Members.FirstOrDefault(x => x.MemberName == name);
 
-            if (field == null) throw new NotSupportedException($"Member {name} not found on BsonMapper for type {member.DeclaringType}.");
+            memberMapper = field ?? throw new NotSupportedException($"Member {name} not found on BsonMapper for type {member.DeclaringType}.");
 
             // define if this field are DbRef (child will need check parent)
             _dbRefType = field.IsDbRef ? field.UnderlyingType : null;
@@ -724,9 +718,119 @@ namespace LiteDB
         }
 
         /// <summary>
+        /// Tries to visit `new BsonRefId&lt;T&gt;(id)` within a member init expression.
+        /// This is only resolved for properties marked as DbRef.
+        /// </summary>
+        private bool TryVisitDbRefIdExpression(Expression node, MemberMapper memberMapper, bool isInList = false)
+        {
+            if (!memberMapper.IsDbRef)
+            {
+                return false;
+            }
+
+            switch (node)
+            {
+                // Implicit convert from BsonRefId<T> to T
+                case UnaryExpression { NodeType: ExpressionType.Convert, Method.Name: "op_Implicit", Operand: var operand }:
+                    return TryVisitDbRefIdExpression(operand, memberMapper, isInList);
+
+                // The actual new BsonRefId<T>
+                case NewExpression { Members: null, Type.IsConstructedGenericType: true } expr
+                    when expr.Type.GetGenericTypeDefinition() == typeof(BsonRefId<>):
+
+                    var typeOfRef = expr.Type.GetGenericArguments()[0];
+
+                    // Type of ref must be assignable to property or if within a list assignable to the list type.
+                    if (memberMapper.DataType.IsAssignableFrom(typeOfRef) || isInList && memberMapper.UnderlyingType.IsAssignableFrom(typeOfRef))
+                    {
+                        ResolveDbRefId(expr, memberMapper);
+                        return true;
+                    }
+
+                    return false;
+
+                // new T[] { new BsonRefId<T>, ... }
+                case NewArrayExpression expr
+                    when !isInList && expr.Type.IsArray && memberMapper.UnderlyingType.IsAssignableFrom(expr.Type.GetElementType()):
+
+                    _builder.Append("[ ");
+
+                    for (var i = 0; i < expr.Expressions.Count; i++)
+                    {
+                        if (i > 0)
+                        {
+                            _builder.Append(", ");
+                        }
+
+                        if (!TryVisitDbRefIdExpression(expr.Expressions[i], memberMapper, true))
+                        {
+                            throw new NotSupportedException($"Expression {expr} not supported for BsonRefId<T>.");
+                        }
+                    }
+
+                    _builder.Append(" ]");
+                    return true;
+
+                // new List<T> { new BsonRefId<T>, ... }
+                case ListInitExpression { Type: { IsConstructedGenericType: true, GenericTypeArguments.Length: 1 } } expr
+                    when !isInList && expr.Type.GetGenericTypeDefinition() == typeof(List<>) && memberMapper.UnderlyingType.IsAssignableFrom(expr.Type.GetGenericArguments()[0]):
+
+                    _builder.Append("[ ");
+
+                    for (var i = 0; i < expr.Initializers.Count; i++)
+                    {
+                        if (i > 0)
+                        {
+                            _builder.Append(", ");
+                        }
+
+                        var initializer = expr.Initializers[i];
+
+                        if (initializer.Arguments.Count != 1 || initializer.AddMethod.Name != "Add")
+                        {
+                            throw new NotSupportedException($"List initializers {initializer.AddMethod.Name} not supported when convert to BsonExpression ({node}).");
+                        }
+
+                        if (!TryVisitDbRefIdExpression(initializer.Arguments[0], memberMapper, true))
+                        {
+                            throw new NotSupportedException($"Expression {expr} not supported for BsonRefId<T>.");
+                        }
+                    }
+
+                    _builder.Append(" ]");
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Resolves and writes `new BsonRefId&lt;T&gt;(id)` into the _builder.
+        /// </summary>
+        private void ResolveDbRefId(NewExpression node, MemberMapper memberMapper)
+        {
+            _builder.Append("{$id:");
+
+            ResolvePattern("@0", null, node.Arguments);
+
+            _builder.Append(", $ref: ");
+            Visit(Expression.Constant(memberMapper.DbRefCollectionName));
+
+            var refType = node.Type.GetGenericArguments()[0];
+            if (refType != memberMapper.UnderlyingType)
+            {
+                _builder.Append(", $type: ");
+                Visit(Expression.Constant(_mapper.SerializeTypeName(refType)));
+            }
+
+            _builder.Append("}");
+        }
+
+        /// <summary>
         /// Try find a Type Resolver for declaring type
         /// </summary>
-        private bool TryGetResolver(Type declaringType, out ITypeResolver typeResolver)
+        private static bool TryGetResolver(Type declaringType, out ITypeResolver typeResolver)
         {
             // get method declaring type - if is from any kind of list, read as Enumerable
             var isCollection = Reflection.IsCollection(declaringType);

--- a/LiteDB/Client/Mapper/MemberMapper.cs
+++ b/LiteDB/Client/Mapper/MemberMapper.cs
@@ -52,7 +52,7 @@ namespace LiteDB
         /// <summary>
         /// Is this property an DbRef? Must implement Serialize/Deserialize delegates
         /// </summary>
-        public bool IsDbRef { get; set; }
+        public bool IsDbRef => DbRefCollectionName != null;
 
         /// <summary>
         /// Indicate that this property contains an list of elements (IEnumerable)
@@ -68,5 +68,10 @@ namespace LiteDB
         /// Is this property ignore
         /// </summary>
         public bool IsIgnore { get; set; }
+
+        /// <summary>
+        /// Sets the name of the referenced collection if this property is a DbRef.
+        /// </summary>
+        internal string DbRefCollectionName { get; set; }
     }
 }


### PR DESCRIPTION
With this PR, a LINQ expression helper type `BsonRefId<T>` is introduced that allows explicit setting of DbRef objects in LINQ expressions, for example in `UpdateMany`.

```csharp
db.GetCollection<A>()
    .UpdateMany(
        x => new A
        {
            Id = x.Id,
            Bref = new BsonRefId<B>(100), // instead of `new B { }` which would be included inline
        },
        x => x.Id == 11);
```

Resolves #2739 